### PR TITLE
Add Module07 Annotations to Single Sample Pipeline

### DIFF
--- a/inputs/GATKSVPipelineBatch.ref_panel_1kg.json
+++ b/inputs/GATKSVPipelineBatch.ref_panel_1kg.json
@@ -781,7 +781,7 @@
   "GATKSVPipelineBatch.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineBatch.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineBatch.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "GATKSVPipelineBatch.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",
   "GATKSVPipelineBatch.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",

--- a/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
+++ b/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
@@ -32,7 +32,7 @@
   "GATKSVPipelineSingleSample.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineSingleSample.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",
   "GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",

--- a/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
+++ b/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
@@ -87,6 +87,12 @@
   "GATKSVPipelineSingleSample.clean_vcf_random_seed": 0,
   "GATKSVPipelineSingleSample.run_vcf_qc" : false,
 
+  "GATKSVPipelineSingleSample.protein_coding_gtf" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gencode.canonical_pc.gtf.gz",
+  "GATKSVPipelineSingleSample.linc_rna_gtf" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gencode.lincRNA.gtf.gz",
+  "GATKSVPipelineSingleSample.promoter_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/promoter.bed",
+  "GATKSVPipelineSingleSample.noncoding_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed",
+  "GATKSVPipelineSingleSample.annotation_sv_per_shard" : "5000",
+
   "GATKSVPipelineSingleSample.cnmops_mem_gb_override_sample3": 24,
 
   "GATKSVPipelineSingleSample.ref_samples" : [

--- a/scripts/docker/update_json_docker.sh
+++ b/scripts/docker/update_json_docker.sh
@@ -62,7 +62,7 @@ fi
 #################################################
 
 shopt -s nullglob
-JSON_ARR=(${BASE_DIR}/*.json ${BASE_DIR}/test/*/*.json ${BASE_DIR}/single_sample/*.json)
+JSON_ARR=(${BASE_DIR}/*.json ${BASE_DIR}/test/*/*.json ${BASE_DIR}/inputs/*.json)
 JSONS=$(printf "%s "  "${JSON_ARR[@]}")
 
 for name in "${DOCKER_NAME_ARR[@]}"; do

--- a/src/svtk/svtk/annotation/annotate.py
+++ b/src/svtk/svtk/annotation/annotate.py
@@ -39,12 +39,18 @@ def annotate_noncoding(sv, noncoding):
     noncoding_hits = annotate_intersection(sv, noncoding, filetype='bed')
     noncoding_hits = noncoding_hits.drop_duplicates()
 
-    noncoding_hits.loc[noncoding_hits.hit_type == 'SPAN', 'effect'] = 'NONCODING_SPAN'
-    noncoding_hits.loc[noncoding_hits.hit_type != 'SPAN', 'effect'] = 'NONCODING_BREAKPOINT'
+    if noncoding_hits.shape[0] > 0:
+        if len(noncoding_hits.hit_type == 'SPAN') != 0:
+            noncoding_hits.loc[noncoding_hits.hit_type == 'SPAN', 'effect'] = 'NONCODING_SPAN'
+        if len(noncoding_hits.hit_type != 'SPAN') != 0:
+            noncoding_hits.loc[noncoding_hits.hit_type != 'SPAN', 'effect'] = 'NONCODING_BREAKPOINT'
+        noncoding_cols = 'name svtype gene_name effect'.split()
+        effects = noncoding_hits[noncoding_cols].drop_duplicates()
+    else:
+        # no hits found, add an empty 'effect' column
+        noncoding_hits['effect'] = ''
+        effects = noncoding_hits
 
-    noncoding_cols = 'name svtype gene_name effect'.split()
-
-    effects = noncoding_hits[noncoding_cols].drop_duplicates()
     return effects
 
 

--- a/test/batch/GATKSVPipelineBatch.test_large.json
+++ b/test/batch/GATKSVPipelineBatch.test_large.json
@@ -349,7 +349,7 @@
   "GATKSVPipelineBatch.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineBatch.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineBatch.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "GATKSVPipelineBatch.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",
   "GATKSVPipelineBatch.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00a/Module00aBatch.test_large.json
+++ b/test/module00a/Module00aBatch.test_large.json
@@ -18,7 +18,7 @@
 
   "Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatch.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module00aBatch.delly_docker": "gatksv/delly:8645aa",
   "Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",

--- a/test/module00a/Module00aBatch.test_small.json
+++ b/test/module00a/Module00aBatch.test_small.json
@@ -18,7 +18,7 @@
 
   "Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatch.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",
   "Module00aBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00a/Module00aBatchTest.test_large.json
+++ b/test/module00a/Module00aBatchTest.test_large.json
@@ -454,7 +454,7 @@
 
   "Module00aBatchTest.Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatchTest.Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module00aBatchTest.Module00aBatch.delly_docker": "gatksv/delly:8645aa",
   "Module00aBatchTest.Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatchTest.Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",

--- a/test/module00a/Module00aBatchTest.test_small.json
+++ b/test/module00a/Module00aBatchTest.test_small.json
@@ -75,7 +75,7 @@
 
   "Module00aBatchTest.Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatchTest.Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module00aBatchTest.Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatchTest.Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",
   "Module00aBatchTest.Module00aBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00b/Module00b.test_large.json
+++ b/test/module00b/Module00b.test_large.json
@@ -1,7 +1,7 @@
 {
   "Module00b.run_vcf_qc" : "true",
   "Module00b.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00b.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module00b.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",
   "Module00b.wgd_scoring_mask": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/wgd_scoring_mask.hg38.gnomad_v3.bed",
   "Module00b.genome_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.genome",

--- a/test/module00b/Module00b.test_small.json
+++ b/test/module00b/Module00b.test_small.json
@@ -1,7 +1,7 @@
 {
   "Module00b.run_vcf_qc" : "true",
   "Module00b.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00b.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module00b.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",
   "Module00b.wgd_scoring_mask": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/wgd_scoring_mask.hg38.gnomad_v3.bed",
   "Module00b.genome_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.genome",

--- a/test/module00c/Module00c.test_large.json
+++ b/test/module00c/Module00c.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00c.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module00c.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",
   "Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00c.test_small.json
+++ b/test/module00c/Module00c.test_small.json
@@ -1,6 +1,6 @@
 {
   "Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00c.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module00c.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",
   "Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_baf_from_vcf.json
+++ b/test/module00c/Module00cTest.test_baf_from_vcf.json
@@ -440,7 +440,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00cTest.Module00c.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_large.json
+++ b/test/module00c/Module00cTest.test_large.json
@@ -440,7 +440,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00cTest.Module00c.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_small.json
+++ b/test/module00c/Module00cTest.test_small.json
@@ -60,7 +60,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00cTest.Module00c.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module01/Module01.test_large.json
+++ b/test/module01/Module01.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
 
   "Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01.test_small.json
+++ b/test/module01/Module01.test_small.json
@@ -1,6 +1,6 @@
 {
   "Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
 
   "Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01Test.test_large.json
+++ b/test/module01/Module01Test.test_large.json
@@ -125,7 +125,7 @@
   "Module01Test.Module01Metrics.Module01Metrics.wham_metrics.mem_gib" : 3.75,
 
   "Module01Test.Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01Test.Module01.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
 
   "Module01Test.Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01Test.Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01Test.test_small.json
+++ b/test/module01/Module01Test.test_small.json
@@ -25,7 +25,7 @@
   "Module01Test.Module01Metrics.baseline_melt_vcf" : "gs://gatk-sv-resources/test/module01/small/output/test_small.melt.vcf.gz",
 
   "Module01Test.Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01Test.Module01.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
 
   "Module01Test.Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01Test.Module01.depth_flags": "--merge-coordinates",

--- a/test/module02/Module02.test_large.json
+++ b/test/module02/Module02.test_large.json
@@ -1,5 +1,5 @@
 {
-  "Module02.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module02/Module02.test_small.json
+++ b/test/module02/Module02.test_small.json
@@ -1,5 +1,5 @@
 {
-  "Module02.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module02/Module02Test.test_large.json
+++ b/test/module02/Module02Test.test_large.json
@@ -114,7 +114,7 @@
   "Module02Test.Module02Metrics.linux_docker" : "ubuntu:18.04",
   "Module02Test.Module02Metrics.contig_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list",
 
-  "Module02Test.Module02.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module02Test.Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02Test.Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02Test.Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module02/Module02Test.test_small.json
+++ b/test/module02/Module02Test.test_small.json
@@ -19,7 +19,7 @@
   "Module02Test.Module02Metrics.linux_docker" : "ubuntu:18.04",
   "Module02Test.Module02Metrics.contig_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list",
 
-  "Module02Test.Module02.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module02Test.Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02Test.Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02Test.Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module03/Module03.test_large.json
+++ b/test/module03/Module03.test_large.json
@@ -1,5 +1,5 @@
 {
-  "Module03.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module03.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module03.linux_docker" : "ubuntu:18.04",
 

--- a/test/module03/Module03Test.test_large.json
+++ b/test/module03/Module03Test.test_large.json
@@ -120,7 +120,7 @@
   "Module03Test.Module03Metrics.Module03Metrics.PESR_VCF_Metrics.mem_gib" : "3.75",
   "Module03Test.Module03Metrics.Module03Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
 
-  "Module03Test.Module03.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module03Test.Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module03Test.Module03.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module03Test.Module03.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04/MergeCohortVcfs.test.json
+++ b/test/module04/MergeCohortVcfs.test.json
@@ -1,5 +1,5 @@
 {
-  "MergeCohortVcfs.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "MergeCohortVcfs.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "MergeCohortVcfs.pesr_vcfs": ["gs://gatk-sv-resources/test/module03/large/output/test_large.filtered_pesr_merged.vcf.gz"],
   "MergeCohortVcfs.depth_vcfs": ["gs://gatk-sv-resources/test/module03/large/output/test_large.depth.outliers_removed.vcf.gz"]
 }

--- a/test/module04/Module04.test_large.json
+++ b/test/module04/Module04.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module04.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module04.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module04.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04/Module04Test.test_large.json
+++ b/test/module04/Module04Test.test_large.json
@@ -121,7 +121,7 @@
   "Module04Test.Module04Metrics.Module04Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
 
   "Module04Test.Module04.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module04Test.Module04.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module04Test.Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module04Test.Module04.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04Test.Module04.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04b/Module04b.test.json
+++ b/test/module04b/Module04b.test.json
@@ -2,7 +2,7 @@
   "Module04b.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04b.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "Module04b.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module04b.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module04b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module04b.n_RdTest_bins": "100000",
   "Module04b.n_per_split": "5000",
 

--- a/test/module05_06/Module05_06.test_large.json
+++ b/test/module05_06/Module05_06.test_large.json
@@ -38,7 +38,7 @@
   "Module05_06.max_shards_per_chrom": 100,
   "Module05_06.min_variants_per_shard": 30,
 
-  "Module05_06.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module05_06.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module05_06.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module05_06.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",

--- a/test/module05_06/Module05_06Test.test_large.json
+++ b/test/module05_06/Module05_06Test.test_large.json
@@ -159,7 +159,7 @@
   "Module05_06Test.Module05_06.max_shards_per_chrom": 100,
   "Module05_06Test.Module05_06.min_variants_per_shard": 30,
 
-  "Module05_06Test.Module05_06.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "Module05_06Test.Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "Module05_06Test.Module05_06.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module05_06Test.Module05_06.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module05_06Test.Module05_06.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",

--- a/test/module07/Module07.test.json
+++ b/test/module07/Module07.test.json
@@ -14,5 +14,5 @@
   "Module07.prefix" :       "Talkowski_SV_PCR-free_WGS_144",
 
   "Module07.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module07.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3"
+  "Module07.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations"
 }

--- a/test/module07/Module07.test.json
+++ b/test/module07/Module07.test.json
@@ -2,10 +2,10 @@
   "Module07.vcf" :     "gs://fc-fae972fb-9dbf-41c7-926f-f419a767a1ab/61a7ce7c-3b3c-4716-977a-ffb6e34464b6/minGQ_filter_workflow_v2/d841eeb6-90c3-4ff2-8b99-7a793c85cfea/call-combine_vcfs/Talkowski_SV_PCR-free_WGS_144.minGQ_filtered.vcf.gz",
   "Module07.vcf_idx" : "gs://fc-fae972fb-9dbf-41c7-926f-f419a767a1ab/61a7ce7c-3b3c-4716-977a-ffb6e34464b6/minGQ_filter_workflow_v2/d841eeb6-90c3-4ff2-8b99-7a793c85cfea/call-combine_vcfs/Talkowski_SV_PCR-free_WGS_144.minGQ_filtered.vcf.gz.tbi",
 
-  "Module07.protein_coding_gtf" : "gs://broad-dsde-methods/cromwell-execution-36/PrepareGencode/810f8195-fb2c-4f75-ac6a-81781de8350c/call-MakeCanonicalGtf/gencode.canonical_pc.gtf.gz",
-  "Module07.linc_rna_gtf" :       "gs://broad-dsde-methods/cromwell-execution-36/PrepareGencode/810f8195-fb2c-4f75-ac6a-81781de8350c/call-SubsetLincRNA/gencode.lincRNA.gtf.gz",
-  "Module07.promoter_bed" :       "gs://broad-dsde-methods/cromwell-execution-36/PrepareGencode/810f8195-fb2c-4f75-ac6a-81781de8350c/call-MakePromoters/gencode.canonical_pc.promoter.bed",
-  "Module07.noncoding_bed" :       "gs://broad-dsde-methods/cromwell-execution-36/PrepareGencode/810f8195-fb2c-4f75-ac6a-81781de8350c/call-MakePromoters/gencode.canonical_pc.noncoding.bed",
+  "Module07.protein_coding_gtf" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gencode.canonical_pc.gtf.gz",
+  "Module07.linc_rna_gtf" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gencode.lincRNA.gtf.gz",
+  "Module07.promoter_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/promoter.bed",
+  "Module07.noncoding_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed",
 
   "Module07.contig_list" :  "gs://fc-fae972fb-9dbf-41c7-926f-f419a767a1ab/chromosomes_nochrY.fai",
   "Module07.ped_file":      "gs://fc-fae972fb-9dbf-41c7-926f-f419a767a1ab/FINAL_full_prenatal_dosage_sex.ped",

--- a/test/module07/Module07Preprocessing.wdl.example.json
+++ b/test/module07/Module07Preprocessing.wdl.example.json
@@ -7,6 +7,6 @@
   "Module07Preprocessing.promoter_window": 1000, 
 
   "Module07Preprocessing.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module07Preprocessing.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3"
+  "Module07Preprocessing.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations"
 }
 

--- a/test/module07/PrepareGencode.wdl.example.json
+++ b/test/module07/PrepareGencode.wdl.example.json
@@ -7,6 +7,6 @@
   "PrepareGencode.promoter_window": 1000, 
 
   "PrepareGencode.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "PrepareGencode.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3"
+  "PrepareGencode.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations"
 }
 

--- a/test/mosaic/Mosaics.json
+++ b/test/mosaic/Mosaics.json
@@ -3,7 +3,7 @@
   "MosaicManualCheck.outlier": "gs://gatk-sv-resources/resources/outlier.txt",
   "MosaicManualCheck.famfile": "gs://gatk-sv-resources/test/module03/large/output/test_large.outlier_samples_removed.fam",
   "MosaicManualCheck.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
-  "MosaicManualCheck.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "MosaicManualCheck.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "MosaicManualCheck.agg_metrics": ["gs://gatk-sv-resources/test/module02/large/output/test_large.metrics"],
   "MosaicManualCheck.per_batch_clustered_pesr_vcf_list": ["gs://gatk-sv-resources/test/mosaic/pesr_list.txt"],
   "MosaicManualCheck.clustered_depth_vcfs": ["gs://gatk-sv-resources/test/module01/large/output/test_large.depth.vcf.gz"],

--- a/test/phase1/GATKSVPipelinePhase1.test_large.json
+++ b/test/phase1/GATKSVPipelinePhase1.test_large.json
@@ -2,7 +2,7 @@
   "GATKSVPipelinePhase1.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "GATKSVPipelinePhase1.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelinePhase1.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
-  "GATKSVPipelinePhase1.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "GATKSVPipelinePhase1.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "GATKSVPipelinePhase1.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelinePhase1.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",
   "GATKSVPipelinePhase1.linux_docker" : "ubuntu:18.04",

--- a/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
+++ b/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
@@ -192,6 +192,12 @@
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.run_vcf_qc" : false,
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.max_ref_panel_carrier_freq": 0.03,
 
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.protein_coding_gtf" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gencode.canonical_pc.gtf.gz",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.linc_rna_gtf" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gencode.lincRNA.gtf.gz",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.promoter_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/promoter.bed",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.noncoding_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.annotation_sv_per_shard" : "5000",
+
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.ref_std_manta_vcfs" : [
     "gs://gatk-sv-resources/clinical/reference_panel_v1b/manta_std/std_000.manta.SM-BZNZQ.vcf.gz",
     "gs://gatk-sv-resources/clinical/reference_panel_v1b/manta_std/std_001.manta.SM-BZNZR.vcf.gz",

--- a/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
+++ b/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
@@ -136,7 +136,7 @@
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_docker": "gatksv/sv-pipeline:b3af2e3",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "gatksv/sv-pipeline-qc:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -950,6 +950,13 @@ workflow GATKSVPipelineSingleSample {
   output {
     File final_vcf = FinalVCFCleanup.out
     File final_vcf_idx = FinalVCFCleanup.out_idx
+
+    # These files contain events reported in the internal VCF representation
+    # They are less VCF-spec compliant but may be useful if components of the pipeline need to be re-run
+    # on the output.
+    File pre_cleanup_vcf = Module07.output_vcf
+    File pre_cleanup_vcf_idx = Module07.output_vcf_idx
+
     File ploidy_matrix = select_first([Module00c.ploidy_matrix])
     File ploidy_plots = select_first([Module00c.ploidy_plots])
     File metrics_file = SingleSampleMetrics.metrics_file

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -11,6 +11,7 @@ import "SRTest.wdl" as SRTest
 import "Module03.wdl" as m03
 import "Module04.wdl" as m04
 import "Module05_06.wdl" as m0506
+import "Module07.wdl" as m07
 import "GermlineCNVCase.wdl" as gcnv
 import "SingleSampleFiltering.wdl" as SingleSampleFiltering
 import "GATKSVPipelineSingleSampleMetrics.wdl" as SingleSampleMetrics
@@ -359,6 +360,16 @@ workflow GATKSVPipelineSingleSample {
     RuntimeAttr? runtime_override_clean_background_fail
     RuntimeAttr? runtime_override_merge_fam_file_list
     RuntimeAttr? runtime_override_make_cpx_cnv_input_file
+
+    ############################################################
+    ## Module 07
+    ############################################################
+
+    File protein_coding_gtf
+    File linc_rna_gtf
+    File promoter_bed
+    File noncoding_bed
+    Int annotation_sv_per_shard
 
     ############################################################
     ## Single sample filtering
@@ -885,10 +896,25 @@ workflow GATKSVPipelineSingleSample {
         sv_base_mini_docker=sv_base_mini_docker
     }
 
+  call m07.Module07 as Module07 {
+       input:
+        vcf = ResetBothsidesSupportFilter.out,
+        vcf_idx = ResetBothsidesSupportFilter.out_idx,
+        prefix = batch,
+        contig_list = primary_contigs_list,
+        protein_coding_gtf = protein_coding_gtf,
+        linc_rna_gtf = linc_rna_gtf,
+        promoter_bed = promoter_bed,
+        noncoding_bed = noncoding_bed,
+        sv_per_shard = annotation_sv_per_shard,
+        sv_base_mini_docker = sv_base_mini_docker,
+        sv_pipeline_docker = sv_pipeline_docker
+  }
+
   call SingleSampleFiltering.FinalVCFCleanup as FinalVCFCleanup {
     input:
-      single_sample_vcf=ResetBothsidesSupportFilter.out,
-      single_sample_vcf_idx=ResetBothsidesSupportFilter.out_idx,
+      single_sample_vcf=Module07.output_vcf,
+      single_sample_vcf_idx=Module07.output_vcf_idx,
       ref_fasta=reference_fasta,
       ref_fasta_idx=reference_index,
       sv_pipeline_docker=sv_pipeline_docker


### PR DESCRIPTION
This PR adds module07 to the single sample pipeline to add annotations to the final output VCF. Module07 is run before the FinalVCFCleanup task because the variant representation changes made by that task to be more VCF-spec compliant are incompatible with the annotation module.

* Small changes to `svtk annotate` to make sure they don't blow up on empty data frames (as is the case on chrY variants for a female single-sample vcf)
* Added the public annotation resources as inputs to the workflow JSONs, and updated the Module07 test JSON to use them.
* Updated `sv-pipeline` docker image to `cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations`
* Changed the `update_json_docker.sh` script to look in the `inputs` directory instead of the old `single-sample` directory.

