### PR TITLE
Allow docker build with deprecated XML package

### DIFF
--- a/dockerfiles/sv-base/Dockerfile
+++ b/dockerfiles/sv-base/Dockerfile
@@ -13,7 +13,7 @@ ENV HOME=/root
 # G-Cloud
 ARG CLOUD_SDK_VERSION=235.0.0
 ARG GCLOUD_SDK_EXTRA_COMPONENTS
-ARG GCLOUD_SDK_TRANSIENT_DEP="curl gpg-agent gnupg python-pip python-setuptools "
+ARG GCLOUD_SDK_TRANSIENT_DEP="gpg-agent gnupg python-pip python-setuptools "
 ARG GCLOUD_SDK_DEPENDENCIES="lsb-release ${GCLOUD_SDK_TRANSIENT_DEP}"
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -qqy update --fix-missing && \
@@ -53,8 +53,12 @@ RUN apt-get -qqy update --fix-missing && \
 #  4. final clean up
 COPY install_R_packages.R /opt/
 COPY install_bioconductor_packages.R /opt/
+COPY install_deprecated_R_package.sh /opt/
 ARG R_DEP_TRANSIENT="make gpg-agent gnupg"
-ARG R_DEPENDENCIES="software-properties-common build-essential ${R_DEP_TRANSIENT} libz-dev libncurses5-dev libbz2-dev liblzma-dev libcurl4-openssl-dev libssl-dev libxml2-dev ca-certificates apt-transport-https openssh-client"
+ARG R_DEPENDENCIES="software-properties-common build-essential \
+    ${R_DEP_TRANSIENT} libz-dev libncurses5-dev libbz2-dev liblzma-dev \
+    libcurl4-openssl-dev libssl-dev libxml2-dev ca-certificates \
+    apt-transport-https openssh-client"
 ARG R_RELEASE_VERSION="3.5.1"
 ARG SV_BASE_R_PKGS="optparse BiocManager"
 ARG SLIM_R_LIB_CMD="find .  -type d \\( -name \"help\" -o -name \"doc\" -o -name \"html\" -o -name \"htmlwidgets\" -o -name \"demo\" -o -name \"demodata\" -o -name \"examples\" -o -name \"exampleData\" -o -name \"unitTests\" -o -name \"tests\" -o -name \"testdata\" -o -name \"shiny\" \\) | xargs rm -rf"

--- a/dockerfiles/sv-base/install_deprecated_R_package.sh
+++ b/dockerfiles/sv-base/install_deprecated_R_package.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eu -o pipefail
+
+MODULE_ARCHIVE_URL=$1
+
+ARCHIVE_DIR=$(mktemp -d "${TMPDIR:-/tmp/}$(basename $0).XXXXXXXXXXXX")
+trap "rm -rf $ARCHIVE_DIR" EXIT
+
+MODULE_ARCHIVE_DEST="$ARCHIVE_DIR/$(basename "$MODULE_ARCHIVE_URL")"
+curl "$MODULE_ARCHIVE_URL" --output "$MODULE_ARCHIVE_DEST"
+Rscript -e "install.packages('$MODULE_ARCHIVE_DEST', repos = NULL, quiet = TRUE)"

--- a/dockerfiles/sv-pipeline-base/Dockerfile
+++ b/dockerfiles/sv-pipeline-base/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get -qqy update --fix-missing && \
                  libxml2-dev && \
     mkdir -p /tmp/R_pkg_download/ && \
     cd /opt/ && \
-    Rscript --vanilla install_R_packages.R XML && \
+    /opt/install_deprecated_R_package.sh https://cran.r-project.org/src/contrib/Archive/XML/XML_3.99-0.3.tar.gz && \
     cd "/usr/lib/R/site-library" && eval ${SLIM_R_LIB_CMD} && \
     cd "/usr/local/lib/R/site-library" && eval ${SLIM_R_LIB_CMD} && \
     apt-get -qqy remove make cmake automake && \


### PR DESCRIPTION
* Added install_deprected_R_package.sh to download and install R packages
  that are no longer supported in online repos.
* Updated sv-base/Dockerfile to install this script and include curl
  dependency.
* Updated sv-pipeline-base/Dockerfile to use this script to install XML
  R module