### PR TITLE
Re-write CTX reciprocal translocation events as BNDs in final single-sample output

### DIFF
--- a/inputs/GATKSVPipelineBatch.ref_panel_1kg.json
+++ b/inputs/GATKSVPipelineBatch.ref_panel_1kg.json
@@ -782,7 +782,7 @@
   "GATKSVPipelineBatch.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineBatch.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "GATKSVPipelineBatch.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineBatch.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",

--- a/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
+++ b/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
@@ -33,7 +33,7 @@
   "GATKSVPipelineSingleSample.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",

--- a/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json
+++ b/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json
@@ -34,7 +34,7 @@
   "GATKSVPipelineSingleSample.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",

--- a/src/sv-pipeline/04_variant_resolution/scripts/postCPX_cleanup.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/postCPX_cleanup.py
@@ -25,7 +25,7 @@ INS_ALT_INFO = [
 # info keys we need to make sure we have
 INFO_KEYS = {
     'END2' : '##INFO=<ID=END2,Type=Integer,Number=1,Description="Position of breakpoint on CHR2">',
-    'CHR2' : '##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome for END coordinate">',
+    'CHR2' : '##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome for END2 coordinate">',
     'UNRESOLVED' : '##INFO=<ID=UNRESOLVED,Number=0,Type=Flag,Description="Variant is unresolved.">',
     'UNRESOLVED_TYPE' : '##INFO=<ID=UNRESOLVED_TYPE,Number=1,Type=String,Description="Class of unresolved variant.">'
 }

--- a/src/sv-pipeline/04_variant_resolution/scripts/rm_cpx_info.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/rm_cpx_info.py
@@ -23,7 +23,7 @@ def rmcpx(vcf, fout):
         svtype = record.info['SVTYPE']
 
         #Clear CPX info fields for non-CPX variants
-        if svtype != "CPX":
+        if svtype != "CPX" and svtype != "CTX":
             for info in 'CPX_TYPE CPX_INTERVALS'.split():
                 if info in record.info.keys():
                     record.info.pop(info)

--- a/src/svtk/svtk/cli/resolve.py
+++ b/src/svtk/svtk/cli/resolve.py
@@ -27,6 +27,7 @@ CPX_INFO = [
     '##ALT=<ID=INS,Description="Insertion">',
     '##ALT=<ID=UNR,Description="Unresolved breakend or complex SV">',
     '##INFO=<ID=SOURCE,Number=1,Type=String,Description="Source of inserted sequence.">',
+    '##INFO=<ID=END2,Number=1,Type=Integer,Description="Position of breakpoint on CHR2">',
     '##INFO=<ID=CPX_TYPE,Number=1,Type=String,Description="Class of complex variant.">',
     '##INFO=<ID=CPX_INTERVALS,Number=.,Type=String,Description="Genomic intervals constituting complex variant.">',
     '##INFO=<ID=EVENT,Number=1,Type=String,Description="ID of event associated to breakend">',

--- a/src/svtk/svtk/cxsv/complex_sv.py
+++ b/src/svtk/svtk/cxsv/complex_sv.py
@@ -316,6 +316,7 @@ class ComplexSV:
             self.vcf_record.chrom = plus.chrom
             self.vcf_record.pos = plus.pos
             self.vcf_record.info['CHR2'] = plus.info['CHR2']
+            self.vcf_record.info['END2'] = plus.stop
             self.vcf_record.stop = plus.stop
             self.vcf_record.info['SVLEN'] = -1
 
@@ -351,6 +352,7 @@ class ComplexSV:
             self.vcf_record.stop = sink_end
 
             self.vcf_record.info['CHR2'] = source_chrom
+            self.vcf_record.info['END2'] = sink_end
             self.vcf_record.info['SVLEN'] = abs(source_end - source_start)
 
             interval = '{0}_{1}:{2}-{3}'

--- a/test/batch/GATKSVPipelineBatch.test_large.json
+++ b/test/batch/GATKSVPipelineBatch.test_large.json
@@ -350,7 +350,7 @@
   "GATKSVPipelineBatch.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineBatch.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "GATKSVPipelineBatch.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineBatch.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00a/Module00aBatch.test_large.json
+++ b/test/module00a/Module00aBatch.test_large.json
@@ -18,7 +18,7 @@
 
   "Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module00aBatch.delly_docker": "gatksv/delly:8645aa",
   "Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",

--- a/test/module00a/Module00aBatch.test_small.json
+++ b/test/module00a/Module00aBatch.test_small.json
@@ -18,7 +18,7 @@
 
   "Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",
   "Module00aBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00a/Module00aBatchTest.test_large.json
+++ b/test/module00a/Module00aBatchTest.test_large.json
@@ -454,7 +454,7 @@
 
   "Module00aBatchTest.Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatchTest.Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module00aBatchTest.Module00aBatch.delly_docker": "gatksv/delly:8645aa",
   "Module00aBatchTest.Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatchTest.Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",

--- a/test/module00a/Module00aBatchTest.test_small.json
+++ b/test/module00a/Module00aBatchTest.test_small.json
@@ -75,7 +75,7 @@
 
   "Module00aBatchTest.Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatchTest.Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module00aBatchTest.Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatchTest.Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",
   "Module00aBatchTest.Module00aBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00b/Module00b.test_large.json
+++ b/test/module00b/Module00b.test_large.json
@@ -1,7 +1,7 @@
 {
   "Module00b.run_vcf_qc" : "true",
   "Module00b.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module00b.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00b.wgd_scoring_mask": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/wgd_scoring_mask.hg38.gnomad_v3.bed",
   "Module00b.genome_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.genome",

--- a/test/module00b/Module00b.test_small.json
+++ b/test/module00b/Module00b.test_small.json
@@ -1,7 +1,7 @@
 {
   "Module00b.run_vcf_qc" : "true",
   "Module00b.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module00b.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00b.wgd_scoring_mask": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/wgd_scoring_mask.hg38.gnomad_v3.bed",
   "Module00b.genome_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.genome",

--- a/test/module00c/Module00c.test_large.json
+++ b/test/module00c/Module00c.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00c.test_small.json
+++ b/test/module00c/Module00c.test_small.json
@@ -1,6 +1,6 @@
 {
   "Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_baf_from_vcf.json
+++ b/test/module00c/Module00cTest.test_baf_from_vcf.json
@@ -440,7 +440,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_large.json
+++ b/test/module00c/Module00cTest.test_large.json
@@ -440,7 +440,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_small.json
+++ b/test/module00c/Module00cTest.test_small.json
@@ -60,7 +60,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module01/Module01.test_large.json
+++ b/test/module01/Module01.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
 
   "Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01.test_small.json
+++ b/test/module01/Module01.test_small.json
@@ -1,6 +1,6 @@
 {
   "Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
 
   "Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01Test.test_large.json
+++ b/test/module01/Module01Test.test_large.json
@@ -125,7 +125,7 @@
   "Module01Test.Module01Metrics.Module01Metrics.wham_metrics.mem_gib" : 3.75,
 
   "Module01Test.Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
 
   "Module01Test.Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01Test.Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01Test.test_small.json
+++ b/test/module01/Module01Test.test_small.json
@@ -25,7 +25,7 @@
   "Module01Test.Module01Metrics.baseline_melt_vcf" : "gs://gatk-sv-resources/test/module01/small/output/test_small.melt.vcf.gz",
 
   "Module01Test.Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
 
   "Module01Test.Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01Test.Module01.depth_flags": "--merge-coordinates",

--- a/test/module02/Module02.test_large.json
+++ b/test/module02/Module02.test_large.json
@@ -1,5 +1,5 @@
 {
-  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module02/Module02.test_small.json
+++ b/test/module02/Module02.test_small.json
@@ -1,5 +1,5 @@
 {
-  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module02/Module02Test.test_large.json
+++ b/test/module02/Module02Test.test_large.json
@@ -114,7 +114,7 @@
   "Module02Test.Module02Metrics.linux_docker" : "ubuntu:18.04",
   "Module02Test.Module02Metrics.contig_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list",
 
-  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module02Test.Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02Test.Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02Test.Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module02/Module02Test.test_small.json
+++ b/test/module02/Module02Test.test_small.json
@@ -19,7 +19,7 @@
   "Module02Test.Module02Metrics.linux_docker" : "ubuntu:18.04",
   "Module02Test.Module02Metrics.contig_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list",
 
-  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module02Test.Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02Test.Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02Test.Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module03/Module03.test_large.json
+++ b/test/module03/Module03.test_large.json
@@ -1,5 +1,5 @@
 {
-  "Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module03.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module03.linux_docker" : "ubuntu:18.04",
 

--- a/test/module03/Module03Qc.test_large.json
+++ b/test/module03/Module03Qc.test_large.json
@@ -25,7 +25,7 @@
   "Module03Qc.werling_2018_tarball": "gs://gatk-sv-resources-secure/resources/Werling_2018_hg38.tar.gz",
 
   
-  "Module03Qc.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module03Qc.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module03Qc.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module03Qc.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
 

--- a/test/module03/Module03Test.test_large.json
+++ b/test/module03/Module03Test.test_large.json
@@ -120,7 +120,7 @@
   "Module03Test.Module03Metrics.Module03Metrics.PESR_VCF_Metrics.mem_gib" : "3.75",
   "Module03Test.Module03Metrics.Module03Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
 
-  "Module03Test.Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module03Test.Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module03Test.Module03.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module03Test.Module03.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04/MergeCohortVcfs.test.json
+++ b/test/module04/MergeCohortVcfs.test.json
@@ -1,5 +1,5 @@
 {
-  "MergeCohortVcfs.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "MergeCohortVcfs.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "MergeCohortVcfs.pesr_vcfs": ["gs://gatk-sv-resources/test/module03/large/output/test_large.filtered_pesr_merged.vcf.gz"],
   "MergeCohortVcfs.depth_vcfs": ["gs://gatk-sv-resources/test/module03/large/output/test_large.depth.outliers_removed.vcf.gz"]
 }

--- a/test/module04/Module04.test_large.json
+++ b/test/module04/Module04.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module04.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module04.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04/Module04Test.test_large.json
+++ b/test/module04/Module04Test.test_large.json
@@ -121,7 +121,7 @@
   "Module04Test.Module04Metrics.Module04Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
 
   "Module04Test.Module04.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module04Test.Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module04Test.Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module04Test.Module04.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04Test.Module04.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04b/Module04b.test.json
+++ b/test/module04b/Module04b.test.json
@@ -2,7 +2,7 @@
   "Module04b.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04b.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "Module04b.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module04b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module04b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module04b.n_RdTest_bins": "100000",
   "Module04b.n_per_split": "5000",
 

--- a/test/module05_06/Module05_06.test_large.json
+++ b/test/module05_06/Module05_06.test_large.json
@@ -38,7 +38,7 @@
   "Module05_06.max_shards_per_chrom": 100,
   "Module05_06.min_variants_per_shard": 30,
 
-  "Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module05_06.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module05_06.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module05_06.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",

--- a/test/module05_06/Module05_06Test.test_large.json
+++ b/test/module05_06/Module05_06Test.test_large.json
@@ -159,7 +159,7 @@
   "Module05_06Test.Module05_06.max_shards_per_chrom": 100,
   "Module05_06Test.Module05_06.min_variants_per_shard": 30,
 
-  "Module05_06Test.Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "Module05_06Test.Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "Module05_06Test.Module05_06.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module05_06Test.Module05_06.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module05_06Test.Module05_06.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",

--- a/test/module07/Module07.test.json
+++ b/test/module07/Module07.test.json
@@ -14,5 +14,5 @@
   "Module07.prefix" :       "Talkowski_SV_PCR-free_WGS_144",
 
   "Module07.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module07.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations"
+  "Module07.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be"
 }

--- a/test/module07/Module07Preprocessing.wdl.example.json
+++ b/test/module07/Module07Preprocessing.wdl.example.json
@@ -7,6 +7,6 @@
   "Module07Preprocessing.promoter_window": 1000, 
 
   "Module07Preprocessing.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module07Preprocessing.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations"
+  "Module07Preprocessing.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be"
 }
 

--- a/test/module07/PrepareGencode.wdl.example.json
+++ b/test/module07/PrepareGencode.wdl.example.json
@@ -7,6 +7,6 @@
   "PrepareGencode.promoter_window": 1000, 
 
   "PrepareGencode.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "PrepareGencode.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations"
+  "PrepareGencode.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be"
 }
 

--- a/test/mosaic/Mosaics.json
+++ b/test/mosaic/Mosaics.json
@@ -3,7 +3,7 @@
   "MosaicManualCheck.outlier": "gs://gatk-sv-resources/resources/outlier.txt",
   "MosaicManualCheck.famfile": "gs://gatk-sv-resources/test/module03/large/output/test_large.outlier_samples_removed.fam",
   "MosaicManualCheck.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
-  "MosaicManualCheck.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "MosaicManualCheck.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "MosaicManualCheck.agg_metrics": ["gs://gatk-sv-resources/test/module02/large/output/test_large.metrics"],
   "MosaicManualCheck.per_batch_clustered_pesr_vcf_list": ["gs://gatk-sv-resources/test/mosaic/pesr_list.txt"],
   "MosaicManualCheck.clustered_depth_vcfs": ["gs://gatk-sv-resources/test/module01/large/output/test_large.depth.vcf.gz"],

--- a/test/phase1/GATKSVPipelinePhase1.test_large.json
+++ b/test/phase1/GATKSVPipelinePhase1.test_large.json
@@ -2,7 +2,7 @@
   "GATKSVPipelinePhase1.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "GATKSVPipelinePhase1.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelinePhase1.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
-  "GATKSVPipelinePhase1.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "GATKSVPipelinePhase1.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "GATKSVPipelinePhase1.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelinePhase1.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelinePhase1.linux_docker" : "ubuntu:18.04",

--- a/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
+++ b/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
@@ -137,7 +137,7 @@
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_3c9d26c_single_sample_annotations",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",


### PR DESCRIPTION
This PR updates the representation of CTX reciprocal translocation events to a set of four linked BND records (two for the A -> B breakpoint and two for the B -> A breakpoint). This works on events that are encoded as PQ/QP or PP/QQ. 

The second coordinate of the breakpoint for these events is preserved in the END2 INFO tag in `svtk complex_sv`

I did not update the dockers in this PR because I think there are other pending updates with docker revisions and I didn't want to clobber them and was thinking that we might batch up a few of these PRs and do one docker build, but I can add a docker version upgrade if requested by whoever reviews this.