### PR TITLE
Analyze resource acquisition/quota usage from workflow metadata

### DIFF
--- a/scripts/cromwell/analyze_resource_acquisition.py
+++ b/scripts/cromwell/analyze_resource_acquisition.py
@@ -2,459 +2,488 @@
 
 import json
 import argparse
-import numpy as np
 import dateutil.parser
-from dateutil.tz import tzutc
 import datetime
-import time
 import pandas as pd
-import math
 import random
 import matplotlib.pyplot as plt
 import matplotlib.ticker
 import sys
 from os.path import basename, isfile, getsize
-SEED = 42
+import logging
 
 """
 Summary: Scrapes workflow metadata to analyze resource acquisition (VMs, CPU, RAM, disk memory), for the purpose
-	of understanding resource peaks and timing jobs to avoid hitting quotas.
+  of understanding resource peaks and timing jobs to avoid hitting quotas.
 
-Usage: 
-	python analyze_resource_acquisition workflow_metadata.json /path/to/output_basename [optional flags]
-	Optional flags:
-	--plot_title WorkflowName (WorkflowName will be prepended to plot title)
-	--save_table (to save a TSV file of the table used to create the plot)
-	--override_warning (to attempt to run script on workflow that raised a warning)
+Usage:
+  python analyze_resource_acquisition workflow_metadata.json /path/to/output_basename [optional flags]
+  Optional flags:
+  --plot-title WorkflowName (WorkflowName will be prepended to plot title)
+  --save-table (to save a TSV file of the table used to create the plot)
+  --override-warning (to attempt to run script on workflow that raised a warning)
+  --log-level LEVEL (specify level of logging information to print, ie. INFO, WARNING, ERROR - not case-sensitive)
 
 Parameters:
-	workflow_metadata.json: path to Cromwell metadata file for workflow of interest
-	/path/to/output_basename: base output path, to which extensions will be appended for each output file, 
-		ie. /output_dir/basename will yield /output_dir/basename.plot.png, /output_dir/basename.table.tsv, etc
-		or, /output_dir/ will yield plot.png, table.tsv, peaks.txt, etc
+  workflow_metadata.json: path to Cromwell metadata file for workflow of interest
+  /path/to/output_basename: base output path, to which extensions will be appended for each output file,
+    ie. /output_dir/basename will yield /output_dir/basename.plot.png, /output_dir/basename.table.tsv, etc
+    or, /output_dir/ will yield plot.png, table.tsv, peaks.txt, etc
 
 Outputs:
-	- plot (png) of VMs, CPUs (total, preemptible, and nonpreemptible), RAM, and disk (HDD, SSD) acquisitioned over time 
-	- (optional, with --save_table flag) table of resource acquisition over time for each type of resource listed above
-	- peak resource acquisition for each type of resource listed above (TSV file)
-	- number of non-preemptible VMs used (prints to stdout) and the names of the tasks that used them (TSV file, if any)
-	- number of tasks call-cached (prints to stdout), and their task names (TSV file, if any)
+  - plot (png) of VMs, CPUs (total, preemptible, and nonpreemptible), RAM, and disk (HDD, SSD) acquisitioned over time
+  - (optional, with --save-table flag) table of resource acquisition over time for each type of resource listed above
+  - peak resource acquisition for each type of resource listed above (TSV file)
+  - number of non-preemptible VMs used (prints to stdout) and the names of the tasks that used them (TSV file, if any)
+  - number of tasks call-cached (prints to stdout), and their task names (TSV file, if any)
 """
+
 NUM_CACHED = 0
 CACHED = dict()
 NUM_NONPREEMPTIBLE = 0
 NONPREEMBTIBLE_TASKS = dict()
 
-def get_disk_info(metadata):
-	"""
-	Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
-	Modified to return (hdd_size, ssd_size)
-	"""
-	if "runtimeAttributes" in metadata and "disks" in metadata['runtimeAttributes']:
-		bootDiskSizeGb = 0.0
-		if "bootDiskSizeGb" in metadata['runtimeAttributes']:
-			bootDiskSizeGb = float(metadata['runtimeAttributes']['bootDiskSizeGb'])
-		# Note - am lumping boot disk in with requested disk.  Assuming boot disk is same type as requested.
-		# i.e. is it possible that boot disk is HDD when requested is SDD.
-		(name, disk_size, disk_type) = metadata['runtimeAttributes']["disks"].split()
-		if disk_type == "HDD":
-			return float(disk_size), float(0)
-		elif disk_type == "SSD":
-			return float(0), float(disk_size)
-		else:
-			return float(0), float(0)
-	else:
-		# we can't tell disk size in this case so just return nothing
-		return float(0),float(0)
-		
-def was_preemptible_vm(metadata):
-	"""
-	Source: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
-	"""
-	if "runtimeAttributes" in metadata and "preemptible" in metadata['runtimeAttributes']:
-		pe_count = int(metadata['runtimeAttributes']["preemptible"])
-		attempt = int(metadata['attempt'])
 
-		return attempt <= pe_count
-	else:
-		# we can't tell (older metadata) so conservatively return false
-		return False
+def get_disk_info(metadata):
+  """
+  Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
+  Modified to return (hdd_size, ssd_size)
+  """
+  if "runtimeAttributes" in metadata and "disks" in metadata['runtimeAttributes']:
+    bootDiskSizeGb = 0.0
+    if "bootDiskSizeGb" in metadata['runtimeAttributes']:
+      bootDiskSizeGb = float(metadata['runtimeAttributes']['bootDiskSizeGb'])
+    # Note - am lumping boot disk in with requested disk.  Assuming boot disk is same type as requested.
+    # i.e. is it possible that boot disk is HDD when requested is SDD.
+    (name, disk_size, disk_type) = metadata['runtimeAttributes']["disks"].split()
+    if disk_type == "HDD":
+      return float(disk_size), float(0)
+    elif disk_type == "SSD":
+      return float(0), float(disk_size)
+    else:
+      return float(0), float(0)
+  else:
+    # we can't tell disk size in this case so just return nothing
+    return float(0), float(0)
+
+
+def was_preemptible_vm(metadata):
+  """
+  Source: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
+  """
+  if "runtimeAttributes" in metadata and "preemptible" in metadata['runtimeAttributes']:
+    pe_count = int(metadata['runtimeAttributes']["preemptible"])
+    attempt = int(metadata['attempt'])
+
+    return attempt <= pe_count
+  else:
+    # we can't tell (older metadata) so conservatively return false
+    return False
+
 
 def used_cached_results(metadata):
-	"""
-	Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
-	"""
-	return "callCaching" in metadata and "hit" in metadata["callCaching"] and metadata["callCaching"]["hit"]
+  """
+  Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
+  """
+  return "callCaching" in metadata and "hit" in metadata["callCaching"] and metadata["callCaching"]["hit"]
+
 
 def calculate_start_end(call_info):
-	"""
-	Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
-	"""
-	# get start (start time of VM start) & end time (end time of 'ok') according to metadata
-	start = None
-	end = None
+  """
+  Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
+  """
+  # get start (start time of VM start) & end time (end time of 'ok') according to metadata
+  start = None
+  end = None
 
-	if 'executionEvents' in call_info:
-		for x in call_info['executionEvents']:
-			# ignore incomplete executionEvents (could be due to server restart or similar)
-			if 'description' not in x:
-				continue
-			y = x['description']
+  if 'executionEvents' in call_info:
+    for x in call_info['executionEvents']:
+      # ignore incomplete executionEvents (could be due to server restart or similar)
+      if 'description' not in x:
+        continue
+      y = x['description']
 
-			if 'backend' in call_info and call_info['backend'] == 'PAPIv2':
-				if y.startswith("PreparingJob"):
-					start = dateutil.parser.parse(x['startTime'])
-				if y.startswith("Worker released"):
-					end = dateutil.parser.parse(x['endTime'])
-			else:
-				if y.startswith("start"):
-					start = dateutil.parser.parse(x['startTime'])
-				if y.startswith("ok"):
-					end = dateutil.parser.parse(x['endTime'])
+      if 'backend' in call_info and call_info['backend'] == 'PAPIv2':
+        if y.startswith("PreparingJob"):
+          start = dateutil.parser.parse(x['startTime'])
+        if y.startswith("Worker released"):
+          end = dateutil.parser.parse(x['endTime'])
+      else:
+        if y.startswith("start"):
+          start = dateutil.parser.parse(x['startTime'])
+        if y.startswith("ok"):
+          end = dateutil.parser.parse(x['endTime'])
 
-	# if we are preempted or if cromwell used previously cached results, we don't even get a start time from JES.
-	# if cromwell was restarted, the start time from JES might not have been written to the metadata.
-	# in either case, use the Cromwell start time which is earlier but not wrong.
-	if start is None:
-		start = dateutil.parser.parse(call_info['start'])
+  # if we are preempted or if cromwell used previously cached results, we don't even get a start time from JES.
+  # if cromwell was restarted, the start time from JES might not have been written to the metadata.
+  # in either case, use the Cromwell start time which is earlier but not wrong.
+  if start is None:
+    start = dateutil.parser.parse(call_info['start'])
 
-	# if we are preempted or if cromwell used previously cached results, we don't get an endtime from JES right now.
-	# if cromwell was restarted, the start time from JES might not have been written to the metadata.
-	# in either case, use the Cromwell end time which is later but not wrong
-	if end is None:
-		end = dateutil.parser.parse(call_info['end'])
+  # if we are preempted or if cromwell used previously cached results, we don't get an endtime from JES right now.
+  # if cromwell was restarted, the start time from JES might not have been written to the metadata.
+  # in either case, use the Cromwell end time which is later but not wrong
+  if end is None:
+    end = dateutil.parser.parse(call_info['end'])
 
-	return start, end
+  return start, end
+
 
 def get_mem_cpu(m):
-	"""
-	Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
-	"""
-	cpu = 'na'
-	memory = 'na'
-	if 'runtimeAttributes' in m:
-		if 'cpu' in m['runtimeAttributes']:
-			cpu = int(m['runtimeAttributes']['cpu'])
-		if 'memory' in m['runtimeAttributes']:
-			mem_str = m['runtimeAttributes']['memory']
-			memory = float(mem_str[:mem_str.index(" ")])
-	return cpu, memory
+  """
+  Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
+  """
+  cpu = 'na'
+  memory = 'na'
+  if 'runtimeAttributes' in m:
+    if 'cpu' in m['runtimeAttributes']:
+      cpu = int(m['runtimeAttributes']['cpu'])
+    if 'memory' in m['runtimeAttributes']:
+      mem_str = m['runtimeAttributes']['memory']
+      memory = float(mem_str[:mem_str.index(" ")])
+  return cpu, memory
+
+
+def add_label_to_alias(alias, labels):
+  # In alias, track hierarchy of workflow/task up to current task nicely without repetition
+  if alias is None:
+    alias = ""
+  to_add = ""
+  if 'wdl-call-alias' in labels:
+    to_add = labels['wdl-call-alias']
+  elif 'wdl-task-name' in labels:
+    to_add = labels['wdl-task-name']
+  if to_add != "" and not alias.endswith(to_add):
+    if alias != "" and alias[-1] != ".":
+      alias += "."
+    alias += to_add
+
+  return alias
+
+
+def get_call_alias(alias, call):
+  # In call_alias, track hierarchy of workflow/task up to current call nicely without repetition
+  if alias is None:
+    alias = ""
+  call_split = call.split('.')
+  call_name = call
+  if alias.endswith(call_split[0]):
+    call_name = call_split[1]
+  call_alias = alias
+  if call_alias != "" and call_alias[-1] != ".":
+    call_alias += "."
+  call_alias += call_name
+
+  return call_alias
+
+
+def update_nonpreemptible_counters(alias):
+  global NUM_NONPREEMPTIBLE
+  global NONPREEMBTIBLE_TASKS
+  NUM_NONPREEMPTIBLE += 1
+  if alias in NONPREEMBTIBLE_TASKS:
+    NONPREEMBTIBLE_TASKS[alias] += 1
+  else:
+    NONPREEMBTIBLE_TASKS[alias] = 1
+
+
+def update_cached_counters(alias):
+  global CACHED
+  global NUM_CACHED
+  NUM_CACHED += 1
+  if alias in CACHED:
+    CACHED[alias] += 1
+  else:
+    CACHED[alias] = 1
+
 
 def getCalls(m, alias=None):
-	"""
-	Modified from download_monitoring_logs.py script by Mark Walker
-	https://github.com/broadinstitute/gatk-sv/blob/master/scripts/cromwell/download_monitoring_logs.py
-	"""
-	if isinstance(m, list):
-		call_metadata = []
-		for m_shard in m:
-			call_metadata.extend(getCalls(m_shard, alias=alias))
-		return call_metadata
+  """
+  Modified from download_monitoring_logs.py script by Mark Walker
+  https://github.com/broadinstitute/gatk-sv/blob/master/scripts/cromwell/download_monitoring_logs.py
+  """
+  if isinstance(m, list):
+    call_metadata = []
+    for m_shard in m:
+      call_metadata.extend(getCalls(m_shard, alias=alias))
+    return call_metadata
 
-	if 'labels' in m:
-		# In alias, track hierarchy of workflow/task up to current task nicely without repetition
-		if alias is None:
-			alias = ""
-		to_add = ""
-		if 'wdl-call-alias' in m['labels']:
-			to_add = m['labels']['wdl-call-alias']
-		elif 'wdl-task-name' in m['labels']:
-			to_add = m['labels']['wdl-task-name']
-		if to_add != "" and not alias.endswith(to_add):
-			if alias != "" and alias[-1] != ".":
-				alias += "."
-			alias += to_add
+  if 'labels' in m:
+    alias = add_label_to_alias(alias, m['labels'])
 
-	
+  call_metadata = []
+  if 'calls' in m:
+    for call in m['calls']:
+      # Skips scatters that don't contain calls
+      if '.' not in call:
+        continue
+      call_alias = get_call_alias(alias, call)
+      # recursively get metadata
+      call_metadata.extend(getCalls(m['calls'][call], alias=call_alias))
 
-	call_metadata = []
-	if 'calls' in m:
-		for call in m['calls']:
-			# Skips scatters that don't contain calls
-			if '.' not in call:
-				continue
-			# In call_alias, track hierarchy of workflow/task up to current call nicely without repetition
-			if alias is None:
-				alias = ""
-			call_split = call.split('.')
-			call_name = call
-			if alias.endswith(call_split[0]):
-				call_name = call_split[1]
-			call_alias = alias
-			if call_alias != "" and call_alias[-1] != ".":
-				call_alias += "."
-			call_alias += call_name
-			# recursively get metadata
-			call_metadata.extend(getCalls(m['calls'][call], alias=call_alias))
+  if 'subWorkflowMetadata' in m:
+    call_metadata.extend(getCalls(m['subWorkflowMetadata'], alias=alias))
 
-	if 'subWorkflowMetadata' in m:
-		call_metadata.extend(getCalls(m['subWorkflowMetadata'], alias=alias))
+  # in a call
+  if alias and ('monitoringLog' in m):
+    shard_index = '-2'
+    if 'shardIndex' in m:
+      shard_index = m['shardIndex']
 
-	# in a call
-	if alias and ('monitoringLog' in m):
-		shard_index = '-2'
-		if 'shardIndex' in m:
-			shard_index = m['shardIndex']
+    attempt = '0'
+    if 'attempt' in m:
+      attempt = m['attempt']
 
-		attempt = '0'
-		if 'attempt' in m:
-			attempt = m['attempt']
+    job_id = 'na'
+    if 'jobId' in m:
+      job_id = m['jobId'].split('/')[-1]
 
-		job_id = 'na'
-		if 'jobId' in m:
-			job_id = m['jobId'].split('/')[-1]
+    start, end = calculate_start_end(m)
 
-		start, end = calculate_start_end(m)
+    cpu, memory = get_mem_cpu(m)
 
-		cpu, memory = get_mem_cpu(m)
+    cached = used_cached_results(m)
 
-		cached = used_cached_results(m)
-		
+    callroot = 'na'
+    if 'callRoot' in m:
+      callroot = m['callRoot']
 
-		callroot = 'na'
-		if 'callRoot' in m:
-			callroot = m['callRoot']
+    preemptible = was_preemptible_vm(m)
+    preemptible_cpu = 0
+    nonpreemptible_cpu = 0
+    if preemptible:
+      preemptible_cpu = cpu
+    else:
+      nonpreemptible_cpu = cpu
 
-		preemptible = was_preemptible_vm(m)
-		preemptible_cpu = 0
-		nonpreemptible_cpu = 0
-		if preemptible:
-			preemptible_cpu = cpu
-		else:
-			nonpreemptible_cpu = cpu
-			
+    hdd_size, ssd_size = get_disk_info(m)
 
-		hdd_size, ssd_size = get_disk_info(m)
+    call_metadata.append((start, 1, cpu, preemptible_cpu, nonpreemptible_cpu, memory, hdd_size, ssd_size))
+    call_metadata.append((end, -1, -1 * cpu, -1 * preemptible_cpu, -1 * nonpreemptible_cpu, -1 * memory, -1 * hdd_size, -1 * ssd_size))
+    if not preemptible:
+      update_nonpreemptible_counters(alias)
 
-		call_metadata.append((start, 1, cpu, preemptible_cpu, nonpreemptible_cpu, memory, hdd_size, ssd_size))
-		call_metadata.append((end, -1, -1*cpu, -1*preemptible_cpu, -1*nonpreemptible_cpu, -1*memory, -1*hdd_size, -1*ssd_size))
-		if not preemptible:
-			global NUM_NONPREEMPTIBLE
-			global NONPREEMBTIBLE_TASKS
-			NUM_NONPREEMPTIBLE += 1
-			if alias in NONPREEMBTIBLE_TASKS:
-				NONPREEMBTIBLE_TASKS[alias] += 1
-			else:
-				NONPREEMBTIBLE_TASKS[alias] = 1
+    if cached:
+      update_cached_counters(alias)
 
-		if cached:
-			global CACHED
-			global NUM_CACHED
-			NUM_CACHED += 1
-			if alias in CACHED:
-				CACHED[alias] += 1
-			else:
-				CACHED[alias] = 1
+  return call_metadata
 
-	return call_metadata
 
 def check_workflow_valid(metadata, metadata_file, override_warning):
-	# these errors cannot be overcome
-	if 'status' not in metadata:
-		print("ERROR: Incomplete metadata input file %s. File lacks workflow status field." % metadata_file, file=sys.stderr)
-		exit(1)
-	if metadata['status'] == "fail": # Unrecognized workflow ID failure - unable to download metadata
-		err_msg = "ERROR: Workflow metadata download failure."
-		if 'message' in metadata:
-			err_msg += " Message: " + metadata['message']
-		print(err_msg, file=sys.stderr)
-		exit(1)
-	# these errors may be able to be overcome for partial output
-	found_retryable_error = False
-	if metadata['status'] == "Failed":
-		print("Warning: Workflow failed.", file=sys.stderr)
-		found_retryable_error = True
-	for event in metadata['workflowProcessingEvents']:
-		if event['description'] == "Released":
-			print("Warning: Server was interrupted during workflow execution, which is likely to impact plot accuracy.", file=sys.stderr)
-			found_retryable_error = True
-			break
-	if found_retryable_error:
-		if override_warning:
-			print("Override_warning=TRUE. Proceeding with caution.", file=sys.stderr)
-		else:
-			print("To attempt to proceed anyway, re-run the script with the --override_warning flag.", file=sys.stderr)
-			exit(1)
+  # these errors cannot be overcome
+  if 'status' not in metadata:
+    raise RuntimeError("Incomplete metadata input file %s. File lacks workflow status field." % metadata_file)
+  if metadata['status'] == "fail":  # Unrecognized workflow ID failure - unable to download metadata
+    err_msg = "Workflow metadata download failure."
+    if 'message' in metadata:
+      err_msg += " Message: " + metadata['message']
+    raise RuntimeError(err_msg)
+
+  # these errors may be able to be overcome for partial output
+  found_retryable_error = False
+  if metadata['status'] == "Failed":
+    logging.warning("Workflow failed, which is likely to impact plot accuracy.")
+    found_retryable_error = True
+  for event in metadata['workflowProcessingEvents']:
+    if event['description'] == "Released":
+      logging.warning("Server was interrupted during workflow execution, which is likely to impact plot accuracy.")
+      found_retryable_error = True
+      break
+  if found_retryable_error:
+    if override_warning:
+      logging.info("Override_warning=TRUE. Proceeding with caution.")
+    else:
+      raise RuntimeError("One or more retryable errors encountered (see logging info for warnings). To attempt to proceed anyway, re-run the script with the --override-warning flag.")
+
 
 def get_call_metadata(metadata_file, override_warning=False):
-	"""
-	Based on: https://github.com/broadinstitute/gatk-sv/blob/master/scripts/cromwell/download_monitoring_logs.py
-	"""
-	metadata = json.load(open(metadata_file, 'r'))
-	check_workflow_valid(metadata, metadata_file, override_warning)
-	colnames = ['timestamp', 'vm_delta', 'cpu_all_delta', 'cpu_preemptible_delta', 'cpu_nonpreemptible_delta', 'memory_delta', 'hdd_delta', 'ssd_delta']
+  """
+  Based on: https://github.com/broadinstitute/gatk-sv/blob/master/scripts/cromwell/download_monitoring_logs.py
+  """
+  metadata = json.load(open(metadata_file, 'r'))
+  check_workflow_valid(metadata, metadata_file, override_warning)
+  colnames = ['timestamp', 'vm_delta', 'cpu_all_delta', 'cpu_preemptible_delta', 'cpu_nonpreemptible_delta', 'memory_delta', 'hdd_delta', 'ssd_delta']
 
-	call_metadata = getCalls(metadata)
-	if len(call_metadata) == 0:
-		print("ERROR: No calls in workflow metadata.", file=sys.stderr)
-		exit(1)
-	call_metadata = pd.DataFrame(call_metadata, columns=colnames)
+  call_metadata = getCalls(metadata)
+  if len(call_metadata) == 0:
+    raise RuntimeError("No calls in workflow metadata.")
+  call_metadata = pd.DataFrame(call_metadata, columns=colnames)
 
-	return call_metadata
+  return call_metadata
+
 
 def transform_call_metadata(call_metadata):
-	"""
-	Based on: https://github.com/broadinstitute/dsde-pipelines/blob/master/scripts/quota_usage.py
-	"""
-	call_metadata = call_metadata.sort_values(by='timestamp')
-	call_metadata['timestamp'] -= call_metadata.timestamp.iloc[0] # make timestamps start from 0 by subtracting minimum (at index 0 after sorting)
-	call_metadata['seconds'] = call_metadata['timestamp'].dt.total_seconds() # get timedelta in seconds because plot labels won't format correctly otherwise
-	
-	call_metadata['vm'] = call_metadata.vm_delta.cumsum()
-	call_metadata['cpu_all'] = call_metadata.cpu_all_delta.cumsum()
-	call_metadata['cpu_preemptible'] = call_metadata.cpu_preemptible_delta.cumsum()
-	call_metadata['cpu_nonpreemptible'] = call_metadata.cpu_nonpreemptible_delta.cumsum()
-	call_metadata['memory'] = call_metadata.memory_delta.cumsum()
-	call_metadata['ssd'] = call_metadata.ssd_delta.cumsum()
-	call_metadata['hdd'] = call_metadata.hdd_delta.cumsum()
+  """
+  Based on: https://github.com/broadinstitute/dsde-pipelines/blob/master/scripts/quota_usage.py
+  """
+  call_metadata = call_metadata.sort_values(by='timestamp')
+  call_metadata['timestamp_zero'] = call_metadata['timestamp'] - call_metadata.timestamp.iloc[0]  # make timestamps start from 0 by subtracting minimum (at index 0 after sorting)
+  call_metadata['seconds'] = call_metadata['timestamp_zero'].dt.total_seconds()  # get timedelta in seconds because plot labels won't format correctly otherwise
 
-	return call_metadata
+  call_metadata['vm'] = call_metadata.vm_delta.cumsum()
+  call_metadata['cpu_all'] = call_metadata.cpu_all_delta.cumsum()
+  call_metadata['cpu_preemptible'] = call_metadata.cpu_preemptible_delta.cumsum()
+  call_metadata['cpu_nonpreemptible'] = call_metadata.cpu_nonpreemptible_delta.cumsum()
+  call_metadata['memory'] = call_metadata.memory_delta.cumsum()
+  call_metadata['ssd'] = call_metadata.ssd_delta.cumsum()
+  call_metadata['hdd'] = call_metadata.hdd_delta.cumsum()
+
+  return call_metadata
+
 
 def plot_resources_time(df, title_name, output_name):
-	"""
-	Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/master/scripts/quota_usage.py
-	"""
-	print("Writing " + output_name, file = sys.stderr)
-	colors = {
-		"vm": "#006FA6", #blue 
-		"cpu_all": "black",
-		"cpu_preemptible": "#10a197", #turquoise 
-		"cpu_nonpreemptible": "#A30059", #dark pink
-		"memory": "#FF4A46", #coral red
-		"hdd": "#72418F", #purple
-		"ssd": "#008941", #green
-	}
-	LABEL_SIZE = 17
-	TITLE_SIZE = 20
-	TICK_SIZE = 15
+  """
+  Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/master/scripts/quota_usage.py
+  """
+  logging.info("Writing " + output_name)
+  colors = {
+      "vm": "#006FA6",  # blue
+      "cpu_all": "black",
+      "cpu_preemptible": "#10a197",  # turquoise
+      "cpu_nonpreemptible": "#A30059",  # dark pink
+      "memory": "#FF4A46",  # coral red
+      "hdd": "#72418F",  # purple
+      "ssd": "#008941",  # green
+  }
+  LABEL_SIZE = 17
+  TITLE_SIZE = 20
+  TICK_SIZE = 15
 
-	fig,ax = plt.subplots(4,1, figsize = (14,26), sharex = True)
-	ax[0].set_title(title_name + "Resource Acquisition Over Time", fontsize=TITLE_SIZE)
+  fig, ax = plt.subplots(4, 1, figsize=(14, 26), sharex=True)
+  ax[0].set_title(title_name + "Resource Acquisition Over Time", fontsize=TITLE_SIZE)
 
-	ax[0].plot(df['seconds'], df['vm'], color = colors["vm"])
-	ax[0].set_ylabel("VMs", fontsize = LABEL_SIZE)
-	plt.setp(ax[0].get_yticklabels(), fontsize = TICK_SIZE)
+  ax[0].plot(df['seconds'], df['vm'], color=colors["vm"])
+  ax[0].set_ylabel("VMs", fontsize=LABEL_SIZE)
+  plt.setp(ax[0].get_yticklabels(), fontsize=TICK_SIZE)
 
-	ax[1].plot(df['seconds'], df['cpu_all'], color = colors["cpu_all"], linewidth = 2, label = "All")
-	ax[1].plot(df['seconds'], df['cpu_preemptible'], color = colors["cpu_preemptible"], linestyle = "dashed", label = "Preemptible")
-	ax[1].plot(df['seconds'], df['cpu_nonpreemptible'], color = colors["cpu_nonpreemptible"], linestyle = "dashed", label = "Non-preemptible")
-	ax[1].set_ylabel("CPU Cores", fontsize = LABEL_SIZE)
-	plt.setp(ax[1].get_yticklabels(), fontsize = TICK_SIZE)
-	ax[1].legend(loc = "upper right", title = "CPU Types", fontsize = TICK_SIZE, title_fontsize = TICK_SIZE)
+  ax[1].plot(df['seconds'], df['cpu_all'], color=colors["cpu_all"], linewidth=2, label="All")
+  ax[1].plot(df['seconds'], df['cpu_preemptible'], color=colors["cpu_preemptible"], linestyle="dashed", label="Preemptible")
+  ax[1].plot(df['seconds'], df['cpu_nonpreemptible'], color=colors["cpu_nonpreemptible"], linestyle="dashed", label="Non-preemptible")
+  ax[1].set_ylabel("CPU Cores", fontsize=LABEL_SIZE)
+  plt.setp(ax[1].get_yticklabels(), fontsize=TICK_SIZE)
+  ax[1].legend(loc="upper right", title="CPU Types", fontsize=TICK_SIZE, title_fontsize=TICK_SIZE)
 
-	ax[2].plot(df['seconds'], df['memory'], color = colors["memory"])
-	ax[2].set_ylabel("RAM (GiB)", fontsize = LABEL_SIZE)
-	plt.setp(ax[2].get_yticklabels(), fontsize = TICK_SIZE)
+  ax[2].plot(df['seconds'], df['memory'], color=colors["memory"])
+  ax[2].set_ylabel("RAM (GiB)", fontsize=LABEL_SIZE)
+  plt.setp(ax[2].get_yticklabels(), fontsize=TICK_SIZE)
 
-	ax[3].plot(df['seconds'], df['hdd'], color = colors["hdd"], label = "HDD")
-	ax[3].plot(df['seconds'], df['ssd'], color = colors["ssd"], label = "SSD")
-	ax[3].set_ylabel("Disk Memory (GiB)", fontsize = LABEL_SIZE)
-	plt.setp(ax[3].get_yticklabels(), fontsize = TICK_SIZE)
-	ax[3].legend(loc = "upper right", title = "Disk Types", fontsize = TICK_SIZE, title_fontsize = TICK_SIZE)
+  ax[3].plot(df['seconds'], df['hdd'], color=colors["hdd"], label="HDD")
+  ax[3].plot(df['seconds'], df['ssd'], color=colors["ssd"], label="SSD")
+  ax[3].set_ylabel("Disk Memory (GiB)", fontsize=LABEL_SIZE)
+  plt.setp(ax[3].get_yticklabels(), fontsize=TICK_SIZE)
+  ax[3].legend(loc="upper right", title="Disk Types", fontsize=TICK_SIZE, title_fontsize=TICK_SIZE)
 
-	formatter = matplotlib.ticker.FuncFormatter(lambda x,pos: str(datetime.timedelta(seconds = x)))
-	ax[3].xaxis.set_major_formatter(formatter) 
-	plt.setp(ax[3].get_xticklabels(), rotation = 15, fontsize = TICK_SIZE)
-	ax[3].set_xlabel("Time", fontsize = LABEL_SIZE)
-	
-	fig.savefig(output_name, bbox_inches='tight')
+  formatter = matplotlib.ticker.FuncFormatter(lambda x, pos: str(datetime.timedelta(seconds=x)))
+  ax[3].xaxis.set_major_formatter(formatter)
+  plt.setp(ax[3].get_xticklabels(), rotation=15, fontsize=TICK_SIZE)
+  ax[3].set_xlabel("Time", fontsize=LABEL_SIZE)
+
+  fig.savefig(output_name, bbox_inches='tight')
+
 
 def write_resources_time_table(call_metadata, table_file):
-	print("Writing " + table_file, file = sys.stderr)
-	call_metadata.to_csv(
-		table_file, 
-		columns = ["timestamp", "seconds", "vm", "cpu_all", "cpu_preemptible", "cpu_nonpreemptible", "memory", "hdd", "ssd"],
-		sep='\t', 
-		index = False
-	)
+  logging.info("Writing " + table_file)
+  call_metadata.to_csv(
+      table_file,
+      columns=["timestamp", "seconds", "vm", "cpu_all", "cpu_preemptible", "cpu_nonpreemptible", "memory", "hdd", "ssd"],
+      sep='\t',
+      index=False,
+      date_format='%Y-%m-%dT%H:%M%:%SZ'
+  )
+
 
 def write_peak_usage(m, peak_file):
-	print("Writing " + peak_file, file = sys.stderr)
-	with open(peak_file, 'w') as out:
-		out.write("peak_vms\t" + str(max(m['vm'])) + "\n")
-		out.write("peak_cpu_all\t" + str(max(m['cpu_all'])) + "\n")
-		out.write("peak_cpu_preemptible\t" + str(max(m['cpu_preemptible'])) + "\n")
-		out.write("peak_cpu_nonpreemptible\t" + str(max(m['cpu_nonpreemptible'])) + "\n")
-		out.write("peak_ram_gib\t" + "{:.2f}".format(max(m['memory'])) + "\n")
-		out.write("peak_disk_hdd_gib\t" + str(max(m['hdd'])) + "\n")
-		out.write("peak_disk_ssd_gib\t" + str(max(m['ssd'])) + "\n")
+  logging.info("Writing " + peak_file)
+  with open(peak_file, 'w') as out:
+    out.write("peak_vms\t" + str(max(m['vm'])) + "\n")
+    out.write("peak_cpu_all\t" + str(max(m['cpu_all'])) + "\n")
+    out.write("peak_cpu_preemptible\t" + str(max(m['cpu_preemptible'])) + "\n")
+    out.write("peak_cpu_nonpreemptible\t" + str(max(m['cpu_nonpreemptible'])) + "\n")
+    out.write("peak_ram_gib\t" + "{:.2f}".format(max(m['memory'])) + "\n")
+    out.write("peak_disk_hdd_gib\t" + str(max(m['hdd'])) + "\n")
+    out.write("peak_disk_ssd_gib\t" + str(max(m['ssd'])) + "\n")
+
 
 def write_cached_warning(cached_file):
-	global CACHED
-	global NUM_CACHED
-	if NUM_CACHED > 0:
-		print("%d cached tasks found, writing tasks to %s." % (NUM_CACHED, cached_file))
-		with open(cached_file, 'w') as cached_out:
-			cached_out.write("#task_name\tnum_cached\n")
-			cached_out.write("all_tasks\t%d\n" % NUM_CACHED)
-			cached_out.write("\n".join([x + '\t' + str(CACHED[x]) for x in sorted(list(CACHED.keys()))]) + "\n")
-	else:
-		print("0 cached tasks found.")
+  global CACHED
+  global NUM_CACHED
+  if NUM_CACHED > 0:
+    logging.info("%d cached tasks found, writing tasks to %s." % (NUM_CACHED, cached_file))
+    with open(cached_file, 'w') as cached_out:
+      cached_out.write("#task_name\tnum_cached\n")
+      cached_out.write("all_tasks\t%d\n" % NUM_CACHED)
+      cached_out.write("\n".join([x + '\t' + str(CACHED[x]) for x in sorted(list(CACHED.keys()))]) + "\n")
+  else:
+    logging.info("0 cached tasks found.")
+
 
 def write_nonpreemptible_vms(vms_file):
-	global NUM_NONPREEMPTIBLE
-	global NONPREEMBTIBLE_TASKS
-	if NUM_NONPREEMPTIBLE > 0:
-		print("%d non-preemptible VMs found, writing tasks to %s." % (NUM_NONPREEMPTIBLE, vms_file))
-		with open(vms_file, 'w') as vms_out:
-			vms_out.write("#task_name\tnum_nonpreemptible\n")
-			vms_out.write("all_tasks\t%d\n" % NUM_NONPREEMPTIBLE)
-			vms_out.write("\n".join([x + '\t' + str(NONPREEMBTIBLE_TASKS[x]) for x in sorted(list(NONPREEMBTIBLE_TASKS.keys()))]) + "\n")
-	else:
-		print("0 non-preemptible VMs found.")
-			
+  global NUM_NONPREEMPTIBLE
+  global NONPREEMBTIBLE_TASKS
+  if NUM_NONPREEMPTIBLE > 0:
+    logging.info("%d non-preemptible VMs found, writing tasks to %s." % (NUM_NONPREEMPTIBLE, vms_file))
+    with open(vms_file, 'w') as vms_out:
+      vms_out.write("#task_name\tnum_nonpreemptible\n")
+      vms_out.write("all_tasks\t%d\n" % NUM_NONPREEMPTIBLE)
+      vms_out.write("\n".join([x + '\t' + str(NONPREEMBTIBLE_TASKS[x]) for x in sorted(list(NONPREEMBTIBLE_TASKS.keys()))]) + "\n")
+  else:
+    logging.info("0 non-preemptible VMs found.")
+
+
 def check_file_nonempty(f):
-	if not isfile(f): 
-		print("ERROR: Required metadata input file %s does not exist." % f, file=sys.stderr)
-		exit(1)
-	elif getsize(f) == 0:
-		print("ERROR: Required metadata input file %s is empty." % f, file=sys.stderr)
-		exit(1)
+  if not isfile(f):
+    raise RuntimeError("Required metadata input file %s does not exist." % f)
+  elif getsize(f) == 0:
+    raise RuntimeError("Required metadata input file %s is empty." % f)
+
 
 # Main function
 def main():
-	parser = argparse.ArgumentParser()
-	parser.add_argument("workflow_metadata", help="Workflow metadata JSON file")
-	parser.add_argument("output_base", help="Output directory + basename")
-	parser.add_argument("--plot_title", help="Provide workflow name for plot title: <name> Resource Acquisition Over Time", required=False, default = "")
-	parser.add_argument("--override_warning", help="Execute script workflow warning (server interrupted, workflow failed, etc.), which may impact plot accuracy", \
-		required=False, default=False, action='store_true')
-	parser.add_argument("--save_table", help="Save TSV copy of resources over time table used to make plot", required=False, default=False, action='store_true')
-	args = parser.parse_args()
-	random.seed(SEED)
+  parser = argparse.ArgumentParser()
+  parser.add_argument("workflow_metadata", help="Workflow metadata JSON file")
+  parser.add_argument("output_base", help="Output directory + basename")
+  parser.add_argument("--plot-title", help="Provide workflow name for plot title: <name> Resource Acquisition Over Time", required=False, default="")
+  parser.add_argument("--override-warning", help="Execute script workflow warning (server interrupted, workflow failed, etc.), which may impact plot accuracy",
+                      required=False, default=False, action='store_true')
+  parser.add_argument("--save-table", help="Save TSV copy of resources over time table used to make plot", required=False, default=False, action='store_true')
+  parser.add_argument("--log-level", help="Specify level of logging information, ie. info, warning, error (not case-sensitive)", required=False, default="INFO")
+  args = parser.parse_args()
 
-	metadata_file, output_base, plt_title, override_warning, save_table = args.workflow_metadata, args.output_base, args.plot_title, args.override_warning, args.save_table
-	if plt_title != "":
-		plt_title += " "
-	sep = "."
-	if basename(output_base) == "":
-		sep = ""
+  # get args as variables
+  metadata_file, output_base = args.workflow_metadata, args.output_base  # required args
+  plt_title, override_warning, save_table, log_level = args.plot_title, args.override_warning, args.save_table, args.log_level  # optional args
 
-	check_file_nonempty(metadata_file)
-	call_metadata = get_call_metadata(metadata_file, override_warning)
-	call_metadata = transform_call_metadata(call_metadata)
+  # set attributes based on input parameters
+  numeric_level = getattr(logging, log_level.upper(), None)
+  if not isinstance(numeric_level, int):
+    raise ValueError('Invalid log level: %s' % log_level)
+  logging.basicConfig(level=numeric_level, format='%(levelname)s: %(message)s')
+  if plt_title != "":
+    plt_title += " "
+  sep = "."
+  if basename(output_base) == "":
+    sep = ""
 
-	cached_file = output_base + sep + "cached.tsv"
-	write_cached_warning(cached_file)
+  check_file_nonempty(metadata_file)
+  call_metadata = get_call_metadata(metadata_file, override_warning)
+  call_metadata = transform_call_metadata(call_metadata)
 
-	vms_file = output_base + sep + "vms_file.tsv"
-	write_nonpreemptible_vms(vms_file)
-	
-	plot_file = output_base + sep + "plot.png"
-	plot_resources_time(call_metadata, plt_title, plot_file)
+  cached_file = output_base + sep + "cached.tsv"
+  write_cached_warning(cached_file)
 
-	if save_table:
-		table_file = output_base + sep + "table.tsv"
-		write_resources_time_table(call_metadata, table_file)
+  vms_file = output_base + sep + "vms_file.tsv"
+  write_nonpreemptible_vms(vms_file)
 
-	peak_file = output_base + sep + "peaks.tsv"
-	write_peak_usage(call_metadata, peak_file)
+  plot_file = output_base + sep + "plot.png"
+  plot_resources_time(call_metadata, plt_title, plot_file)
 
+  if save_table:
+    table_file = output_base + sep + "table.tsv"
+    write_resources_time_table(call_metadata, table_file)
 
-if __name__== "__main__":
-	main()
-
-
+  peak_file = output_base + sep + "peaks.tsv"
+  write_peak_usage(call_metadata, peak_file)
 
 
-
+if __name__ == "__main__":
+  main()

--- a/scripts/cromwell/analyze_resource_acquisition.py
+++ b/scripts/cromwell/analyze_resource_acquisition.py
@@ -1,0 +1,307 @@
+#!/bin/python
+
+import json
+import argparse
+import numpy as np
+import dateutil.parser
+from dateutil.tz import tzutc
+import datetime
+import time
+import pandas as pd
+import math
+import random
+SEED = 42
+
+def get_seconds_from_epoch(time_string):
+	return (dateutil.parser.parse(time_string) - datetime.datetime(1900,1,1,tzinfo=tzutc())).total_seconds()
+
+def get_disk_info(metadata):
+	"""
+	Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
+	Modified to return (hdd_size, ssd_size)
+	"""
+	if "runtimeAttributes" in metadata and "disks" in metadata['runtimeAttributes']:
+		bootDiskSizeGb = 0.0
+		if "bootDiskSizeGb" in metadata['runtimeAttributes']:
+			bootDiskSizeGb = float(metadata['runtimeAttributes']['bootDiskSizeGb'])
+		# Note - am lumping boot disk in with requested disk.  Assuming boot disk is same type as requested.
+		# i.e. is it possible that boot disk is HDD when requested is SDD.
+		(name, disk_size, disk_type) = metadata['runtimeAttributes']["disks"].split()
+		if disk_type == "HDD":
+			return float(disk_size), float(0)
+		elif disk_type == "SSD":
+			return float(0), float(disk_size)
+		else:
+			return float(0), float(0)
+	else:
+		# we can't tell disk size in this case so just return nothing
+		return float(0),float(0)
+		
+def was_preemptible_vm(metadata):
+	if "runtimeAttributes" in metadata and "preemptible" in metadata['runtimeAttributes']:
+		pe_count = int(metadata['runtimeAttributes']["preemptible"])
+		attempt = int(metadata['attempt'])
+
+		return attempt <= pe_count
+	else:
+		# we can't tell (older metadata) so conservatively return false
+		return False
+
+def used_cached_results(metadata):
+	"""
+	Source: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
+	"""
+	return "callCaching" in metadata and metadata["callCaching"]["hit"]
+
+def calculate_start_end(call_info):
+	"""
+	Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
+	"""
+	# get start (start time of VM start) & end time (end time of 'ok') according to metadata
+	start = None
+	end = None
+
+	if 'executionEvents' in call_info:
+		for x in call_info['executionEvents']:
+			y = x['description']
+
+			if 'backend' in call_info and call_info['backend'] == 'PAPIv2':
+				if y.startswith("PreparingJob"):
+					start = dateutil.parser.parse(x['startTime'])
+				if y.startswith("Worker released"):
+					end = dateutil.parser.parse(x['endTime'])
+			else:
+				if y.startswith("start"):
+					start = dateutil.parser.parse(x['startTime'])
+				if y.startswith("ok"):
+					end = dateutil.parser.parse(x['endTime'])
+
+	# if we are preempted or if cromwell used previously cached results, we don't even get a start time from JES.
+	# if cromwell was restarted, the start time from JES might not have been written to the metadata.
+	# in either case, use the Cromwell start time which is earlier but not wrong.
+	if start is None:
+		start = dateutil.parser.parse(call_info['start'])
+
+	# if we are preempted or if cromwell used previously cached results, we don't get an endtime from JES right now.
+	# if cromwell was restarted, the start time from JES might not have been written to the metadata.
+	# in either case, use the Cromwell end time which is later but not wrong
+	if end is None:
+		end = dateutil.parser.parse(call_info['end'])
+
+	# start = get_seconds_from_epoch(start)
+	# end = get_seconds_from_epoch(end)
+	return start, end
+
+def was_preempted(call_info):
+	# We treat Preempted and RetryableFailure the same.  The latter is a general case of the former
+	return call_info['executionStatus'] in ['Preempted', 'RetryableFailure']
+
+def calculate_start_end_simple(m):
+	start = 'na'
+	if 'start' in m:
+		start = get_seconds_from_epoch(m['start'])
+
+	end = 'na'
+	if 'end' in m:
+		end = get_seconds_from_epoch(m['end'])
+
+	return start, end
+
+def getCalls(m, alias=None):
+	"""
+	Modified from download_monitoring_logs.py script by Mark Walker
+	https://github.com/broadinstitute/gatk-sv/blob/master/scripts/cromwell/download_monitoring_logs.py
+	"""
+	if isinstance(m, list):
+		call_metadata = []
+		for m_shard in m:
+			call_metadata.extend(getCalls(m_shard, alias=alias))
+		return call_metadata
+
+	if 'labels' in m:
+		if 'wdl-call-alias' in m['labels']:
+			alias = m['labels']['wdl-call-alias']
+		elif 'wdl-task-name' in m['labels']:
+			alias = m['labels']['wdl-task-name']
+
+	shard_index = '-2'
+	if 'shardIndex' in m:
+		shard_index = m['shardIndex']
+
+	attempt = '0'
+	if 'attempt' in m:
+		attempt = m['attempt']
+
+	job_id = 'na'
+	if 'jobId' in m:
+		job_id = m['jobId'].split('/')[-1]
+
+	start, end = calculate_start_end(m)
+
+	cpu = 'na'
+	memory = 'na'
+	if 'runtimeAttributes' in m:
+		if 'cpu' in m['runtimeAttributes']:
+			cpu = int(m['runtimeAttributes']['cpu'])
+		if 'memory' in m['runtimeAttributes']:
+			mem_str = m['runtimeAttributes']['memory']
+			memory = float(mem_str[:mem_str.index(" ")])
+
+	cached = used_cached_results(m)
+
+	callroot = 'na'
+	if 'callRoot' in m:
+		callroot = m['callRoot']
+
+	preemptible = was_preemptible_vm(m)
+	preemptible_cpu = 0
+	nonpreemptible_cpu = 0
+	if preemptible:
+		preemptible_cpu = cpu
+	else:
+		nonpreemptible_cpu = cpu
+
+	hdd_size, ssd_size = get_disk_info(m)
+
+	call_metadata = []
+	if 'calls' in m:
+		for call in m['calls']:
+			# Skips scatters that don't contain calls
+			if '.' not in call:
+				continue
+			call_alias = call.split('.')[1]
+			call_metadata.extend(getCalls(m['calls'][call], alias=call_alias))
+
+	if 'subWorkflowMetadata' in m:
+		call_metadata.extend(getCalls(m['subWorkflowMetadata'], alias=alias))
+
+	# in a call
+	if alias and ('monitoringLog' in m):
+		#call_metadata.append((alias, start,end,shard_index, attempt, job_id, cpu, cached, callroot, memory, preemptible, hdd_size, ssd_size))
+		call_metadata.append((start, cpu, preemptible_cpu, nonpreemptible_cpu, memory, hdd_size, ssd_size))
+		call_metadata.append((end, -1*cpu, -1*preemptible_cpu, -1*nonpreemptible_cpu, -1*memory, -1*hdd_size, -1*ssd_size))
+
+	return call_metadata
+
+def get_data_table(metadata_file):
+	metadata = json.load(open(metadata_file, 'r'))
+	#call_metadata = np.asarray(getCalls(metadata, metadata['workflowName']))
+	#colnames = ['alias','start','end','shard_index','attempt','job_id','cpu', 'cached','callroot', 'memory', 'preemptible', 'hdd_size', 'ssd_size']
+	colnames = ['timestamp','cpu_all', 'memory', 'preemptible', 'hdd_size', 'ssd_size']
+
+	call_metadata = getCalls(metadata, metadata['workflowName'])
+	print(len(call_metadata))
+	print(len(set(call_metadata)))
+	call_metadata = pd.DataFrame(call_metadata, columns=colnames)
+	print(call_metadata)
+
+	mintime = min(call_metadata['start'])
+	call_metadata['start'] -= mintime
+	call_metadata['end'] -= mintime
+
+	return call_metadata
+
+def get_data_table_cumulative(metadata_file):
+	metadata = json.load(open(metadata_file, 'r'))
+	colnames = ['timestamp','cpu_all_delta', 'cpu_preemptible_delta', 'cpu_nonpreemptible_delta','memory_delta', 'hdd_delta', 'ssd_delta']
+
+	call_metadata = getCalls(metadata, metadata['workflowName'])
+	call_metadata = pd.DataFrame(call_metadata, columns=colnames)
+	#call_metadata[['timestamp']] = call_metadata[['timestamp']].astype('datetime64')
+
+	call_metadata = call_metadata.sort_values(by='timestamp')
+	#print(call_metadata[['timestamp']])
+
+	call_metadata['cpu_all'] = call_metadata.cpu_all_delta.cumsum()
+	call_metadata['cpu_preemptible'] = call_metadata.cpu_preemptible_delta.cumsum()
+	call_metadata['cpu_nonpreemptible'] = call_metadata.cpu_nonpreemptible_delta.cumsum()
+	call_metadata['memory'] = call_metadata.memory_delta.cumsum()
+	call_metadata['ssd'] = call_metadata.ssd_delta.cumsum()
+	call_metadata['hdd'] = call_metadata.hdd_delta.cumsum()
+
+	return call_metadata
+
+def make_time_bins(call_metadata, count_by):
+	total_elapsed_seconds = max(call_metadata['end'])
+	time_ranges = np.array(range(0,math.ceil(total_elapsed_seconds),count_by))
+	bins = len(time_ranges)
+	time_ranges = np.vstack((time_ranges, time_ranges + count_by)).T
+
+	return bins, time_ranges
+
+def get_binned_data(call_metadata):
+	#wip 
+	count_by = 5 # bin resolution, in seconds
+	bins, time_ranges = make_time_bins(call_metadata, count_by)
+	
+	cols_list = ["vms", "all_cpus", "preemptibles", "non-preemptibles","memory", "hdd", "ssd"]
+	cols = {x:i for i,x in enumerate(cols_list)}
+	data = np.zeros((bins, len(cols_list)))
+
+	cpus = np.zeros(bins)
+	for rownum in range(len(call_metadata)):
+		call = call_metadata.loc[rownum]
+		#print("alias: %s, shard_index: %s, attempt: %s, id: %s, start: %.2f, end: %.2f"% (call['alias'], call['shard_index'], call['attempt'],call['job_id'],call['start'], call['end']))
+		if call['cpu'] != 'na':
+			cpus[np.intersect1d(np.where(call['start'] <= time_ranges[:,1])[0], np.where(call['end'] > time_ranges[:,0])[0])] += call['cpu']
+	#print(cpus)
+
+def plot(df, title_name, output_name):
+	"""
+	Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/master/scripts/quota_usage.py
+	"""
+	ax = df[['timestamp','cpu_all','cpu_preemptible', 'cpu_nonpreemptible', 'ssd','hdd']].plot(x='timestamp', secondary_y=['ssd', 'hdd'], title=title_name, drawstyle="steps-post")
+	ax.set_xlabel("Time")
+	ax.set_ylabel("Cores")
+	ax.legend(loc='center')
+	ax.right_ax.set_ylabel("Disk (GiB)")
+	
+	h1, l1 = ax.get_legend_handles_labels()
+	h2, l2 = ax.right_ax.get_legend_handles_labels()
+	ax.legend(h1+h2, l1+l2, loc="upper center")
+	
+	ax.get_figure().savefig(output_name)
+
+def print_peak_usage(m):
+	print("Peak CPUs (all): " + str(max(m['cpu_all'])))
+	print("Peak Preemptible CPUs: " + str(max(m['cpu_preemptible'])))
+	print("Peak Non-preemptible CPUs: " + str(max(m['cpu_nonpreemptible'])))
+	print("Peak HDD: " + str(max(m['hdd'])) + " GiB")
+	print("Peak SSD: " + str(max(m['ssd'])) + " GiB")
+
+# Main function
+def main():
+	parser = argparse.ArgumentParser()
+	parser.add_argument("workflow_metadata", help="Workflow metadata JSON file")
+	parser.add_argument("output_base", help="Output directory + basename")
+	args = parser.parse_args()
+	random.seed(SEED)
+
+	metadata_file = args.workflow_metadata
+	output_base = args.output_base
+
+	call_metadata = get_data_table_cumulative(metadata_file)
+	
+	png_file = output_base + ".png"
+	print("Writing " + png_file)
+	plot(call_metadata, metadata_file, png_file)
+
+	txt_file = output_base + ".txt"
+	print("Writing " + txt_file)
+	call_metadata.to_csv(txt_file, sep='\t')
+
+	print_peak_usage(call_metadata)
+
+
+if __name__== "__main__":
+	main()
+
+
+
+
+
+
+
+
+
+

--- a/scripts/cromwell/analyze_resource_acquisition.py
+++ b/scripts/cromwell/analyze_resource_acquisition.py
@@ -13,6 +13,7 @@ import random
 import matplotlib.pyplot as plt
 import matplotlib.ticker
 import sys
+from os.path import basename
 SEED = 42
 
 """
@@ -25,18 +26,18 @@ Usage:
 Parameters:
 	workflow_metadata.json: path to Cromwell metadata file for workflow of interest
 	/path/to/output_basename: base output path, to which extensions will be appended for each output file, 
-		ie. /output_dir/basename will yield /output_dir/basename_plot.png, /output_dir/basename_table.tsv, etc
+		ie. /output_dir/basename will yield /output_dir/basename.plot.png, /output_dir/basename.table.tsv, etc
+		or, /output_dir/ will yield plot.png, table.tsv, etc
 
 Outputs:
 	- plot (png) of VMs, CPUs (total, preemptible, and nonpreemptible), RAM, and disk (HDD, SSD) acquisitioned over time 
 	- table of resource acquisition over time for each type of resource listed above
-	- text file containing peak resource acuqisition for each type of resource listed above
-	- [preemptible things]
-	- text file containing list of tasks that used call-caching
+	- text file of peak resource acquisition for each type of resource listed above
+	- (coming soon) [preemptible things]
+	- (prints to stdout) warning of any tasks that used call-caching
 """
-
-def get_seconds_from_epoch(time_string):
-	return (dateutil.parser.parse(time_string) - datetime.datetime(1900,1,1,tzinfo=tzutc())).total_seconds()
+NUM_CACHED = 0
+CACHED = set()
 
 def get_disk_info(metadata):
 	"""
@@ -74,7 +75,7 @@ def used_cached_results(metadata):
 	"""
 	Source: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
 	"""
-	return "callCaching" in metadata and metadata["callCaching"]["hit"]
+	return "callCaching" in metadata and "hit" in metadata["callCaching"] and metadata["callCaching"]["hit"]
 
 def calculate_start_end(call_info):
 	"""
@@ -119,16 +120,16 @@ def was_preempted(call_info):
 	# We treat Preempted and RetryableFailure the same.  The latter is a general case of the former
 	return call_info['executionStatus'] in ['Preempted', 'RetryableFailure']
 
-def calculate_start_end_simple(m):
-	start = 'na'
-	if 'start' in m:
-		start = get_seconds_from_epoch(m['start'])
-
-	end = 'na'
-	if 'end' in m:
-		end = get_seconds_from_epoch(m['end'])
-
-	return start, end
+def get_mem_cpu(m):
+	cpu = 'na'
+	memory = 'na'
+	if 'runtimeAttributes' in m:
+		if 'cpu' in m['runtimeAttributes']:
+			cpu = int(m['runtimeAttributes']['cpu'])
+		if 'memory' in m['runtimeAttributes']:
+			mem_str = m['runtimeAttributes']['memory']
+			memory = float(mem_str[:mem_str.index(" ")])
+	return cpu, memory
 
 def getCalls(m, alias=None):
 	"""
@@ -161,16 +162,14 @@ def getCalls(m, alias=None):
 
 	start, end = calculate_start_end(m)
 
-	cpu = 'na'
-	memory = 'na'
-	if 'runtimeAttributes' in m:
-		if 'cpu' in m['runtimeAttributes']:
-			cpu = int(m['runtimeAttributes']['cpu'])
-		if 'memory' in m['runtimeAttributes']:
-			mem_str = m['runtimeAttributes']['memory']
-			memory = float(mem_str[:mem_str.index(" ")])
+	cpu, memory = get_mem_cpu(m)
 
 	cached = used_cached_results(m)
+	if cached:
+		global CACHED
+		global NUM_CACHED
+		CACHED.add(alias)
+		NUM_CACHED += 1
 
 	callroot = 'na'
 	if 'callRoot' in m:
@@ -200,30 +199,32 @@ def getCalls(m, alias=None):
 
 	# in a call
 	if alias and ('monitoringLog' in m):
-		#call_metadata.append((alias, start,end,shard_index, attempt, job_id, cpu, cached, callroot, memory, preemptible, hdd_size, ssd_size))
 		call_metadata.append((start, 1, cpu, preemptible_cpu, nonpreemptible_cpu, memory, hdd_size, ssd_size))
 		call_metadata.append((end, -1, -1*cpu, -1*preemptible_cpu, -1*nonpreemptible_cpu, -1*memory, -1*hdd_size, -1*ssd_size))
 
 	return call_metadata
 
-def get_data_table(metadata_file):
+def get_call_metadata(metadata_file):
 	"""
-	Based on: 
-		https://github.com/broadinstitute/dsde-pipelines/blob/master/scripts/quota_usage.py
-		https://github.com/broadinstitute/gatk-sv/blob/master/scripts/cromwell/download_monitoring_logs.py
+	Based on: https://github.com/broadinstitute/gatk-sv/blob/master/scripts/cromwell/download_monitoring_logs.py
 	"""
 	metadata = json.load(open(metadata_file, 'r'))
 	colnames = ['timestamp', 'vm_delta', 'cpu_all_delta', 'cpu_preemptible_delta', 'cpu_nonpreemptible_delta', 'memory_delta', 'hdd_delta', 'ssd_delta']
 
 	call_metadata = getCalls(metadata, metadata['workflowName'])
 	call_metadata = pd.DataFrame(call_metadata, columns=colnames)
-	#call_metadata[['timestamp']] = call_metadata[['timestamp']].astype('datetime64')
 
+	return call_metadata
+
+def transform_call_metadata(call_metadata):
+	"""
+	Based on: https://github.com/broadinstitute/dsde-pipelines/blob/master/scripts/quota_usage.py
+	"""
 	call_metadata = call_metadata.sort_values(by='timestamp')
 	call_metadata['timestamp'] -= call_metadata.timestamp.iloc[0] # make timestamps start from 0 by subtracting minimum (at index 0 after sorting)
 	# print(call_metadata[['timestamp']])
-	call_metadata['seconds'] = call_metadata['timestamp'].dt.total_seconds()
-	print(call_metadata.dtypes)
+	call_metadata['seconds'] = call_metadata['timestamp'].dt.total_seconds() # get timedelta in seconds because plot labels won't format correctly otherwise
+	#print(call_metadata.dtypes)
 	
 	call_metadata['vm'] = call_metadata.vm_delta.cumsum()
 	call_metadata['cpu_all'] = call_metadata.cpu_all_delta.cumsum()
@@ -235,20 +236,19 @@ def get_data_table(metadata_file):
 
 	return call_metadata
 
-def plot(df, title_name, output_name):
+def plot_resources_time(df, title_name, output_name):
 	"""
 	Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/master/scripts/quota_usage.py
 	"""
 	print("Writing " + output_name, file = sys.stderr)
 	colors = {
-		"vm": "#006FA6", #blue (dark blue, could use if change to turquoise/cyan: "#0000A6")
+		"vm": "#006FA6", #blue 
 		"cpu_all": "black",
 		"cpu_preemptible": "#10a197", #turquoise 
 		"cpu_nonpreemptible": "#A30059", #dark pink
 		"memory": "#FF4A46", #coral red
 		"hdd": "#72418F", #purple
 		"ssd": "#008941", #green
-		#  "#FF913F", # orange # "gray"
 	}
 	LABEL_SIZE = 17
 	TITLE_SIZE = 20
@@ -285,14 +285,25 @@ def plot(df, title_name, output_name):
 	
 	fig.savefig(output_name, bbox_inches='tight')
 
-def print_peak_usage(m):
-	print("Peak VMs: " + str(max(m['vm'])))
-	print("Peak CPUs (all): " + str(max(m['cpu_all'])))
-	print("Peak Preemptible CPUs: " + str(max(m['cpu_preemptible'])))
-	print("Peak Non-preemptible CPUs: " + str(max(m['cpu_nonpreemptible'])))
-	print("Peak RAM: " + "{:.2f}".format(max(m['memory'])) + " GiB")
-	print("Peak HDD: " + str(max(m['hdd'])) + " GiB")
-	print("Peak SSD: " + str(max(m['ssd'])) + " GiB")
+def write_resources_time_table(call_metadata, table_file):
+	print("Writing " + table_file, file = sys.stderr)
+	call_metadata.to_csv(
+		table_file, 
+		columns = ["timestamp", "seconds", "vm", "cpu_all", "cpu_preemptible", "cpu_nonpreemptible", "memory", "hdd", "ssd"],
+		sep='\t', 
+		index = False
+	)
+
+def write_peak_usage(m, peak_file):
+	print("Writing " + peak_file, file = sys.stderr)
+	with open(peak_file, 'w') as out:
+		out.write("Peak VMs: " + str(max(m['vm'])) + "\n")
+		out.write("Peak CPUs (all): " + str(max(m['cpu_all'])) + "\n")
+		out.write("Peak Preemptible CPUs: " + str(max(m['cpu_preemptible'])) + "\n")
+		out.write("Peak Non-preemptible CPUs: " + str(max(m['cpu_nonpreemptible'])) + "\n")
+		out.write("Peak RAM: " + "{:.2f}".format(max(m['memory'])) + " GiB" + "\n")
+		out.write("Peak HDD: " + str(max(m['hdd'])) + " GiB" + "\n")
+		out.write("Peak SSD: " + str(max(m['ssd'])) + " GiB" + "\n")
 
 # Main function
 def main():
@@ -308,17 +319,32 @@ def main():
 	plt_title = args.plot_title
 	if plt_title != "":
 		plt_title += " "
+	sep = "."
+	if basename(output_base) == "":
+		sep = ""
 
-	call_metadata = get_data_table(metadata_file)
+	call_metadata = get_call_metadata(metadata_file)
+	call_metadata = transform_call_metadata(call_metadata)
+
+	global CACHED
+	global NUM_CACHED
+	if NUM_CACHED > 0:
+		if NUM_CACHED == 1:
+			print("Warning: %d task was call-cached, so this analysis may underestimate typical resource acquisition for this workflow. \nThe cached task was:" % NUM_CACHED)
+		else:
+			print("Warning: %d tasks were call-cached, so this analysis may underestimate typical resource acquisition for this workflow. \nCached tasks include (repeat names omitted):" % NUM_CACHED)
+		print(", ".join(list(CACHED)))
+	else:
+		print("No cached tasks")
 	
-	plot_file = output_base + ".plot.png"
-	plot(call_metadata, plt_title, plot_file)
+	plot_file = output_base + sep + "plot.png"
+	plot_resources_time(call_metadata, plt_title, plot_file)
 
-	table_file = output_base + ".table.tsv"
-	print("Writing " + table_file)
-	call_metadata.to_csv(table_file, sep='\t', index = False)
+	table_file = output_base + sep + "table.tsv"
+	write_resources_time_table(call_metadata, table_file)
 
-	print_peak_usage(call_metadata)
+	peak_file = output_base + sep + "peaks.txt"
+	write_peak_usage(call_metadata, peak_file)
 
 
 if __name__== "__main__":

--- a/scripts/cromwell/analyze_resource_acquisition.py
+++ b/scripts/cromwell/analyze_resource_acquisition.py
@@ -122,13 +122,6 @@ def calculate_start_end(call_info):
 
 	return start, end
 
-def was_preempted(call_info):
-	"""
-	Source: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py
-	"""
-	# We treat Preempted and RetryableFailure the same.  The latter is a general case of the former
-	return call_info['executionStatus'] in ['Preempted', 'RetryableFailure']
-
 def get_mem_cpu(m):
 	"""
 	Modified from: https://github.com/broadinstitute/dsde-pipelines/blob/develop/scripts/calculate_cost.py

--- a/scripts/cromwell/analyze_resource_acquisition.py
+++ b/scripts/cromwell/analyze_resource_acquisition.py
@@ -21,7 +21,7 @@ Summary: Scrapes workflow metadata to analyze resource acquisition (VMs, CPU, RA
 	of understanding resource peaks and timing jobs to avoid hitting quotas.
 
 Usage: 
-	python analyze_resource_acquisition workflow_metadata.json /path/to/output_basename
+	python analyze_resource_acquisition workflow_metadata.json /path/to/output_basename [--plot_title WorkflowName]
 
 Parameters:
 	workflow_metadata.json: path to Cromwell metadata file for workflow of interest


### PR DESCRIPTION
### PR Description
Add script to scrape workflow metadata file to analyze resource acquisition over time. Documentation copied from top of script:
```
Summary: Scrapes workflow metadata to analyze resource acquisition (VMs, CPU, RAM, disk memory), for the purpose
	of understanding resource peaks and timing jobs to avoid hitting quotas.

Usage: 
	python analyze_resource_acquisition workflow_metadata.json /path/to/output_basename [optional flags]
	Optional flags:
	--plot_title WorkflowName (WorkflowName will be prepended to plot title)
	--save_table (to save a TSV file of the table used to create the plot)
	--override_warning (to attempt to run script on workflow that raised a warning)

Parameters:
	workflow_metadata.json: path to Cromwell metadata file for workflow of interest
	/path/to/output_basename: base output path, to which extensions will be appended for each output file, 
		ie. /output_dir/basename will yield /output_dir/basename.plot.png, /output_dir/basename.table.tsv, etc
		or, /output_dir/ will yield plot.png, table.tsv, peaks.txt, etc

Outputs:
	- plot (png) of VMs, CPUs (total, preemptible, and nonpreemptible), RAM, and disk (HDD, SSD) acquisitioned over time 
	- (optional, with --save_table flag) table of resource acquisition over time for each type of resource listed above
	- peak resource acquisition for each type of resource listed above (TSV file)
	- number of non-preemptible VMs used (prints to stdout) and the names of the tasks that used them (TSV file, if any)
	- number of tasks call-cached (prints to stdout), and their task names (TSV file, if any)
```

### Testing
This script has been tested through repeated usage for gnomAD monitoring and resource optimization, including on very large metadata files (ie. Module02) and files with and without call-caching. 

### Notes on future work
This script is ready for use, but there are several changes/additional features that I plan to implement when I get a chance, including:
* Split out non-preemptible VMs over time plot for scale
* Add further analysis of preemption rates, including graphs of time-to-preemption
* Add option to plot resource acquisition of multiple workflows over time in one plot - a modified version of this script exists with this functionality, but I would like to merge the two as they share most of the same code
* Small tweaks including: warning message if exact time not found in metadata file --> using less exact time