### PR TITLE
Single sample pipeline bug fixes

### DIFF
--- a/inputs/GATKSVPipelineBatch.ref_panel_1kg.json
+++ b/inputs/GATKSVPipelineBatch.ref_panel_1kg.json
@@ -782,7 +782,7 @@
   "GATKSVPipelineBatch.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineBatch.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "GATKSVPipelineBatch.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineBatch.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",

--- a/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
+++ b/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
@@ -33,7 +33,7 @@
   "GATKSVPipelineSingleSample.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",

--- a/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json
+++ b/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json
@@ -34,7 +34,7 @@
   "GATKSVPipelineSingleSample.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineSingleSample.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",

--- a/src/sv-pipeline/scripts/vcf_qc/clean_vcf2bed_output.R
+++ b/src/sv-pipeline/scripts/vcf_qc/clean_vcf2bed_output.R
@@ -77,7 +77,11 @@ if(is.null(nsamp)){
 dat$observations <- sapply(dat$samples,function(samples){
   length(unique(unlist(strsplit(as.character(samples),split=","))))
 })
-dat$carrierFreq <- dat$observations/nsamp
+if (nrow(dat) > 0) {
+  dat$carrierFreq <- dat$observations/nsamp
+} else {
+  dat$carrierFreq <- numeric()
+}
 if(any(dat$frequency > 1)){
   stop("Incorrect number of samples supplied; some carrier frequencies > 1")
 }

--- a/src/sv-pipeline/scripts/vcf_qc/collectQC.vcf_wide.sh
+++ b/src/sv-pipeline/scripts/vcf_qc/collectQC.vcf_wide.sh
@@ -209,11 +209,11 @@ sort -Vk1,1 -k2,2n -k3,3n >> \
 ${QCTMP}/vcf2bed_cleaned.bed
 #Run Rscript to clean VCF stats
 ${BIN}/clean_vcf2bed_output.R \
--N ${nsamp} \
-${QCTMP}/vcf2bed_cleaned.bed \
-${QCTMP}/genotype_counts_per_SV.txt \
-${SVTYPES} \
-${QCTMP}/vcf2bed_cleaned.simple.bed
+  -N ${nsamp} \
+  ${QCTMP}/vcf2bed_cleaned.bed \
+  ${QCTMP}/genotype_counts_per_SV.txt \
+  ${SVTYPES} \
+  ${QCTMP}/vcf2bed_cleaned.simple.bed
 #Reformat cleaned VCF stats
 head -n1 ${QCTMP}/vcf2bed_cleaned.simple.bed | awk '{ print "#"$0 }' > \
 ${QCTMP}/vcf2bed_cleaned.simple.bed2

--- a/test/batch/GATKSVPipelineBatch.test_large.json
+++ b/test/batch/GATKSVPipelineBatch.test_large.json
@@ -350,7 +350,7 @@
   "GATKSVPipelineBatch.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineBatch.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "GATKSVPipelineBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "GATKSVPipelineBatch.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineBatch.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00a/Module00aBatch.test_large.json
+++ b/test/module00a/Module00aBatch.test_large.json
@@ -18,7 +18,7 @@
 
   "Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module00aBatch.delly_docker": "gatksv/delly:8645aa",
   "Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",

--- a/test/module00a/Module00aBatch.test_small.json
+++ b/test/module00a/Module00aBatch.test_small.json
@@ -18,7 +18,7 @@
 
   "Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",
   "Module00aBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00a/Module00aBatchTest.test_large.json
+++ b/test/module00a/Module00aBatchTest.test_large.json
@@ -454,7 +454,7 @@
 
   "Module00aBatchTest.Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatchTest.Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module00aBatchTest.Module00aBatch.delly_docker": "gatksv/delly:8645aa",
   "Module00aBatchTest.Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatchTest.Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",

--- a/test/module00a/Module00aBatchTest.test_small.json
+++ b/test/module00a/Module00aBatchTest.test_small.json
@@ -75,7 +75,7 @@
 
   "Module00aBatchTest.Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatchTest.Module00aBatch.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module00aBatchTest.Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatchTest.Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",
   "Module00aBatchTest.Module00aBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00b/Module00b.test_large.json
+++ b/test/module00b/Module00b.test_large.json
@@ -1,7 +1,7 @@
 {
   "Module00b.run_vcf_qc" : "true",
   "Module00b.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module00b.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00b.wgd_scoring_mask": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/wgd_scoring_mask.hg38.gnomad_v3.bed",
   "Module00b.genome_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.genome",

--- a/test/module00b/Module00b.test_small.json
+++ b/test/module00b/Module00b.test_small.json
@@ -1,7 +1,7 @@
 {
   "Module00b.run_vcf_qc" : "true",
   "Module00b.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module00b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module00b.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00b.wgd_scoring_mask": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/wgd_scoring_mask.hg38.gnomad_v3.bed",
   "Module00b.genome_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.genome",

--- a/test/module00c/Module00c.test_large.json
+++ b/test/module00c/Module00c.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00c.test_small.json
+++ b/test/module00c/Module00c.test_small.json
@@ -1,6 +1,6 @@
 {
   "Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_baf_from_vcf.json
+++ b/test/module00c/Module00cTest.test_baf_from_vcf.json
@@ -440,7 +440,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_large.json
+++ b/test/module00c/Module00cTest.test_large.json
@@ -440,7 +440,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_small.json
+++ b/test/module00c/Module00cTest.test_small.json
@@ -60,7 +60,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module00cTest.Module00c.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module01/Module01.test_large.json
+++ b/test/module01/Module01.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
 
   "Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01.test_small.json
+++ b/test/module01/Module01.test_small.json
@@ -1,6 +1,6 @@
 {
   "Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
 
   "Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01Test.test_large.json
+++ b/test/module01/Module01Test.test_large.json
@@ -125,7 +125,7 @@
   "Module01Test.Module01Metrics.Module01Metrics.wham_metrics.mem_gib" : 3.75,
 
   "Module01Test.Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
 
   "Module01Test.Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01Test.Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01Test.test_small.json
+++ b/test/module01/Module01Test.test_small.json
@@ -25,7 +25,7 @@
   "Module01Test.Module01Metrics.baseline_melt_vcf" : "gs://gatk-sv-resources/test/module01/small/output/test_small.melt.vcf.gz",
 
   "Module01Test.Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
 
   "Module01Test.Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01Test.Module01.depth_flags": "--merge-coordinates",

--- a/test/module02/Module02.test_large.json
+++ b/test/module02/Module02.test_large.json
@@ -1,5 +1,5 @@
 {
-  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module02/Module02.test_small.json
+++ b/test/module02/Module02.test_small.json
@@ -1,5 +1,5 @@
 {
-  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module02/Module02Test.test_large.json
+++ b/test/module02/Module02Test.test_large.json
@@ -114,7 +114,7 @@
   "Module02Test.Module02Metrics.linux_docker" : "ubuntu:18.04",
   "Module02Test.Module02Metrics.contig_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list",
 
-  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module02Test.Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02Test.Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02Test.Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module02/Module02Test.test_small.json
+++ b/test/module02/Module02Test.test_small.json
@@ -19,7 +19,7 @@
   "Module02Test.Module02Metrics.linux_docker" : "ubuntu:18.04",
   "Module02Test.Module02Metrics.contig_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list",
 
-  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module02Test.Module02.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module02Test.Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02Test.Module02.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module02Test.Module02.sv_base_docker": "gatksv/sv-base:b3af2e3",

--- a/test/module03/Module03.test_large.json
+++ b/test/module03/Module03.test_large.json
@@ -1,5 +1,5 @@
 {
-  "Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module03.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module03.linux_docker" : "ubuntu:18.04",
 

--- a/test/module03/Module03Qc.test_large.json
+++ b/test/module03/Module03Qc.test_large.json
@@ -25,7 +25,7 @@
   "Module03Qc.werling_2018_tarball": "gs://gatk-sv-resources-secure/resources/Werling_2018_hg38.tar.gz",
 
   
-  "Module03Qc.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module03Qc.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module03Qc.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module03Qc.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
 

--- a/test/module03/Module03Test.test_large.json
+++ b/test/module03/Module03Test.test_large.json
@@ -120,7 +120,7 @@
   "Module03Test.Module03Metrics.Module03Metrics.PESR_VCF_Metrics.mem_gib" : "3.75",
   "Module03Test.Module03Metrics.Module03Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
 
-  "Module03Test.Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module03Test.Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module03Test.Module03.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module03Test.Module03.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04/MergeCohortVcfs.test.json
+++ b/test/module04/MergeCohortVcfs.test.json
@@ -1,5 +1,5 @@
 {
-  "MergeCohortVcfs.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "MergeCohortVcfs.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "MergeCohortVcfs.pesr_vcfs": ["gs://gatk-sv-resources/test/module03/large/output/test_large.filtered_pesr_merged.vcf.gz"],
   "MergeCohortVcfs.depth_vcfs": ["gs://gatk-sv-resources/test/module03/large/output/test_large.depth.outliers_removed.vcf.gz"]
 }

--- a/test/module04/Module04.test_large.json
+++ b/test/module04/Module04.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module04.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module04.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04/Module04Test.test_large.json
+++ b/test/module04/Module04Test.test_large.json
@@ -121,7 +121,7 @@
   "Module04Test.Module04Metrics.Module04Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
 
   "Module04Test.Module04.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module04Test.Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module04Test.Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module04Test.Module04.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04Test.Module04.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04b/Module04b.test.json
+++ b/test/module04b/Module04b.test.json
@@ -2,7 +2,7 @@
   "Module04b.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04b.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "Module04b.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module04b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module04b.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module04b.n_RdTest_bins": "100000",
   "Module04b.n_per_split": "5000",
 

--- a/test/module05_06/Module05_06.test_large.json
+++ b/test/module05_06/Module05_06.test_large.json
@@ -38,7 +38,7 @@
   "Module05_06.max_shards_per_chrom": 100,
   "Module05_06.min_variants_per_shard": 30,
 
-  "Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module05_06.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module05_06.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module05_06.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",

--- a/test/module05_06/Module05_06Test.test_large.json
+++ b/test/module05_06/Module05_06Test.test_large.json
@@ -159,7 +159,7 @@
   "Module05_06Test.Module05_06.max_shards_per_chrom": 100,
   "Module05_06Test.Module05_06.min_variants_per_shard": 30,
 
-  "Module05_06Test.Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "Module05_06Test.Module05_06.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module05_06Test.Module05_06.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module05_06Test.Module05_06.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module05_06Test.Module05_06.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",

--- a/test/module07/Module07.test.json
+++ b/test/module07/Module07.test.json
@@ -18,5 +18,5 @@
   "Module07.prefix" :       "Talkowski_SV_PCR-free_WGS_144",
 
   "Module07.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module07.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e"
+  "Module07.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d"
 }

--- a/test/module07/Module07Preprocessing.wdl.example.json
+++ b/test/module07/Module07Preprocessing.wdl.example.json
@@ -7,6 +7,6 @@
   "Module07Preprocessing.promoter_window": 1000, 
 
   "Module07Preprocessing.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "Module07Preprocessing.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e"
+  "Module07Preprocessing.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d"
 }
 

--- a/test/module07/PrepareGencode.wdl.example.json
+++ b/test/module07/PrepareGencode.wdl.example.json
@@ -7,6 +7,6 @@
   "PrepareGencode.promoter_window": 1000, 
 
   "PrepareGencode.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "PrepareGencode.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e"
+  "PrepareGencode.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d"
 }
 

--- a/test/mosaic/Mosaics.json
+++ b/test/mosaic/Mosaics.json
@@ -3,7 +3,7 @@
   "MosaicManualCheck.outlier": "gs://gatk-sv-resources/resources/outlier.txt",
   "MosaicManualCheck.famfile": "gs://gatk-sv-resources/test/module03/large/output/test_large.outlier_samples_removed.fam",
   "MosaicManualCheck.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
-  "MosaicManualCheck.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "MosaicManualCheck.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "MosaicManualCheck.agg_metrics": ["gs://gatk-sv-resources/test/module02/large/output/test_large.metrics"],
   "MosaicManualCheck.per_batch_clustered_pesr_vcf_list": ["gs://gatk-sv-resources/test/mosaic/pesr_list.txt"],
   "MosaicManualCheck.clustered_depth_vcfs": ["gs://gatk-sv-resources/test/module01/large/output/test_large.depth.vcf.gz"],

--- a/test/phase1/GATKSVPipelinePhase1.test_large.json
+++ b/test/phase1/GATKSVPipelinePhase1.test_large.json
@@ -2,7 +2,7 @@
   "GATKSVPipelinePhase1.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "GATKSVPipelinePhase1.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelinePhase1.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
-  "GATKSVPipelinePhase1.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "GATKSVPipelinePhase1.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "GATKSVPipelinePhase1.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelinePhase1.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelinePhase1.linux_docker" : "ubuntu:18.04",

--- a/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
+++ b/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
@@ -137,7 +137,7 @@
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_base_docker": "gatksv/sv-base:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
-  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_external_af_annotation_565a1e",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",

--- a/wdl/CollectCoverage.wdl
+++ b/wdl/CollectCoverage.wdl
@@ -51,6 +51,7 @@ task CollectCounts {
     gatk --java-options "-Xmx~{command_mem_mb}m" CollectReadCounts \
       -L ~{intervals} \
       --input ~{bam} \
+      --read-index ~{bam_idx} \
       --reference ~{ref_fasta} \
       --format TSV \
       --interval-merging-rule OVERLAPPING_ONLY \

--- a/wdl/Tasks02.wdl
+++ b/wdl/Tasks02.wdl
@@ -40,6 +40,10 @@ task SplitVCF {
     mkdir splits
     tabix ~{vcf} ~{chrom} | split -a ~{suffix_len} -d -l ~{split_size} - splits/~{batch}.~{algorithm}.split.
 
+    if [ ! -f splits/~{batch}.~{algorithm}.split.`printf '%0~{suffix_len}d' 0` ]; then
+      touch splits/~{batch}.~{algorithm}.split.`printf '%0~{suffix_len}d' 0`
+    fi
+
     #Add headers to each split
     mkdir headered
     for split in splits/~{batch}.~{algorithm}.split.*; do


### PR DESCRIPTION
This fixes several bugs encountered by users of the single sample pipeline on different inputs that would result in the pipeline failing to complete with an error message:

* The `RunManta` task failed when run with a bam file input and an index file that did not conform to the naming scheme `$BAMNAME.bam.bai` https://github.com/broadinstitute/gatk-sv/issues/11
* The `CollectCoverage` task also failed to run when the index did not follow the expected naming convention. https://github.com/broadinstitute/gatk-sv/issues/48
* `PETest` and `SRTest` could fail if shards of the input VCF were empty (for example, if they had no calls on chrY). 
* Module0506 could fail in the `MasterVcfQc` workflow if shards of the VCF were empty (this was also encountered when samples were missing any calls on chrY.

