### PR TITLE
Fix quotes for filter descriptions in VCF header

### DIFF
--- a/src/sv-pipeline/scripts/downstream_analysis_and_filtering/label_batch_effects.py
+++ b/src/sv-pipeline/scripts/downstream_analysis_and_filtering/label_batch_effects.py
@@ -73,14 +73,14 @@ def main():
     NEW_FILTERS = ['##FILTER=<ID=PCRPLUS_ENRICHED,Description="Site enriched for ' + 
                    'non-reference genotypes among PCR+ samples. Likely reflects ' + 
                    'technical batch effects. All PCR- samples have been assigned ' +
-                   'null GTs for these sites.>"',
+                   'null GTs for these sites.">',
                    '##FILTER=<ID=VARIABLE_ACROSS_BATCHES,Description="Site appears ' + 
                    'at variable frequencies across batches. Likely reflects technical ' + 
-                   'batch effects.>',
+                   'batch effects.">',
                    '##FILTER=<ID=UNSTABLE_AF_PCRMINUS,Description="Allele frequency ' + 
                    'for this variant in PCR- samples is sensitive to choice of GQ ' +
                    'filtering thresholds. All PCR- samples have been assigned null ' + 
-                   'GTs for these sites.>']
+                   'GTs for these sites.">']
 
     header = vcf.header
     for filt in NEW_FILTERS:


### PR DESCRIPTION
Noticed this in the [gnomAD SV VCF](https://storage.googleapis.com/gnomad-public/papers/2019-sv/gnomad_v2.1_sv.sites.vcf.gz).

Omitting the closing `"` for the filter description leads to `>` being included in the description field in the VCF header.

For example, the gnomAD SV VCF has these two lines in the header:

> ##FILTER=<ID=PCRPLUS_ENRICHED,Description="Site enriched for non-reference genotypes among PCR+ samples. Likely reflects technical batch effects. All PCR- samples have been assigned null GTs for these sites.>">

> ##FILTER=<ID=UNSTABLE_AF_PCRMINUS,Description="Allele frequency for this variant in PCR- samples is sensitive to choice of GQ filtering thresholds. All PCR- samples have been assigned null GTs for these sites.>">
