### PR TITLE
add batch-combine workflows for Terra before MergeCohortVcfs and 05/06

### DIFF
--- a/wdl/BatchCombinePre0506.wdl
+++ b/wdl/BatchCombinePre0506.wdl
@@ -11,30 +11,27 @@ workflow BatchCombinePre0506 {
   }
   Array[String] columns = ["trained_genotype_depth_depth_sepcutoff", "regenotyped_depth_vcfs", "merged_bincov", "merged_PE","median_cov", "ped_file_postOutlierExclusion", "genotyped_pesr_vcf", "sr_background_fail", "sr_bothside_pass", "cutoffs"]
 
-  scatter (column in columns) {
-    call select.SelectBatchesAndColumns {
-      input:
-        sample_sets_table_tsv = sample_sets_table_tsv,
-        column = column,
-        batches_opt = batches,
-        linux_docker = linux_docker,
-        runtime_attr_override = runtime_override_batchcombine
-    }
+  call select.SelectBatchesAndColumns {
+    input:
+      sample_sets_table_tsv = sample_sets_table_tsv,
+      columns = columns,
+      batches_opt = batches,
+      linux_docker = linux_docker,
+      runtime_attr_override = runtime_override_batchcombine
   }
-  
 
   output {
     Array[String]? batches_combined_pre_0506 = batches
-    Array[File] trained_genotype_depth_depth_sepcutoff = SelectBatchesAndColumns.column_as_row[0]
-    Array[File] regenotyped_depth_vcfs = SelectBatchesAndColumns.column_as_row[1]
-    Array[File] merged_bincov = SelectBatchesAndColumns.column_as_row[2]
-    Array[File] merged_PE = SelectBatchesAndColumns.column_as_row[3]
-    Array[File] median_cov = SelectBatchesAndColumns.column_as_row[4]
-    Array[File] ped_file_postOutlierExclusion = SelectBatchesAndColumns.column_as_row[5]
-    Array[File] genotyped_pesr_vcf = SelectBatchesAndColumns.column_as_row[6]
-    Array[File] sr_background_fail = SelectBatchesAndColumns.column_as_row[7]
-    Array[File] sr_bothside_pass = SelectBatchesAndColumns.column_as_row[8]
-    Array[File] cutoffs = SelectBatchesAndColumns.column_as_row[9]
+    Array[File] trained_genotype_depth_depth_sepcutoff = SelectBatchesAndColumns.columns_as_rows[0]
+    Array[File] regenotyped_depth_vcfs = SelectBatchesAndColumns.columns_as_rows[1]
+    Array[File] merged_bincov = SelectBatchesAndColumns.columns_as_rows[2]
+    Array[File] merged_PE = SelectBatchesAndColumns.columns_as_rows[3]
+    Array[File] median_cov = SelectBatchesAndColumns.columns_as_rows[4]
+    Array[File] ped_file_postOutlierExclusion = SelectBatchesAndColumns.columns_as_rows[5]
+    Array[File] genotyped_pesr_vcf = SelectBatchesAndColumns.columns_as_rows[6]
+    Array[File] sr_background_fail = SelectBatchesAndColumns.columns_as_rows[7]
+    Array[File] sr_bothside_pass = SelectBatchesAndColumns.columns_as_rows[8]
+    Array[File] cutoffs = SelectBatchesAndColumns.columns_as_rows[9]
   }
   
 }

--- a/wdl/BatchCombinePre0506.wdl
+++ b/wdl/BatchCombinePre0506.wdl
@@ -6,7 +6,7 @@ workflow BatchCombinePre0506 {
   input {
     File sample_sets_table_tsv
     Array[String]? batches
-    String? linux_docker
+    String? python_docker
     RuntimeAttr? runtime_override_batchcombine
   }
   Array[String] columns = ["trained_genotype_depth_depth_sepcutoff", "regenotyped_depth_vcfs", "merged_bincov", "merged_PE","median_cov", "ped_file_postOutlierExclusion", "genotyped_pesr_vcf", "sr_background_fail", "sr_bothside_pass", "cutoffs"]
@@ -16,7 +16,7 @@ workflow BatchCombinePre0506 {
       sample_sets_table_tsv = sample_sets_table_tsv,
       columns = columns,
       batches_opt = batches,
-      linux_docker = linux_docker,
+      python_docker = python_docker,
       runtime_attr_override = runtime_override_batchcombine
   }
 

--- a/wdl/BatchCombinePre0506.wdl
+++ b/wdl/BatchCombinePre0506.wdl
@@ -3,36 +3,38 @@ version 1.0
 import "SelectBatchesAndColumns.wdl" as select
 
 workflow BatchCombinePre0506 {
-	input {
-		File sample_sets_table_tsv
-		Array[String]? batches
-		String? docker
-	}
-	Array[String] columns=["trained_genotype_depth_depth_sepcutoff","regenotyped_depth_vcfs", "merged_bincov", "merged_PE","median_cov","ped_file_postOutlierExclusion", "genotyped_pesr_vcf", "sr_background_fail","sr_bothside_pass","cutoffs"]
+  input {
+    File sample_sets_table_tsv
+    Array[String]? batches
+    String? linux_docker
+    RuntimeAttr? runtime_override_batchcombine
+  }
+  Array[String] columns = ["trained_genotype_depth_depth_sepcutoff", "regenotyped_depth_vcfs", "merged_bincov", "merged_PE","median_cov", "ped_file_postOutlierExclusion", "genotyped_pesr_vcf", "sr_background_fail", "sr_bothside_pass", "cutoffs"]
 
-	scatter (column in columns) {
-		call select.SelectBatchesAndColumns as SelectBatchesAndColumns {
-			input:
-				sample_sets_table_tsv=sample_sets_table_tsv,
-				column=column,
-				batches_opt=batches,
-				docker=docker
-		}
-	}
-	
+  scatter (column in columns) {
+    call select.SelectBatchesAndColumns {
+      input:
+        sample_sets_table_tsv = sample_sets_table_tsv,
+        column = column,
+        batches_opt = batches,
+        linux_docker = linux_docker,
+        runtime_attr_override = runtime_override_batchcombine
+    }
+  }
+  
 
-	output {
-		Array[String]? batches_combined_pre_0506 = batches
-		Array[File] trained_genotype_depth_depth_sepcutoff=SelectBatchesAndColumns.column_as_row[0]
-		Array[File] regenotyped_depth_vcfs=SelectBatchesAndColumns.column_as_row[1]
-		Array[File] merged_bincov=SelectBatchesAndColumns.column_as_row[2]
-		Array[File] merged_PE=SelectBatchesAndColumns.column_as_row[3]
-		Array[File] median_cov=SelectBatchesAndColumns.column_as_row[4]
-		Array[File] ped_file_postOutlierExclusion=SelectBatchesAndColumns.column_as_row[5]
-		Array[File] genotyped_pesr_vcf=SelectBatchesAndColumns.column_as_row[6]
-		Array[File] sr_background_fail=SelectBatchesAndColumns.column_as_row[7]
-		Array[File] sr_bothside_pass=SelectBatchesAndColumns.column_as_row[8]
-		Array[File] cutoffs=SelectBatchesAndColumns.column_as_row[9]
-	}
-	
+  output {
+    Array[String]? batches_combined_pre_0506 = batches
+    Array[File] trained_genotype_depth_depth_sepcutoff = SelectBatchesAndColumns.column_as_row[0]
+    Array[File] regenotyped_depth_vcfs = SelectBatchesAndColumns.column_as_row[1]
+    Array[File] merged_bincov = SelectBatchesAndColumns.column_as_row[2]
+    Array[File] merged_PE = SelectBatchesAndColumns.column_as_row[3]
+    Array[File] median_cov = SelectBatchesAndColumns.column_as_row[4]
+    Array[File] ped_file_postOutlierExclusion = SelectBatchesAndColumns.column_as_row[5]
+    Array[File] genotyped_pesr_vcf = SelectBatchesAndColumns.column_as_row[6]
+    Array[File] sr_background_fail = SelectBatchesAndColumns.column_as_row[7]
+    Array[File] sr_bothside_pass = SelectBatchesAndColumns.column_as_row[8]
+    Array[File] cutoffs = SelectBatchesAndColumns.column_as_row[9]
+  }
+  
 }

--- a/wdl/BatchCombinePre0506.wdl
+++ b/wdl/BatchCombinePre0506.wdl
@@ -1,0 +1,38 @@
+version 1.0
+
+import "SelectBatchesAndColumns.wdl" as select
+
+workflow BatchCombinePre0506 {
+	input {
+		File sample_sets_table_tsv
+		Array[String]? batches
+		String? docker
+	}
+	Array[String] columns=["trained_genotype_depth_depth_sepcutoff","regenotyped_depth_vcfs", "merged_bincov", "merged_PE","median_cov","ped_file_postOutlierExclusion", "genotyped_pesr_vcf", "sr_background_fail","sr_bothside_pass","cutoffs"]
+
+	scatter (column in columns) {
+		call select.SelectBatchesAndColumns as SelectBatchesAndColumns {
+			input:
+				sample_sets_table_tsv=sample_sets_table_tsv,
+				column=column,
+				batches_opt=batches,
+				docker=docker
+		}
+	}
+	
+
+	output {
+		Array[String]? batches_combined_pre_0506 = batches
+		Array[File] trained_genotype_depth_depth_sepcutoff=SelectBatchesAndColumns.column_as_row[0]
+		Array[File] regenotyped_depth_vcfs=SelectBatchesAndColumns.column_as_row[1]
+		Array[File] merged_bincov=SelectBatchesAndColumns.column_as_row[2]
+		Array[File] merged_PE=SelectBatchesAndColumns.column_as_row[3]
+		Array[File] median_cov=SelectBatchesAndColumns.column_as_row[4]
+		Array[File] ped_file_postOutlierExclusion=SelectBatchesAndColumns.column_as_row[5]
+		Array[File] genotyped_pesr_vcf=SelectBatchesAndColumns.column_as_row[6]
+		Array[File] sr_background_fail=SelectBatchesAndColumns.column_as_row[7]
+		Array[File] sr_bothside_pass=SelectBatchesAndColumns.column_as_row[8]
+		Array[File] cutoffs=SelectBatchesAndColumns.column_as_row[9]
+	}
+	
+}

--- a/wdl/BatchCombinePreMerge.wdl
+++ b/wdl/BatchCombinePreMerge.wdl
@@ -3,30 +3,32 @@ version 1.0
 import "SelectBatchesAndColumns.wdl" as select
 
 workflow BatchCombinePreMerge {
-	input {
-		File sample_sets_table_tsv
-		Array[String]? batches
-		String? docker
-	}
-	Array[String] columns=["filtered_depth_vcf","filtered_pesr_vcf"]
-	
-	scatter (column in columns) {
-		call select.SelectBatchesAndColumns as SelectBatchesAndColumns {
-			input:
-				sample_sets_table_tsv=sample_sets_table_tsv,
-				column=column,
-				batches_opt=batches,
-				docker=docker
-		}
-	}
-	
+  input {
+    File sample_sets_table_tsv
+    Array[String]? batches
+    String? linux_docker
+    RuntimeAttr? runtime_override_batchcombine
+  }
+  Array[String] columns = ["filtered_depth_vcf", "filtered_pesr_vcf"]
+  
+  scatter (column in columns) {
+    call select.SelectBatchesAndColumns {
+      input:
+        sample_sets_table_tsv = sample_sets_table_tsv,
+        column = column,
+        batches_opt = batches,
+        linux_docker = linux_docker,
+        runtime_attr_override = runtime_override_batchcombine
+    }
+  }
+  
 
-	output {
-		Array[File] filtered_depth_vcf=SelectBatchesAndColumns.column_as_row[0]
-		Array[File] filtered_pesr_vcf=SelectBatchesAndColumns.column_as_row[1]
-		Array[String]? batches_combined_pre_merge = batches
-	}
-	
+  output {
+    Array[File] filtered_depth_vcf = SelectBatchesAndColumns.column_as_row[0]
+    Array[File] filtered_pesr_vcf = SelectBatchesAndColumns.column_as_row[1]
+    Array[String]? batches_combined_pre_merge = batches
+  }
+  
 }
 
 

--- a/wdl/BatchCombinePreMerge.wdl
+++ b/wdl/BatchCombinePreMerge.wdl
@@ -6,7 +6,7 @@ workflow BatchCombinePreMerge {
   input {
     File sample_sets_table_tsv
     Array[String]? batches
-    String? linux_docker
+    String? python_docker
     RuntimeAttr? runtime_override_batchcombine
   }
   Array[String] columns = ["filtered_depth_vcf", "filtered_pesr_vcf"]
@@ -16,7 +16,7 @@ workflow BatchCombinePreMerge {
       sample_sets_table_tsv = sample_sets_table_tsv,
       columns = columns,
       batches_opt = batches,
-      linux_docker = linux_docker,
+      python_docker = python_docker,
       runtime_attr_override = runtime_override_batchcombine
   }
 

--- a/wdl/BatchCombinePreMerge.wdl
+++ b/wdl/BatchCombinePreMerge.wdl
@@ -11,21 +11,18 @@ workflow BatchCombinePreMerge {
   }
   Array[String] columns = ["filtered_depth_vcf", "filtered_pesr_vcf"]
   
-  scatter (column in columns) {
-    call select.SelectBatchesAndColumns {
-      input:
-        sample_sets_table_tsv = sample_sets_table_tsv,
-        column = column,
-        batches_opt = batches,
-        linux_docker = linux_docker,
-        runtime_attr_override = runtime_override_batchcombine
-    }
+  call select.SelectBatchesAndColumns {
+    input:
+      sample_sets_table_tsv = sample_sets_table_tsv,
+      columns = columns,
+      batches_opt = batches,
+      linux_docker = linux_docker,
+      runtime_attr_override = runtime_override_batchcombine
   }
-  
 
   output {
-    Array[File] filtered_depth_vcf = SelectBatchesAndColumns.column_as_row[0]
-    Array[File] filtered_pesr_vcf = SelectBatchesAndColumns.column_as_row[1]
+    Array[File] filtered_depth_vcf = SelectBatchesAndColumns.columns_as_rows[0]
+    Array[File] filtered_pesr_vcf = SelectBatchesAndColumns.columns_as_rows[1]
     Array[String]? batches_combined_pre_merge = batches
   }
   

--- a/wdl/BatchCombinePreMerge.wdl
+++ b/wdl/BatchCombinePreMerge.wdl
@@ -1,0 +1,32 @@
+version 1.0
+
+import "SelectBatchesAndColumns.wdl" as select
+
+workflow BatchCombinePreMerge {
+	input {
+		File sample_sets_table_tsv
+		Array[String]? batches
+		String? docker
+	}
+	Array[String] columns=["filtered_depth_vcf","filtered_pesr_vcf"]
+	
+	scatter (column in columns) {
+		call select.SelectBatchesAndColumns as SelectBatchesAndColumns {
+			input:
+				sample_sets_table_tsv=sample_sets_table_tsv,
+				column=column,
+				batches_opt=batches,
+				docker=docker
+		}
+	}
+	
+
+	output {
+		Array[File] filtered_depth_vcf=SelectBatchesAndColumns.column_as_row[0]
+		Array[File] filtered_pesr_vcf=SelectBatchesAndColumns.column_as_row[1]
+		Array[String]? batches_combined_pre_merge = batches
+	}
+	
+}
+
+

--- a/wdl/SelectBatchesAndColumns.wdl
+++ b/wdl/SelectBatchesAndColumns.wdl
@@ -1,16 +1,18 @@
 version 1.0
 
+import "Structs.wdl"
+
 task SelectBatchesAndColumns {
   input {
     File sample_sets_table_tsv
     Array[String]? batches_opt
     Array[String] columns
-    String? linux_docker
+    String? python_docker
     RuntimeAttr? runtime_attr_override
   }
   
   Boolean select_batches = defined(batches_opt)
-  Array[String] batches = select_first([batches_opt, ["all"]])
+  Array[String] batches = select_first([batches_opt, ["EMPTY_LIST_PLACEHOLDER"]])
 
   RuntimeAttr default_attr = object {
     cpu_cores: 1, 
@@ -26,43 +28,67 @@ task SelectBatchesAndColumns {
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
     disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
-    docker: select_first([linux_docker, "ubuntu:18.04"])
+    docker: select_first([python_docker, "python:3.7-slim"])
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }
 
   command <<<
     set -euo pipefail
-    1>&2 echo "Selecting data from sample sets table"
-    FILE=~{sample_sets_table_tsv}
+    python3 <<CODE
+    import sys
+    columns = ["~{sep='\",\"' columns}"]
+    batches_lst = ["~{sep='\",\"' batches}"]
+    all_batches = False
+    if len(batches_lst) == 1 and batches_lst[0] == "EMPTY_LIST_PLACEHOLDER":
+      all_batches = True
+    batches = {batch: 0 for batch in batches_lst}
 
-    for COLNAME in '~{sep="' '" columns}'; do
-      1>&2 echo "COLUMN NAME=$COLNAME"
+    with open("~{sample_sets_table_tsv}", 'r') as table:
+      # output format: one tab-separated line of files (one per selected column, in order) per selected batch
+      # this can be transposed to the format WDL can interpret as an Array[Array[File]]
+      # note: assumes one file per column per batch. Array[File] outputs from Module04b should only contain one item because 04b is run per batch in Terra
+      with open("selected.tsv", 'w') as out:
+        header = None
+        for entry in table:
+          if header is None:
+            # check input file format
+            if not entry.startswith("entity:sample_set_id\t"):
+              sys.exit("Malformed file: sample_sets_table_tsv should be a tab-separated sample sets table downloaded from Terra, starting with entity:sample_set_id.")
+            # get columns dictionary from header line
+            header = {colname:colnum for colnum,colname in enumerate(entry.strip().split('\t'))}
+          else:
+            line = entry.lstrip().split('\t')
+            # select desired batches
+            batch = line[header["entity:sample_set_id"]]
+            if all_batches or batch in batches:
+              if not all_batches:
+                batches[batch] += 1
+              output_line = ""
+              # select desired columns
+              for column in columns:
+                if output_line != "":
+                  output_line += '\t'
+                # if column does not exist, enter DNE string - because some files are optional inputs/outputs so not ok to exit
+                # but need to fill the spot so indices of outputs will not be disrupted 
+                # (this is why simple list comprehension + tab-join was not used to generate output_line)
+                if column not in header:
+                  output_line += "COLUMN_DNE"
+                  continue
+                # get entry from this batch for each desired column, remove brackets if an array of files, and save
+                file = line[header[column]].lstrip('["').rstrip('"]')
+                output_line += file
+              out.write(output_line + '\n')
 
-      COLNUM=$(head -1 $FILE | awk -v RS='\t' -v field="$COLNAME" '$0~field{print NR; exit}')
-      if [ ! -z "$COLNUM"]
-      then
-        1>&2 echo "COLUMN NUMBER=$COLNUM"
-
-        # if batches specified, select rows containing given batches in 1st column then select specified column
-        # otherwise, select specified column from all rows
-        # delete quotes and brackets from any bracketed, comma-separated arrays and split by tabs
-        # each column should become one tab-separated row
-        for BATCH in '~{sep="' '" batches}'; do
-          1>&2 echo "BATCH=$BATCH"
-          ~{if select_batches then "awk -v FS='\t' -v bat=$BATCH '$1 == bat' $FILE" else "cat $FILE"} \
-            | cut -f $COLNUM | tr -d []'"' | tr , '\t' >> selected.tsv
-          echo '\n' >> selected.tsv 
-        done
-      else
-        echo '\n' >> selected.tsv # if column does not exist, insert empty line into file
-      fi
-    done
-    
+    # raise exception if batch not found
+    for batch in batches_lst:
+      if not all_batches and batches[batch] == 0:
+        sys.exit("Batch " + batch + " not found in sample sets table.")
+    CODE
   >>>
 
   output {
     # return transposed tsv such that each row is all the files for a given column of the sample set table
-    Array[Array[File]] columns_as_rows = read_tsv("selected.tsv")
+    Array[Array[File]] columns_as_rows = transpose(read_tsv("selected.tsv"))
   }
 }

--- a/wdl/SelectBatchesAndColumns.wdl
+++ b/wdl/SelectBatchesAndColumns.wdl
@@ -1,46 +1,60 @@
 version 1.0
 
 task SelectBatchesAndColumns {
-	input {
-		File sample_sets_table_tsv
-		Array[String]? batches_opt
-		String column
-		String? docker
-	}
-	
-	Boolean select_batches=defined(batches_opt)
-	Array[String] batches=select_first([batches_opt, ["all"]])
+  input {
+    File sample_sets_table_tsv
+    Array[String]? batches_opt
+    String column
+    String? linux_docker
+    RuntimeAttr? runtime_attr_override
+  }
+  
+  Boolean select_batches = defined(batches_opt)
+  Array[String] batches = select_first([batches_opt, ["all"]])
 
-	String docker_set = select_first([docker, "ubuntu:18.04"])
+  RuntimeAttr default_attr = object {
+    cpu_cores: 1, 
+    mem_gb: 0.9,
+    disk_gb: 10,
+    boot_disk_gb: 10,
+    preemptible_tries: 3,
+    max_retries: 1
+  }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: select_first([linux_docker, "ubuntu:18.04"])
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
+  }
 
-	runtime {
-		docker: docker_set
-	}
+  command <<<
+    set -euo pipefail
+    1>&2 echo "Selecting columns from sample sets table"
+    FILE=~{sample_sets_table_tsv}
 
-	command <<<
-		set -euo pipefail
-		1>&2 echo "Selecting columns from sample sets table"
-		FILE=~{sample_sets_table_tsv}
+    COLNAME=~{column}
+    1>&2 echo "COLUMN NAME=$COLNAME"
 
-		COLNAME=~{column}
-		1>&2 echo "COLUMN NAME=$COLNAME"
+    COLNUM=$(head -1 $FILE | awk -v RS='\t' -v field="$COLNAME" '$0~field{print NR; exit}')
+    1>&2 echo "COLUMN NUMBER=$COLNUM"
 
-		COLNUM=$(head -1 $FILE | awk -v RS='\t' -v field="$COLNAME" '$0~field{print NR; exit}')
-		1>&2 echo "COLUMN NUMBER=$COLNUM"
+    # if batches specified, select rows containing given batches in 1st column then select specified column
+    # otherwise, select specified column from all rows
+    # delete quotes and brackets from any bracketed, comma-separated arrays and split by newlines
+    for BATCH in '~{sep="' '" batches}'; do
+      1>&2 echo "BATCH=$BATCH"
+      ~{if select_batches then "1>&2 echo 'Selecting batches from sample sets table'; awk -v FS='\t' -v bat=$BATCH '$1 == bat' $FILE" else "cat $FILE"} \
+        | cut -f $COLNUM | tr -d []'"' | tr , '\n' >> ~{column}_selected.tsv
+    done
+    
+  >>>
 
-		# if batches specified, select rows containing given batches in 1st column then select specified column
-		# otherwise, select specified column from all rows
-		# delete quotes and brackets from any bracketed, comma-separated arrays and split by newlines
-		for BATCH in '~{sep="' '" batches}'; do
-			1>&2 echo "BATCH=$BATCH"
-			~{if select_batches then "1>&2 echo 'Selecting batches from sample sets table'; awk -v FS='\t' -v bat=$BATCH '$1 == bat' $FILE" else "cat $FILE"} \
-				| cut -f $COLNUM | tr -d []'"' | tr , '\n' >> ~{column}_selected.tsv
-		done
-		
-	>>>
-
-	output {
-		# return transposed tsv such that each row is all the files for a given column of the sample set table
-		Array[File] column_as_row = transpose(read_tsv("~{column}_selected.tsv"))[0]
-	}
+  output {
+    # return transposed tsv such that each row is all the files for a given column of the sample set table
+    Array[File] column_as_row = transpose(read_tsv("~{column}_selected.tsv"))[0]
+  }
 }

--- a/wdl/SelectBatchesAndColumns.wdl
+++ b/wdl/SelectBatchesAndColumns.wdl
@@ -1,0 +1,46 @@
+version 1.0
+
+task SelectBatchesAndColumns {
+	input {
+		File sample_sets_table_tsv
+		Array[String]? batches_opt
+		String column
+		String? docker
+	}
+	
+	Boolean select_batches=defined(batches_opt)
+	Array[String] batches=select_first([batches_opt, ["all"]])
+
+	String docker_set = select_first([docker, "ubuntu:18.04"])
+
+	runtime {
+		docker: docker_set
+	}
+
+	command <<<
+		set -euo pipefail
+		1>&2 echo "Selecting columns from sample sets table"
+		FILE=~{sample_sets_table_tsv}
+
+		COLNAME=~{column}
+		1>&2 echo "COLUMN NAME=$COLNAME"
+
+		COLNUM=$(head -1 $FILE | awk -v RS='\t' -v field="$COLNAME" '$0~field{print NR; exit}')
+		1>&2 echo "COLUMN NUMBER=$COLNUM"
+
+		# if batches specified, select rows containing given batches in 1st column then select specified column
+		# otherwise, select specified column from all rows
+		# delete quotes and brackets from any bracketed, comma-separated arrays and split by newlines
+		for BATCH in '~{sep="' '" batches}'; do
+			1>&2 echo "BATCH=$BATCH"
+			~{if select_batches then "1>&2 echo 'Selecting batches from sample sets table'; awk -v FS='\t' -v bat=$BATCH '$1 == bat' $FILE" else "cat $FILE"} \
+				| cut -f $COLNUM | tr -d []'"' | tr , '\n' >> ~{column}_selected.tsv
+		done
+		
+	>>>
+
+	output {
+		# return transposed tsv such that each row is all the files for a given column of the sample set table
+		Array[File] column_as_row = transpose(read_tsv("~{column}_selected.tsv"))[0]
+	}
+}


### PR DESCRIPTION
WDLs for workaround to create cohort-level sample set in Terra with the necessary aggregated files from individual batches. Ideally this would be done with a sample superset/set of sample sets data entity type, but such an entity type does not exist in Terra. It also currently seems to not be possible to upload arrays of files in a sample sets TSV, which limited the approach to the workaround. 

These workflows are designed to fit into the pipeline as follows:

1. Run up through Module03 on samples/sets as appropriate
2. Download the sample sets table as a TSV and upload it to Google Cloud
3. Run BatchCombinePreMerge.wdl with the sample sets TSV URI as input (and the batches to combine, if not all) on a new cohort-level sample set 
4. Run MergeCohortVcfs.wdl and output to Workspace Data
5. Run Modules 04 and 04b on each batch
6. Download the updated sample sets TSV and upload it to Google Cloud
7. Run BatchCombinePre0506.wdl on the existing cohort-level sample set, with the new sample sets TSV URI 
8. Run Modules 05_06 and 07 on the cohort-level sample set

Both BatchCombine workflows use the SelectBatchesAndColumns task, which parses the sample sets TSV to select one column at a time for the specified batches (or all batches if none specified).

Code temporarily hosted on a personal repo (https://github.com/epiercehoffman/gatk-sv-terra-eph) in order to perform testing in the following Terra workspaces (slack DM to be added):
* https://app.terra.bio/#workspaces/fccredits-barium-pear-9593/mod00a%20copy/data
* https://app.terra.bio/#workspaces/fccredits-barium-pear-9593/gatk-sv-pipeline%20copy/data