### PR TITLE
Improve cromwell monitoring script

### DIFF
--- a/scripts/cromwell/cromwell_monitoring_script2.sh
+++ b/scripts/cromwell/cromwell_monitoring_script2.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+# NOTE: this script is intended to be placed in google cloud storage
+# and invoked by adding the following line to your cromwell workflow
+# options:
+#    "monitoring_script": "gs://bucket/path/to/cromwell_monitoring_script2.sh"
+# Upon task completion "monitoring.log" will be added to the appropriate
+# cloud storage folder.
+set -Eeuo pipefail
+
+MONITOR_MOUNT_POINT=${MONITOR_MOUNT_POINT:-"/cromwell_root"}
+SLEEP_TIME=${SLEEP_TIME:-"10"}
+
+function getCpuUsage() {
+    # get the summary cpu statistics (i.e. for all cpus) since boot
+    # get the numeric values in an array, dropping the first field (the
+    # string, "cpu")
+    CPU_TIMES=($(sed -n 's/^cpu\s//p' /proc/stat))
+    # idle time (in system units) is the 3rd numeric field
+    IDLE_TIME=${CPU_TIMES[3]}
+    # total cpu time is sum of all fields
+    TOTAL_TIME=0
+    for T in "${CPU_TIMES[@]}"; do
+        ((TOTAL_TIME += T))
+    done
+    
+    # get the previous times from temp file
+    read PREVIOUS_IDLE PREVIOUS_TOTAL < $TEMP_CPU
+    
+    # write current times to temp file
+    echo "$IDLE_TIME $TOTAL_TIME" > $TEMP_CPU
+    
+    # get the difference in idle and total times since the previous
+    # update, and report the usage as: non-idle time as a percentage
+    # of total time
+    awk -v IDLE=$((IDLE_TIME-PREVIOUS_IDLE)) \
+        -v TOTAL=$((TOTAL_TIME-PREVIOUS_TOTAL)) \
+        'BEGIN { printf "%.1f", 100 * (1 - IDLE / TOTAL) }'
+}
+
+function getMem() {
+    # get desired memory value from /proc/meminfo, in GiB, and also
+    # as a percentage of total
+    # argument is the label of the desired memory value
+    cat /proc/meminfo \
+        | awk -v MEM_FIELD="$1" '{
+            f[substr($1, 1, length($1)-1)] = $2
+        } END {
+            printf "%.2f GiB", f[MEM_FIELD] / 1048576
+        }'     
+}
+
+function getMemUnavailable() {
+    # get unavailable memory from /proc/meminfo, in GiB
+    cat /proc/meminfo \
+        | awk '{
+            f[substr($1, 1, length($1)-1)] = $2
+        } END {
+            if("MemAvailable" in f) {
+                mem_available = f["MemAvailable"]
+            } else {
+                mem_available = f["MemFree"] + f["Buffers"] + f["Cached"]
+            }
+            mem_in_use = f["MemTotal"] - mem_available
+            printf "%.2f\t%.1f", mem_in_use / 1048576, 100 * mem_in_use / f["MemTotal"]
+        }'    
+}
+
+function getDisk() {
+    # get information about disk usage from "df" command.
+    DISK_COLUMN=$(echo "$1" | awk '{print tolower($1)}')
+    MOUNT_POINT=$2
+    # extract desired value
+    VALUE=$(\
+        df -h "$MOUNT_POINT" \
+        | sed 's/Mounted on/Mounted-on/' \
+        | awk -v DISK_COLUMN=$DISK_COLUMN '
+            FNR==1 {
+                NF_HEADER=NF
+                for(i=1; i<=NF; i++) { f[tolower($i)]=NF-i }
+            }
+            FNR>1 {
+                FIELD_NUM=NF-f[DISK_COLUMN]
+                if(FIELD_NUM > 0) {
+                    VALUE=$(FIELD_NUM)
+                    print VALUE
+                } else if(f[DISK_COLUMN] == NF_HEADER-1 && NF == 1) {
+                    VALUE=$(1)
+                    print VALUE
+                }
+            }' \
+    )
+    # If value is a number followed by letters, it is a value with units
+    # and needs to be converted.
+    # If value is a %, print the number and strip the value
+    # Otherwise just print value
+    if [[ "$VALUE" =~ [0-9.]+[%a-zA-Z]+ ]]; then
+        echo "$VALUE"\
+        | sed -E 's/([0-9.]*)([^0-9.]*)/\1 \2/' \
+        | awk '{
+            UNIT=substr($2, 1, 1)
+            if(UNIT == "T") {
+                SCALE=2^10
+            } else if(UNIT == "G") {
+                SCALE=1
+            } else if(UNIT == "M") {
+                SCALE=2^-10
+            } else if(UNIT == "K") {
+                SCALE=2^-20
+            } else if(UNIT == "B") {
+                SCALE=2^-30
+            } else {
+                SCALE=1
+            }
+            printf "%.1f", $1 * SCALE
+        }'
+    else
+        echo "$VALUE"
+    fi
+}
+
+function findBlockDevice() {
+    MOUNT_POINT=$1
+    FILESYSTEM=$(grep -E "$MOUNT_POINT\s" /proc/self/mounts \
+                | awk '{print $1}')
+    DEVICE_NAME=$(basename "$FILESYSTEM")
+    FS_IN_BLOCK=$(find -L /sys/block/ -mindepth 2 -maxdepth 2 -type d \
+                       -name "$DEVICE_NAME")
+    if [ -n "$FS_IN_BLOCK" ]; then
+        # found path to the filesystem in the block devices. get the
+        # block device as the parent dir
+        dirname "$FS_IN_BLOCK"
+    elif [ -d "/sys/block/$DEVICE_NAME" ]; then
+        # the device is itself a block device
+        echo "/sys/block/$DEVICE_NAME"
+    else
+        # couldn't find, possibly mounted by mapper.
+        # look for block device that is just the name of the symlinked
+        # original file. if not found, echo empty string (no device found)
+        BLOCK_DEVICE=$(ls -l "$FILESYSTEM" 2>/dev/null \
+                        | cut -d'>' -f2 \
+                        | xargs basename 2>/dev/null \
+                        || echo)
+        if [[ -z "$BLOCK_DEVICE" ]]; then
+            1>&2 echo "Unable to find block device for filesystem $FILESYSTEM."
+            if [[ -d /sys/block/sdb ]] && ! grep -qE "^/dev/sdb" /etc/mtab; then
+                1>&2 echo "Guessing present but unused sdb is the correct block device."
+                echo "/sys/block/sdb"
+            else           
+                1>&2 echo "Disk IO will not be monitored."
+            fi
+        fi
+    fi
+}
+
+function handle_integer_wrap() {
+    if [ $1 -ge 0 ]; then
+        echo $1
+    else
+        WRAPPED=$1
+        echo "$((WRAPPED + 2**30))"
+    fi
+}
+
+function getBlockDeviceIO() {
+    # get read and write IO rate by looking at appropriate block device
+    STAT_FILE="$1"
+    if [[ -f "$STAT_FILE" ]]; then
+        # get IO stats as comma-separated list to extract 3rd and 7th fields
+        STATS=$(sed -E 's/[[:space:]]+/,/g' $STAT_FILE | sed -E 's/^,//'\
+                | cut -d, -f3,7 | sed -E 's/,/ /g')
+        # get results of previous poll
+        read OLD_READ OLD_WRITE < $TEMP_IO
+        # save new poll results
+        read READ_SECTORS WRITE_SECTORS <<<$STATS
+        echo "$READ_SECTORS $WRITE_SECTORS" > $TEMP_IO
+        # update read and write sectors as difference since previous poll
+        READ_SECTORS=$(handle_integer_wrap $((READ_SECTORS - OLD_READ)))
+        WRITE_SECTORS=$(handle_integer_wrap $((WRITE_SECTORS - OLD_WRITE)))
+
+        # output change in read/write sectors in MiB/s
+        echo "$READ_SECTORS $WRITE_SECTORS" \
+            | awk -v T=$SLEEP_TIME -v B=$SECTOR_BYTES \
+                '{ printf "%.3f\t%.3f",  $1*B/T/1048576, $2*B/T/1048576 }'
+    else
+        printf "nan\tnan"
+    fi
+}
+
+T_START=$(date +%s)
+
+function elapsed_time() {
+    T_NOW=$(date +%s)
+    T_ELAPSED=$((T_NOW-T_START))
+    M=$((T_ELAPSED / 60))
+    S=$((T_ELAPSED % 60))
+    H=$((M / 60))
+    M=$((M % 60))
+    printf "%02d:%02d:%02d" $H $M $S
+}
+
+function runtimeInfo() {
+    printf "%s\t%s\t%s\t%s\t%s\t%s\n" "$(elapsed_time)" "$(getCpuUsage)" "$(getMemUnavailable)" \
+      "$(getDisk Used $MONITOR_MOUNT_POINT)" "$(getDisk Use% $MONITOR_MOUNT_POINT)" \
+      "$(getBlockDeviceIO "$BLOCK_DEVICE_STAT_FILE")"
+}
+
+
+# print out header info
+echo --- General Information ---
+echo Num processors: $(nproc)
+echo Total Memory: $(getMem MemTotal)
+echo Total Disk space: $(getDisk Size "$MONITOR_MOUNT_POINT") GiB
+echo Start time: $(date "+%F %T %z" -d @$T_START)
+echo --- Runtime Information ---
+echo -e "ElapsedTime\tCPU\tMem\tMemPct\tDisk\tDiskPct\tIORead\tIOWrite"
+echo -e "HH:MM:SS   \t%\tGiB\t%\tGiB\t%\tMiB/s\tMiB/s"
+
+# make a temp file to store io information, remove it on exit
+TEMP_IO=$(mktemp "${TMPDIR:-/tmp/}$(basename $0).XXXXXXXXXXXX")
+# make a temp file to store cpu information, remove it on exit
+# remove temp files on exit
+TEMP_CPU=$(mktemp "${TMPDIR:-/tmp/}$(basename $0).XXXXXXXXXXXX")
+trap "rm -f $TEMP_IO $TEMP_CPU" EXIT
+
+
+# find the block device
+BLOCK_DEVICE=$(findBlockDevice "$MONITOR_MOUNT_POINT")
+if [[ -z "$BLOCK_DEVICE" ]] \
+        || [[ ! -f "$BLOCK_DEVICE/queue/hw_sector_size" ]]; then
+    # no block device found, can't get IO info
+    SECTOR_BYTES=0
+    BLOCK_DEVICE_STAT_FILE=""
+else
+    SECTOR_BYTES=$(cat "$BLOCK_DEVICE/queue/hw_sector_size")
+    BLOCK_DEVICE_STAT_FILE="$BLOCK_DEVICE/stat"
+fi
+
+
+# since getCpuUsage looks at differences in stat file, run the update so
+# the first reported update has a sensible previous result to compare to
+echo "0 0" > $TEMP_CPU
+getCpuUsage > /dev/null
+
+# same thing for getBlockDeviceIO
+echo "0 0" > $TEMP_IO
+getBlockDeviceIO "$BLOCK_DEVICE_STAT_FILE" > /dev/null
+
+
+while true; do
+    runtimeInfo
+    sleep $SLEEP_TIME
+done

--- a/scripts/cromwell/get_cromwell_resource_usage2.sh
+++ b/scripts/cromwell/get_cromwell_resource_usage2.sh
@@ -1,0 +1,354 @@
+#!/bin/bash
+
+function show_help() {
+    cat <<-END
+USAGE: get_cromwell_memory_usage2.sh [OPTIONS] WORKFLOW_INFO
+Displays #tasks x #fields table of resource usage info with two
+header lines, and additional column of task descriptions.
+    WORKFLOW_INFO: specifies workflow identity. Can be
+                   a) a cromwell workflow ID
+                   b) a path to workflow output in google cloud (starting with gs://)
+                   c) a local path to workflow output
+    OPTIONS:
+        -r --raw-output
+            If set, output data as tab-separated table. Otherwise pass data through column -t for
+            easier reading.
+        -u --no-units
+            If set, don't show second header line with units.
+        -o --output-file OUTPUT_FILE_NAME
+            If specified, write output to file instead of stdout. Note that all non-tabular output is
+            sent to stderr, so this is just syntactic sugar for file redirection.
+
+-This script works by finding all the logs, sorting them into sensible
+ order, and chopping up their paths to make a description column. If
+ any jobs have not completed they will simply be omitted. The script
+ makes no attempt to figure out what tasks *should* have run. However,
+ the description field should make any such omissions discoverable.
+-If you run on a local path, the log file names must still be
+ "monitoring.log", and the local folder structure must be the same as
+ in the original cloud bucket (other non-log files are not required
+ though)
+-If you pass a workflow id, cromshell will be used to find the
+ appropriate workflow folder in google cloud storage.
+-If cromshell is not located on your PATH, then define the ENV
+ variable CROMSHELL with the appropriate path.
+-Since there is significant start-up time to running gsutil functions,
+ running the inner loop of this script in parallel results in
+ signficant speed-up. Installing gnu parallel (available on osx and
+ linux) triggers this automatically.
+END
+}
+
+if [[ $# == 0 ]]; then
+    show_help
+    exit 0
+fi
+RAW_OUTPUT=false
+SHOW_UNITS=true
+OUTPUT_FILE="/dev/stdout"
+WORKFLOW_INFO=""
+for ((i=1; i<=$#; ++i)); do
+    if [[ ${!i} =~ ^-+(h|help) ]]; then
+        show_help
+        exit 0
+    elif [[ ${!i} =~ ^-+(r|raw-output) ]]; then
+        RAW_OUTPUT=true
+    elif [[ ${!i} =~ ^-+(u|no-units) ]]; then
+        SHOW_UNITS=false
+    elif [[ ${!i} =~ ^-+(o|output-file) ]]; then
+        ((++i))
+        OUTPUT_FILE="${!i}"
+    elif [[ ${!i} =~ ^-.* ]]; then
+        1>&2 echo "Unknown option ${!i}"
+        show_help
+        exit 1
+    elif [[ -z "$WORKFLOW_INFO" ]]; then
+        WORKFLOW_INFO=${!i}
+    else
+        1>&2 echo "Too many arguments"
+        exit 1
+    fi
+done
+export SHOW_UNITS
+
+set -Eeu -o pipefail
+
+CROMSHELL=${CROMSHELL:-"cromshell"}
+
+REMOTE=true
+if [[ -z "$WORKFLOW_INFO" ]]; then
+    1>&2 echo "No WORKFLOW_INFO provided"
+    show_help
+    exit 1
+elif [[ $WORKFLOW_INFO == "gs://"* ]]; then
+    # workflow info is a cloud file, strip trailing slashes (must use sed because OSX uses old bash)
+    WORKFLOW_DIR=$(echo "$WORKFLOW_INFO" | sed 's,/*$,,g')
+elif [[ -d "$WORKFLOW_INFO" ]]; then
+    # workflow info is a local file, strip trailing slashes (must use sed because OSX uses old bash)
+    WORKFLOW_DIR=$(echo "$WORKFLOW_INFO" | sed 's,/*$,,g')
+    REMOTE=false
+else
+    WORKFLOW_ID="$WORKFLOW_INFO"
+    # get the metadata for this workflow id
+    if ! METADATA=$(2>/dev/null $CROMSHELL -t 60 slim-metadata $WORKFLOW_ID); then
+        1>&2 echo "Unable to obtain workflow $WORKFLOW_ID metadata from cromshell, try supplying GCS_PATH_TO_WORKFLOW_FOLDER"
+        exit 1
+    fi
+    # get the appropriate path in google cloud for the workflow dir
+    # from the metadata
+    # a) find lines in the metadata that include a 
+    WORKFLOW_DIR=$( \
+        echo "$METADATA" \
+        | grep -Eo "gs://[^[:space:]]*$WORKFLOW_ID" \
+        | tail -n1 \
+    )
+fi
+1>&2 echo "WORKFLOW_DIR=$WORKFLOW_DIR"
+#1>&2 echo "RAW_OUTPUT=$RAW_OUTPUT"
+#1>&2 echo "SHOW_UNITS=$SHOW_UNITS"
+
+
+function get_monitor_logs() {
+    TOP_DIR=$1
+    REMOTE=$2
+    if $REMOTE; then
+      gsutil -m ls "$TOP_DIR/**monitoring.log" 2>/dev/null || echo ""
+    else
+      find "$TOP_DIR" -name "monitoring.log" 2>/dev/null || echo ""
+    fi
+}
+
+
+# ingest LOG_FILE, TOP_DIR, NUM_SHARDS
+# print out sorting key of form ATTEMPT_KEY -tab- MAIN_KEY
+#    where ATTEMPT_KEY
+#       -lists the attempt number of the executing tasks OR
+#       -if there is no attempt in the path, calls it attempt 0
+#       -digits are padded the same as shards
+#    where MAIN_KEY
+#       -preserves info about calls and shard numbers, each separated
+#        by '/'
+#       -shard numbers having enough 0-padded digts to all be of
+#        the same length
+function get_task_sort_key() {
+    LOG_FILE=$1
+    TOP_DIR=$2
+    N_START=$((1 + $(echo "$TOP_DIR" | tr / '\n' | wc -l)))
+    NUM_SHARDS=$(($3))
+    MAX_SHARD_DIGITS=${#NUM_SHARDS}
+    SHARD_FORMAT="%0${MAX_SHARD_DIGITS}d"
+    # keep info about task calls, shards, and attempts below top-dir
+    # if there is no preemption folder in the path, call it attempt 0
+    echo "$LOG_FILE" \
+        | tr / '\n' \
+        | tail -n+$N_START \
+        | awk -v FS='-' \
+              -v SHARD_FORMAT="$SHARD_FORMAT" '
+            {
+                if($1 == "shard") {
+                    SHARD_KEY=sprintf("%s/" SHARD_FORMAT, SHARD_KEY, $2)
+                } else if($1 == "call") {
+                    CALL_KEY=sprintf("%s/%s", CALL_KEY, $2)
+                } else if($1 == "attempt") {
+                    ATTEMPT_NUMBER=$2
+                }
+            }
+            END {
+              printf SHARD_FORMAT "\t%s/%s", ATTEMPT_NUMBER, CALL_KEY, SHARD_KEY
+            }'
+}
+
+
+function sort_monitor_logs() {
+    TOP_DIR="$1"
+    LOGS_LIST=$(cat)
+    NUM_LOGS=$(($(echo "$LOGS_LIST" | wc -l)))
+    # The older bash on OSX does not have associative arrays, so to
+    # sort file names according to a key, we join the key and the file
+    # name into one string with tab delimiters (okay because these are
+    # cloud paths produced by cromwell and have no tabs). Then sort by
+    # the key, and ultimately cut away the key. There is one extra
+    # complication that there may be multiple "attempts" at each task,
+    # and we only want to keep the final (presumably successful)
+    # attempt.
+    #
+    # 1. for each log file
+    #  a) get a sort key of form: ATTEMPT_KEY tab MAIN_KEY
+    #  b) print line of form: LOG_FILE tab MAIN_KEY tab ATTEMPT_KEY
+    # 2. sort lines by increasing MAIN_KEY, and secondarily by
+    #      decreasing (numeric) ATTEMPT_KEY
+    # 3. keep first unique instance of MAIN_KEY (i.e. the last attempt)
+    # 4. print out the log file (the first field) in sorted order
+    echo "$LOGS_LIST" \
+        | while read -r LOG_FILE; do
+            SORT_KEY=$(get_task_sort_key "$LOG_FILE" "$TOP_DIR" "$NUM_LOGS")
+            printf "%s\t%s\n" "$LOG_FILE" "$SORT_KEY"
+          done \
+        | sort -t $'\t' -k3,3 -k2,2rn \
+        | uniq -f2 \
+        | cut -d$'\t' -f1
+}
+
+
+# Scan LOG_FILE, extract header, and print maximum of each column.
+# If a column is missing data, print "nan"
+function get_task_peak_resource_usage() {
+    LOG_FILE=$1
+    if $REMOTE; then
+        gsutil cat "$LOG_FILE"
+    else
+        cat "$LOG_FILE"
+    fi \
+        | awk '
+            function handle_nan(num) {
+               return num < 0 ? "nan" : num
+            }
+            BEGIN {
+                NEED_HEADER=2
+            }
+            NEED_HEADER == 0 {
+                PEAK_VALUE[1] = $1
+                for(i=2; i<=NF; ++i) {
+                    if($i > PEAK_VALUE[i]) {
+                        PEAK_VALUE[i] = $i
+                    }
+                }
+            }
+            NEED_HEADER>0 {
+                if(NEED_HEADER==2) {
+                    if($1" "$2 == "Num processors:") {
+                        TOT["CPU"] = $3
+                        TOT_NAME["CPU"] = "nCPU"
+                        TOT_UNIT["CPU"] = "#"
+                    }
+                    else if($1" "$2 == "Total Memory:") {
+                        TOT["Mem"] = $3
+                        TOT_NAME["Mem"] = "TotMem"
+                        TOT_UNIT["Mem"] = $4
+                    }
+                    else if($1" "$2 == "Total Disk") {
+                        TOT["Disk"] = $4
+                        TOT_NAME["Disk"] = "TotDisk"
+                        TOT_UNIT["Disk"] = $5
+                    }
+                    else if($1 == "ElapsedTime") {
+                        # this is the first header line
+                        # for summary purposes, augment instantaneous
+                        # usage with total VM stats
+                        PEAK_VALUE[1] = "00:00:00"
+                        HEADER_NAME[1] = $1
+                        printf "%s", $1
+                        for(i=2; i<=NF; ++i) {
+                            PEAK_VALUE[i] = -1.0
+                            HEADER_NAME[i] = $i
+                            if($i in TOT_NAME) {
+                              printf "\t%s", TOT_NAME[$i]
+                              delete TOT_NAME[$i]
+                            }
+                            printf "\t%s", $i
+                        }
+                        printf "\n"
+                        --NEED_HEADER
+                    }
+                } else {
+                    printf "%s", $1
+                    for(i=2; i<=NF; ++i) {
+                        NAME_i = HEADER_NAME[i]
+                        if(NAME_i in TOT_UNIT) {
+                            printf "\t%s", TOT_UNIT[NAME_i]
+                            delete TOT_UNIT[NAME_i]
+                        }
+                        printf "\t%s", $i
+                    }
+                    printf "\n"
+                    --NEED_HEADER
+                }
+            }
+            END {
+                printf "%s", handle_nan(PEAK_VALUE[1])
+                for(i=2; i<=length(PEAK_VALUE); ++i) {
+                    NAME_i = HEADER_NAME[i]
+                    if(NAME_i in TOT) {
+                        printf "\t%s", handle_nan(TOT[NAME_i])
+                        delete TOT[NAME_i]
+                    }
+                    printf "\t%s", handle_nan(PEAK_VALUE[i])
+                }
+                printf "\n"
+            }
+        '
+}
+export -f get_task_peak_resource_usage
+
+
+# Condense directory structure of full path to LOG_FILE into a succinct
+# description of the task. Ignore components above TOP_DIR, as they are
+# common to all the log files that are being requested.
+function get_task_description() {
+    LOG_FILE=$1
+    if [ $# -ge 2 ]; then
+        TOP_DIR=$2
+        N_START=$((1 + $(echo "$TOP_DIR" | tr / '\n' | wc -l)))
+    else
+        N_START=1
+    fi
+    # keep info about task calls and shards below top-dir
+    echo "$LOG_FILE" \
+        | tr / '\n' \
+        | tail -n+$N_START \
+        | grep -E "^(call-|shard-|attempt-)" \
+        | tr '\n' / \
+        | sed -e 's/call-//g' -e 's,/$,,'
+}
+export -f get_task_description
+
+function get_task_columns() {
+    LOG_NUMBER=$1
+    LOG_FILE="$2"
+    TOP_DIR="$3"
+    DESCRIPTION=$(get_task_description "$LOG_FILE" "$TOP_DIR")
+    RESOURCE_USAGE=$(get_task_peak_resource_usage "$LOG_FILE")
+    if [[ $LOG_NUMBER == 1 ]]; then
+        # due to OSX having an ancient version of bash, this produces syntax errors:
+        # paste <(echo "$RESOURCE_USAGE" | head -n2) <(echo "task")
+        printf "%s\ttask\n" "$(echo "$RESOURCE_USAGE" | head -n1)"
+        if $SHOW_UNITS; then
+          echo "$RESOURCE_USAGE" | tail -n2 | head -n1
+        fi
+    fi
+    printf "%s\t%s\n" "$(echo "$RESOURCE_USAGE" | tail -n1)" "$DESCRIPTION"
+}
+export -f get_task_columns
+
+
+function get_workflow_peak_resource_usage() {
+    export TOP_DIR=$1
+    export REMOTE=$2
+    LOGS=$(get_monitor_logs "$TOP_DIR" $REMOTE | sort_monitor_logs "$TOP_DIR")
+    if [ -z "$LOGS" ]; then
+        1>&2 echo "No logs found in $TOP_DIR"
+        exit 0
+    fi
+    if command -v parallel > /dev/null; then
+        # parallel command is installed, use it, much faster!
+        if [ -t 1 ]; then
+            # stdout is a terminal, not being redirected, don't use bar
+            BAR=""
+        else
+            # being redirected, show progress via bar to stderr
+            BAR="--bar"
+        fi
+        echo "$LOGS" | nl -s $'\t' | parallel ${BAR} --env TOP_DIR -k --colsep $'\t' "get_task_columns {1} {2} $TOP_DIR"
+    else
+        1>&2 echo "Consider installing 'parallel', it will give significant speed-up"
+        echo "$LOGS" | nl -s $'\t' | while read -r LOG_NUMBER WORKFLOW_LOG; do
+            get_task_columns $LOG_NUMBER "$WORKFLOW_LOG" "$TOP_DIR"
+        done
+    fi
+}
+
+if $RAW_OUTPUT; then
+    get_workflow_peak_resource_usage "$WORKFLOW_DIR" $REMOTE
+else
+    get_workflow_peak_resource_usage "$WORKFLOW_DIR" $REMOTE | column -t
+fi > "$OUTPUT_FILE"


### PR DESCRIPTION
* Added new cromwell monitoring script:
  /scripts/cromwell/cromwell_monitoring_script2.sh
  Outputs resource log in tabular format that 
  * uses less disk space
  * (is thus hopefully more likely to de-localize after job completion)
  * is easier to visually scan
  * is easier to ingest and process via script
* Added new script to extract summary info from new logs:
  /scripts/cromwell/get_cromwell_resource_usage2.sh 
  This script can process local or remote logs, and can select logs via
  cloud path, local path, or cromwell workflow ID
