### PR TITLE
Annotate single sample output with gnomAD allele frequencies and add BED output

### DIFF
--- a/inputs/GATKSVPipelineBatch.ref_panel_1kg.json
+++ b/inputs/GATKSVPipelineBatch.ref_panel_1kg.json
@@ -782,7 +782,7 @@
   "GATKSVPipelineBatch.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineBatch.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "GATKSVPipelineBatch.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineBatch.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",

--- a/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
+++ b/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
@@ -33,7 +33,7 @@
   "GATKSVPipelineSingleSample.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",

--- a/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
+++ b/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
@@ -92,6 +92,10 @@
   "GATKSVPipelineSingleSample.linc_rna_gtf" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gencode.lincRNA.gtf.gz",
   "GATKSVPipelineSingleSample.promoter_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/promoter.bed",
   "GATKSVPipelineSingleSample.noncoding_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed",
+  "GATKSVPipelineSingleSample.external_af_ref_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gnomad_AF/gnomad_v2.1_sv.sites.GRCh38.bed.gz",
+  "GATKSVPipelineSingleSample.external_af_ref_bed_prefix" :       "gnomad_v2.1_sv",
+  "GATKSVPipelineSingleSample.external_af_population" :      ["ALL", "AFR", "AMR", "EAS", "EUR"],
+
   "GATKSVPipelineSingleSample.annotation_sv_per_shard" : "5000",
 
   "GATKSVPipelineSingleSample.cnmops_mem_gb_override_sample3": 24,

--- a/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json
+++ b/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json
@@ -34,7 +34,7 @@
   "GATKSVPipelineSingleSample.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",

--- a/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json
+++ b/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json
@@ -92,6 +92,10 @@
   "GATKSVPipelineSingleSample.linc_rna_gtf" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gencode.lincRNA.gtf.gz",
   "GATKSVPipelineSingleSample.promoter_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/promoter.bed",
   "GATKSVPipelineSingleSample.noncoding_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed",
+  "GATKSVPipelineSingleSample.external_af_ref_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gnomad_AF/gnomad_v2.1_sv.sites.GRCh38.bed.gz",
+  "GATKSVPipelineSingleSample.external_af_ref_bed_prefix" :       "gnomad_v2.1_sv",
+  "GATKSVPipelineSingleSample.external_af_population" :      ["ALL", "AFR", "AMR", "EAS", "EUR"],
+
   "GATKSVPipelineSingleSample.annotation_sv_per_shard" : "5000",
 
   "GATKSVPipelineSingleSample.cnmops_mem_gb_override_sample3": 24,

--- a/src/sv-pipeline/05_annotation/scripts/R1.bedtools_closest_CNV.R
+++ b/src/sv-pipeline/05_annotation/scripts/R1.bedtools_closest_CNV.R
@@ -106,7 +106,23 @@ add_SV_Size<-function(chs){
   return(chs)
 	}
 
+pop=read.table(pop_file)
+pop_colname = paste(pop[,1],'AF',sep='_')
+pop_colname[pop_colname=='ALL_AF']='AF'
+
+out_columns <- c('name','name.1',pop_colname,'Reciprocal_Overlap')
+
 dat=read.table(input_bed,sep='\t', header=T)
+# if there's no data write an empty table and exit
+if (nrow(dat) == 0) {
+	out_columns[c(1,2)]=c('query_svid','ref_svid')
+	out2 <- data.frame(matrix(ncol = length(out_columns), nrow = 0))
+	names(out2) <- out_columns
+	write.table(out2, output_bed, quote=F, sep='\t', col.names=T, row.names=F)
+	quit()
+}
+
+
 dat[,ncol(dat)+1] = apply(dat,1,function(x){return(max(c(as.integer(x[2]), as.integer(x[8]))))})
 dat[,ncol(dat)+1] = apply(dat,1,function(x){return(min(c(as.integer(x[3]), as.integer(x[9]))))})
 dat[,ncol(dat)+1] = dat[,ncol(dat)]-dat[,ncol(dat)-1]
@@ -128,11 +144,7 @@ out=out[order(out[,2]),]
 out=out[order(out[,1]),]
 colnames(out)[ncol(out)]='Reciprocal_Overlap'
 
-pop=read.table(pop_file)
-pop_colname = paste(pop[,1],'AF',sep='_')
-pop_colname[pop_colname=='ALL_AF']='AF'
-
-out2 = out[,c('name','name.1',pop_colname,'Reciprocal_Overlap')]
+out2 = out[,out_columns]
 colnames(out2)[c(1,2)]=c('query_svid','ref_svid')
 out2=out2[out2$Reciprocal_Overlap>.5,]
 write.table(out2, output_bed, quote=F, sep='\t', col.names=T, row.names=F)

--- a/src/sv-pipeline/05_annotation/scripts/R2.bedtools_closest_INS.R
+++ b/src/sv-pipeline/05_annotation/scripts/R2.bedtools_closest_INS.R
@@ -106,7 +106,22 @@ add_SV_Size<-function(chs){
   return(chs)
 	}
 
+pop=read.table(pop_file)
+pop_colname = paste(pop[,1],'AF',sep='_')
+pop_colname[pop_colname=='ALL_AF']='AF'
+
+out_columns <- c('name','name.1',pop_colname,'INS_dis','INS_ratio')
+
 dat=read.table(input_bed,sep='\t', header=T)
+# if there's no data write an empty table and exit
+if (nrow(dat) == 0) {
+	out_columns[c(1,2)]=c('query_svid','ref_svid')
+	out2 <- data.frame(matrix(ncol = length(out_columns), nrow = 0))
+	names(out2) <- out_columns
+	write.table(out2, output_bed, quote=F, sep='\t', col.names=T, row.names=F)
+	quit()
+}
+
 dat[,ncol(dat)+1] =abs(dat[,8]-dat[,2])
 colnames(dat)[ncol(dat)]='INS_dis'
 dat[,ncol(dat)+1] = dat[,13]/dat[,6]
@@ -127,11 +142,7 @@ out=out[order(out[,3]),]
 out=out[order(out[,2]),]
 out=out[order(out[,1]),]
 
-pop=read.table(pop_file)
-pop_colname = paste(pop[,1],'AF',sep='_')
-pop_colname[pop_colname=='ALL_AF']='AF'
-
-out2 = out[,c('name','name.1',pop_colname,'INS_dis','INS_ratio')]
+out2 = out[,out_columns]
 colnames(out2)[c(1,2)]=c('query_svid','ref_svid')
 
 out2=out2[out2$INS_dis<100 & out2$INS_ratio<10 & out2$INS_ratio>.1,]

--- a/test/batch/GATKSVPipelineBatch.test_large.json
+++ b/test/batch/GATKSVPipelineBatch.test_large.json
@@ -350,7 +350,7 @@
   "GATKSVPipelineBatch.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineBatch.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "GATKSVPipelineBatch.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineBatch.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00a/Module00aBatch.test_large.json
+++ b/test/module00a/Module00aBatch.test_large.json
@@ -18,7 +18,7 @@
 
   "Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module00aBatch.delly_docker": "gatksv/delly:8645aa",
   "Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",

--- a/test/module00a/Module00aBatch.test_small.json
+++ b/test/module00a/Module00aBatch.test_small.json
@@ -18,7 +18,7 @@
 
   "Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",
   "Module00aBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00a/Module00aBatchTest.test_large.json
+++ b/test/module00a/Module00aBatchTest.test_large.json
@@ -454,7 +454,7 @@
 
   "Module00aBatchTest.Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatchTest.Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module00aBatchTest.Module00aBatch.delly_docker": "gatksv/delly:8645aa",
   "Module00aBatchTest.Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatchTest.Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",

--- a/test/module00a/Module00aBatchTest.test_small.json
+++ b/test/module00a/Module00aBatchTest.test_small.json
@@ -75,7 +75,7 @@
 
   "Module00aBatchTest.Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatchTest.Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module00aBatchTest.Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatchTest.Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",
   "Module00aBatchTest.Module00aBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00b/Module00b.test_large.json
+++ b/test/module00b/Module00b.test_large.json
@@ -1,7 +1,7 @@
 {
   "Module00b.run_vcf_qc" : "true",
   "Module00b.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module00b.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00b.wgd_scoring_mask": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/wgd_scoring_mask.hg38.gnomad_v3.bed",
   "Module00b.genome_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.genome",

--- a/test/module00b/Module00b.test_small.json
+++ b/test/module00b/Module00b.test_small.json
@@ -1,7 +1,7 @@
 {
   "Module00b.run_vcf_qc" : "true",
   "Module00b.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module00b.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00b.wgd_scoring_mask": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/wgd_scoring_mask.hg38.gnomad_v3.bed",
   "Module00b.genome_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.genome",

--- a/test/module00c/Module00c.test_large.json
+++ b/test/module00c/Module00c.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00c.test_small.json
+++ b/test/module00c/Module00c.test_small.json
@@ -1,6 +1,6 @@
 {
   "Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_baf_from_vcf.json
+++ b/test/module00c/Module00cTest.test_baf_from_vcf.json
@@ -440,7 +440,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_large.json
+++ b/test/module00c/Module00cTest.test_large.json
@@ -440,7 +440,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_small.json
+++ b/test/module00c/Module00cTest.test_small.json
@@ -60,7 +60,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module01/Module01.test_large.json
+++ b/test/module01/Module01.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
 
   "Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01.test_small.json
+++ b/test/module01/Module01.test_small.json
@@ -1,6 +1,6 @@
 {
   "Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
 
   "Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01Test.test_large.json
+++ b/test/module01/Module01Test.test_large.json
@@ -125,7 +125,7 @@
   "Module01Test.Module01Metrics.Module01Metrics.wham_metrics.mem_gib" : 3.75,
 
   "Module01Test.Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
 
   "Module01Test.Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01Test.Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01Test.test_small.json
+++ b/test/module01/Module01Test.test_small.json
@@ -25,7 +25,7 @@
   "Module01Test.Module01Metrics.baseline_melt_vcf" : "gs://gatk-sv-resources/test/module01/small/output/test_small.melt.vcf.gz",
 
   "Module01Test.Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
 
   "Module01Test.Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01Test.Module01.depth_flags": "--merge-coordinates",

--- a/test/module02/Module02.test_large.json
+++ b/test/module02/Module02.test_large.json
@@ -1,5 +1,5 @@
 {
-  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module02/Module02.test_small.json
+++ b/test/module02/Module02.test_small.json
@@ -1,5 +1,5 @@
 {
-  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module02/Module02Test.test_large.json
+++ b/test/module02/Module02Test.test_large.json
@@ -114,7 +114,7 @@
   "Module02Test.Module02Metrics.linux_docker" : "ubuntu:18.04",
   "Module02Test.Module02Metrics.contig_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list",
 
-  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module02Test.Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02Test.Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02Test.Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module02/Module02Test.test_small.json
+++ b/test/module02/Module02Test.test_small.json
@@ -19,7 +19,7 @@
   "Module02Test.Module02Metrics.linux_docker" : "ubuntu:18.04",
   "Module02Test.Module02Metrics.contig_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list",
 
-  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module02Test.Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02Test.Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02Test.Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module03/Module03.test_large.json
+++ b/test/module03/Module03.test_large.json
@@ -1,5 +1,5 @@
 {
-  "Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module03.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module03.linux_docker" : "ubuntu:18.04",
 

--- a/test/module03/Module03Qc.test_large.json
+++ b/test/module03/Module03Qc.test_large.json
@@ -25,7 +25,7 @@
   "Module03Qc.werling_2018_tarball": "gs://gatk-sv-resources-secure/resources/Werling_2018_hg38.tar.gz",
 
   
-  "Module03Qc.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module03Qc.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module03Qc.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module03Qc.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
 

--- a/test/module03/Module03Test.test_large.json
+++ b/test/module03/Module03Test.test_large.json
@@ -120,7 +120,7 @@
   "Module03Test.Module03Metrics.Module03Metrics.PESR_VCF_Metrics.mem_gib" : "3.75",
   "Module03Test.Module03Metrics.Module03Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
 
-  "Module03Test.Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module03Test.Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module03Test.Module03.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module03Test.Module03.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04/MergeCohortVcfs.test.json
+++ b/test/module04/MergeCohortVcfs.test.json
@@ -1,5 +1,5 @@
 {
-  "MergeCohortVcfs.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "MergeCohortVcfs.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "MergeCohortVcfs.pesr_vcfs": ["gs://gatk-sv-resources/test/module03/large/output/test_large.filtered_pesr_merged.vcf.gz"],
   "MergeCohortVcfs.depth_vcfs": ["gs://gatk-sv-resources/test/module03/large/output/test_large.depth.outliers_removed.vcf.gz"]
 }

--- a/test/module04/Module04.test_large.json
+++ b/test/module04/Module04.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module04.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module04.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04/Module04Test.test_large.json
+++ b/test/module04/Module04Test.test_large.json
@@ -121,7 +121,7 @@
   "Module04Test.Module04Metrics.Module04Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
 
   "Module04Test.Module04.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module04Test.Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module04Test.Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module04Test.Module04.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04Test.Module04.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04b/Module04b.test.json
+++ b/test/module04b/Module04b.test.json
@@ -2,7 +2,7 @@
   "Module04b.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04b.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "Module04b.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module04b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module04b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module04b.n_RdTest_bins": "100000",
   "Module04b.n_per_split": "5000",
 

--- a/test/module05_06/Module05_06.test_large.json
+++ b/test/module05_06/Module05_06.test_large.json
@@ -38,7 +38,7 @@
   "Module05_06.max_shards_per_chrom": 100,
   "Module05_06.min_variants_per_shard": 30,
 
-  "Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module05_06.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module05_06.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module05_06.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",

--- a/test/module05_06/Module05_06Test.test_large.json
+++ b/test/module05_06/Module05_06Test.test_large.json
@@ -159,7 +159,7 @@
   "Module05_06Test.Module05_06.max_shards_per_chrom": 100,
   "Module05_06Test.Module05_06.min_variants_per_shard": 30,
 
-  "Module05_06Test.Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "Module05_06Test.Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "Module05_06Test.Module05_06.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module05_06Test.Module05_06.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module05_06Test.Module05_06.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",

--- a/test/module07/Module07.test.json
+++ b/test/module07/Module07.test.json
@@ -18,5 +18,5 @@
   "Module07.prefix" :       "Talkowski_SV_PCR-free_WGS_144",
 
   "Module07.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module07.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be"
+  "Module07.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e"
 }

--- a/test/module07/Module07.test.json
+++ b/test/module07/Module07.test.json
@@ -6,6 +6,10 @@
   "Module07.linc_rna_gtf" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gencode.lincRNA.gtf.gz",
   "Module07.promoter_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/promoter.bed",
   "Module07.noncoding_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed",
+  "Module07.ref_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gnomad_AF/gnomad_v2.1_sv.sites.GRCh38.bed.gz",
+  "Module07.ref_prefix" :       "gnomad_v2.1_sv",
+  "Module07.population" :      ["ALL", "AFR", "AMR", "EAS", "EUR"],
+
 
   "Module07.contig_list" :  "gs://fc-fae972fb-9dbf-41c7-926f-f419a767a1ab/chromosomes_nochrY.fai",
   "Module07.ped_file":      "gs://fc-fae972fb-9dbf-41c7-926f-f419a767a1ab/FINAL_full_prenatal_dosage_sex.ped",

--- a/test/module07/Module07Preprocessing.wdl.example.json
+++ b/test/module07/Module07Preprocessing.wdl.example.json
@@ -7,6 +7,6 @@
   "Module07Preprocessing.promoter_window": 1000, 
 
   "Module07Preprocessing.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module07Preprocessing.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be"
+  "Module07Preprocessing.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e"
 }
 

--- a/test/module07/PrepareGencode.wdl.example.json
+++ b/test/module07/PrepareGencode.wdl.example.json
@@ -7,6 +7,6 @@
   "PrepareGencode.promoter_window": 1000, 
 
   "PrepareGencode.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "PrepareGencode.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be"
+  "PrepareGencode.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e"
 }
 

--- a/test/mosaic/Mosaics.json
+++ b/test/mosaic/Mosaics.json
@@ -3,7 +3,7 @@
   "MosaicManualCheck.outlier": "gs://gatk-sv-resources/resources/outlier.txt",
   "MosaicManualCheck.famfile": "gs://gatk-sv-resources/test/module03/large/output/test_large.outlier_samples_removed.fam",
   "MosaicManualCheck.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
-  "MosaicManualCheck.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "MosaicManualCheck.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "MosaicManualCheck.agg_metrics": ["gs://gatk-sv-resources/test/module02/large/output/test_large.metrics"],
   "MosaicManualCheck.per_batch_clustered_pesr_vcf_list": ["gs://gatk-sv-resources/test/mosaic/pesr_list.txt"],
   "MosaicManualCheck.clustered_depth_vcfs": ["gs://gatk-sv-resources/test/module01/large/output/test_large.depth.vcf.gz"],

--- a/test/phase1/GATKSVPipelinePhase1.test_large.json
+++ b/test/phase1/GATKSVPipelinePhase1.test_large.json
@@ -2,7 +2,7 @@
   "GATKSVPipelinePhase1.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "GATKSVPipelinePhase1.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelinePhase1.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
-  "GATKSVPipelinePhase1.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "GATKSVPipelinePhase1.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "GATKSVPipelinePhase1.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelinePhase1.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelinePhase1.linux_docker" : "ubuntu:18.04",

--- a/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
+++ b/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
@@ -197,6 +197,10 @@
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.linc_rna_gtf" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gencode.lincRNA.gtf.gz",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.promoter_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/promoter.bed",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.noncoding_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/noncoding.sort.hg38.bed",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.external_af_ref_bed" :       "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/gnomad_AF/gnomad_v2.1_sv.sites.GRCh38.bed.gz",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.external_af_ref_bed_prefix" :       "gnomad_v2.1_sv",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.external_af_population" :      ["ALL", "AFR", "AMR", "EAS", "EUR"],
+
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.annotation_sv_per_shard" : "5000",
 
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.ref_std_manta_vcfs" : [

--- a/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
+++ b/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
@@ -137,7 +137,7 @@
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_ctx_rep_eccc9be",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",

--- a/wdl/AnnotateExternalAF.wdl
+++ b/wdl/AnnotateExternalAF.wdl
@@ -19,8 +19,6 @@ workflow AnnotateExternalAF {
         String sv_pipeline_docker
 
         # overrides for local tasks
-        RuntimeAttr? runtime_override_plot_qc_vcf_wide
-        RuntimeAttr? runtime_override_thousand_g_benchmark
         RuntimeAttr? runtime_attr_modify_vcf
     }
     call SplitBed as split_ref_bed{
@@ -139,7 +137,7 @@ workflow AnnotateExternalAF {
     }
 
     output{
-        File annotate_vcf = ModifyVcf.annotated_vcf
+        File annotated_vcf = ModifyVcf.annotated_vcf
         File annotated_vcf_tbi = ModifyVcf.annotated_vcf_tbi
     }
 

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -941,6 +941,13 @@ workflow GATKSVPipelineSingleSample {
         sv_pipeline_docker = sv_pipeline_docker
   }
 
+  call SingleSampleFiltering.VcfToBed as VcfToBed {
+    input:
+      vcf = Module07.output_vcf,
+      prefix = batch,
+      sv_pipeline_docker = sv_pipeline_docker
+  }
+
   call SingleSampleFiltering.FinalVCFCleanup as FinalVCFCleanup {
     input:
       single_sample_vcf=Module07.output_vcf,
@@ -980,6 +987,8 @@ workflow GATKSVPipelineSingleSample {
   output {
     File final_vcf = FinalVCFCleanup.out
     File final_vcf_idx = FinalVCFCleanup.out_idx
+
+    File final_bed = VcfToBed.bed
 
     # These files contain events reported in the internal VCF representation
     # They are less VCF-spec compliant but may be useful if components of the pipeline need to be re-run

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -372,6 +372,10 @@ workflow GATKSVPipelineSingleSample {
     File noncoding_bed
     Int annotation_sv_per_shard
 
+    File? external_af_ref_bed             # bed file with population AFs for annotation
+    String? external_af_ref_bed_prefix    # name of external AF bed file call set
+    Array[String]? external_af_population # populations to annotate external AFs (required if ref_bed set, use "ALL" for all)
+
     ############################################################
     ## Single sample filtering
     ############################################################
@@ -929,6 +933,9 @@ workflow GATKSVPipelineSingleSample {
         linc_rna_gtf = linc_rna_gtf,
         promoter_bed = promoter_bed,
         noncoding_bed = noncoding_bed,
+        ref_bed = external_af_ref_bed,
+        ref_prefix = external_af_ref_bed_prefix,
+        population = external_af_population,
         sv_per_shard = annotation_sv_per_shard,
         sv_base_mini_docker = sv_base_mini_docker,
         sv_pipeline_docker = sv_pipeline_docker

--- a/wdl/SingleSampleFiltering.wdl
+++ b/wdl/SingleSampleFiltering.wdl
@@ -602,3 +602,40 @@ task ConvertCNVsWithoutDepthSupportToBNDs {
 
 }
 
+task VcfToBed {
+  input {
+    File vcf
+    String prefix
+    String sv_pipeline_docker
+    RuntimeAttr? runtime_attr_override
+  }
+
+  RuntimeAttr default_attr = object {
+    cpu_cores: 1,
+    mem_gb: 3.75,
+    disk_gb: 10,
+    boot_disk_gb: 10,
+    preemptible_tries: 3,
+    max_retries: 1
+  }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+  output {
+    File bed = "${prefix}.bed"
+  }
+  command <<<
+
+    svtk vcf2bed ~{vcf} ~{prefix}.bed -i ALL --include-filters
+
+  >>>
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: sv_pipeline_docker
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
+  }
+}
+


### PR DESCRIPTION
This PR enables annotation of the single sample pipeline's output with gnomAD allele frequencies.

It modifies`module07.wdl` to optionally annotate the vcf with allele frequencies from an external resource if the right parameters are supplied. 

In addition, a version of the single sample pipeline's output is supplied in BED format in addition to VCF.