### PR TITLE
Fix bugs in Module07 wdl

### DIFF
--- a/wdl/AnnotateChromosome.wdl
+++ b/wdl/AnnotateChromosome.wdl
@@ -181,7 +181,7 @@ task MergeAnnotations {
       ~{prefix}.annotated.vcf
 
     bgzip ~{prefix}.annotated.vcf
-    tabix ~{prefix}.annotated.vcf
+    tabix ~{prefix}.annotated.vcf.gz
     
     orig=$( zcat ~{vcf} | cut -f1 | grep -cv "^#" )
     new=$( zcat ~{prefix}.annotated.vcf.gz | cut -f1 | grep -cv "^#")

--- a/wdl/Module07.wdl
+++ b/wdl/Module07.wdl
@@ -54,8 +54,8 @@ workflow Module07 {
 
   call pav.PruneAndAddVafs as PruneAndAddVafs {
     input:
-      vcf                    = vcf,
-      vcf_idx                = vcf_idx,
+      vcf                    = AnnotateVcf.annotated_vcf,
+      vcf_idx                = AnnotateVcf.annotated_vcf_idx,
       prefix                 = prefix,
       sample_pop_assignments = sample_pop_assignments,
       prune_list             = prune_list,


### PR DESCRIPTION
This fixes two issues in the Module07 WDL:

* The MergeAnnotations task was failing due to not looking for the bgzipped vcf to index
* The PruneAndAddVafs tasks were not operating on the annotated VCFs, causing the annotations to be lost. 