### PR TITLE
Fix additional failures on empty shards in annotation module

### DIFF
--- a/test/module01/Module01Test.test_large.json
+++ b/test/module01/Module01Test.test_large.json
@@ -119,10 +119,10 @@
   "Module01Test.Module01Metrics.baseline_wham_vcf" : "gs://gatk-sv-resources/test/module01/large/output/test_large.wham.vcf.gz",
   "Module01Test.Module01Metrics.baseline_melt_vcf" : "gs://gatk-sv-resources/test/module01/large/output/test_large.melt.vcf.gz",
 
-  "Module01Test.Module01Metrics.Module01Metrics.depth_metrics.mem_gib" : 3.75,
-  "Module01Test.Module01Metrics.Module01Metrics.manta_metrics.mem_gib" : 3.75,
-  "Module01Test.Module01Metrics.Module01Metrics.melt_metrics.mem_gib" : 3.75,
-  "Module01Test.Module01Metrics.Module01Metrics.wham_metrics.mem_gib" : 3.75,
+  "Module01Test.Module01Metrics.depth_metrics.mem_gib" : 3.75,
+  "Module01Test.Module01Metrics.manta_metrics.mem_gib" : 3.75,
+  "Module01Test.Module01Metrics.melt_metrics.mem_gib" : 3.75,
+  "Module01Test.Module01Metrics.wham_metrics.mem_gib" : 3.75,
 
   "Module01Test.Module01.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module01Test.Module01.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",

--- a/test/module03/Module03Test.test_large.json
+++ b/test/module03/Module03Test.test_large.json
@@ -117,8 +117,8 @@
   "Module03Test.Module03Metrics.baseline_filtered_pesr_vcf" : "gs://gatk-sv-resources/test/module03/large/output/test_large.filtered_pesr_merged.vcf.gz",
   "Module03Test.Module03Metrics.baseline_filtered_depth_vcf" : "gs://gatk-sv-resources/test/module03/large/output/test_large.depth.outliers_removed.vcf.gz",
 
-  "Module03Test.Module03Metrics.Module03Metrics.PESR_VCF_Metrics.mem_gib" : "3.75",
-  "Module03Test.Module03Metrics.Module03Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
+  "Module03Test.Module03Metrics.PESR_VCF_Metrics.mem_gib" : "3.75",
+  "Module03Test.Module03Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
 
   "Module03Test.Module03.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",
   "Module03Test.Module03.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",

--- a/test/module04/Module04Test.test_large.json
+++ b/test/module04/Module04Test.test_large.json
@@ -117,8 +117,8 @@
   "Module04Test.Module04Metrics.baseline_genotyped_pesr_vcf" : "gs://gatk-sv-resources/test/module04/large/output/test_large.pesr.vcf.gz",
   "Module04Test.Module04Metrics.baseline_genotyped_depth_vcf" : "gs://gatk-sv-resources/test/module04/large/output/test_large.depth.vcf.gz",
 
-  "Module04Test.Module04Metrics.Module04Metrics.PESR_VCF_Metrics.mem_gib" : "3.75",
-  "Module04Test.Module04Metrics.Module04Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
+  "Module04Test.Module04Metrics.PESR_VCF_Metrics.mem_gib" : "3.75",
+  "Module04Test.Module04Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
 
   "Module04Test.Module04.sv_base_mini_docker": "gatksv/sv-base-mini:b3af2e3",
   "Module04Test.Module04.sv_pipeline_docker": "cwhelan/sv-pipeline:cw_single_sample_fixes_edd44d",

--- a/test/module05_06/Module05_06Test.test_large.json
+++ b/test/module05_06/Module05_06Test.test_large.json
@@ -117,8 +117,8 @@
   "Module05_06Test.Module05_06Metrics.baseline_final_vcf" : "gs://gatk-sv-resources/test/module0506/large/output/test_large.resolved_regenotyped.vcf.gz",
   "Module05_06Test.Module05_06Metrics.baseline_cleaned_vcf" : "gs://gatk-sv-resources/test/module0506/large/output/test_large.cleaned.vcf.gz",
 
-  "Module05_06Test.Module05_06Metrics.Module05_06Metrics.Final_VCF_Metrics.mem_gib" : "3.75",
-  "Module05_06Test.Module05_06Metrics.Module05_06Metrics.Cleaned_VCF_Metrics.mem_gib" : "3.75",
+  "Module05_06Test.Module05_06Metrics.Final_VCF_Metrics.mem_gib" : "3.75",
+  "Module05_06Test.Module05_06Metrics.Cleaned_VCF_Metrics.mem_gib" : "3.75",
 
   "Module05_06Test.Module05_06.bin_exclude": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/bin_exclude.hg38.bed.gz",
   "Module05_06Test.Module05_06.contig_list": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",

--- a/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
+++ b/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
@@ -100,11 +100,11 @@
     "TCGA-W9-A837-10A-01D-A706-36"
   ],
 
-  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.GATKSVPipelineSingleSample.SingleSampleMetrics.baseline_cleaned_vcf": "gs://gatk-sv-resources/test/clinical/na19240/output/test_na19240.cleaned.newmcnv.vcf.gz",
-  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.GATKSVPipelineSingleSample.SingleSampleMetrics.baseline_final_vcf": "gs://gatk-sv-resources/test/clinical/na19240/output/test_na19240.cleaned.filter_depth_lt_5000.filter_by_SM-GN4BI_gt.filter_by_ref_panel.reset_filters.final_cleanup.newmcnv.vcf.gz",
-  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.GATKSVPipelineSingleSample.SingleSampleMetrics.baseline_genotyped_pesr_vcf": "gs://gatk-sv-resources/test/clinical/na19240/output/test_na19240.pesr.vcf.gz",
-  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.GATKSVPipelineSingleSample.SingleSampleMetrics.baseline_genotyped_depth_vcf": "gs://gatk-sv-resources/test/clinical/na19240/output/test_na19240.depth.vcf.gz",
-  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.GATKSVPipelineSingleSample.SingleSampleMetrics.baseline_non_genotyped_unique_depth_calls_vcf": "gs://gatk-sv-resources/test/clinical/na19240/output/test_na19240.cleaned.filter_depth_lt_5000.unique_SM-GN4BI_depth_non_alt_gt.with_vargq.vcf.gz",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.SingleSampleMetrics.baseline_cleaned_vcf": "gs://gatk-sv-resources/test/clinical/na19240/output/test_na19240.cleaned.newmcnv.vcf.gz",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.SingleSampleMetrics.baseline_final_vcf": "gs://gatk-sv-resources/test/clinical/na19240/output/test_na19240.cleaned.filter_depth_lt_5000.filter_by_SM-GN4BI_gt.filter_by_ref_panel.reset_filters.final_cleanup.newmcnv.vcf.gz",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.SingleSampleMetrics.baseline_genotyped_pesr_vcf": "gs://gatk-sv-resources/test/clinical/na19240/output/test_na19240.pesr.vcf.gz",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.SingleSampleMetrics.baseline_genotyped_depth_vcf": "gs://gatk-sv-resources/test/clinical/na19240/output/test_na19240.depth.vcf.gz",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.SingleSampleMetrics.baseline_non_genotyped_unique_depth_calls_vcf": "gs://gatk-sv-resources/test/clinical/na19240/output/test_na19240.cleaned.filter_depth_lt_5000.unique_SM-GN4BI_depth_non_alt_gt.with_vargq.vcf.gz",
   "GATKSVPipelineSingleSampleTest.PlotMetrics.sv_pipeline_base_docker": "gatksv/sv-pipeline-base:b3af2e3",
 
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.batch" : "test_na19240",

--- a/wdl/AnnotateChromosome.wdl
+++ b/wdl/AnnotateChromosome.wdl
@@ -120,8 +120,8 @@ task AnnotateIntervals {
       ~{vcf} \
       ~{prefix}.~{intervals_set}.vcf
     
-    orig=$( zcat ~{vcf} | cut -f1 | grep -cv "^#" )
-    new=$( cut -f1 ~{prefix}.~{intervals_set}.vcf | grep -cv "^#" )
+    orig=$( zcat ~{vcf} | cut -f1 | grep -cv "^#" || true )
+    new=$( cut -f1 ~{prefix}.~{intervals_set}.vcf | grep -cv "^#" || true )
     
     if [ "$new" -ne "$orig" ]; then
       echo "ANNOTATED VCF DOES NOT HAVE THE SAME NUMBER OF RECORDS AS INPUT VCF ($new vs $orig)"
@@ -183,8 +183,8 @@ task MergeAnnotations {
     bgzip ~{prefix}.annotated.vcf
     tabix ~{prefix}.annotated.vcf.gz
     
-    orig=$( zcat ~{vcf} | cut -f1 | grep -cv "^#" )
-    new=$( zcat ~{prefix}.annotated.vcf.gz | cut -f1 | grep -cv "^#")
+    orig=$( zcat ~{vcf} | cut -f1 | grep -cv "^#" || true)
+    new=$( zcat ~{prefix}.annotated.vcf.gz | cut -f1 | grep -cv "^#" || true)
     if [ "$new" -ne "$orig" ]; then
       echo "ANNOTATED VCF DOES NOT HAVE THE SAME NUMBER OF RECORDS AS INPUT VCF ($new vs $orig)"
       exit 1

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -22,6 +22,10 @@ import "Structs.wdl"
 # Runs Modules 00abc, 01, 03.MergePesrVcfs, 04, 05/06
 
 workflow GATKSVPipelineSingleSample {
+  meta {
+    allowNestedInputs: true
+  }
+
   input {
     # Batch info
     String batch

--- a/wdl/GATKSVPipelineSingleSampleTest.wdl
+++ b/wdl/GATKSVPipelineSingleSampleTest.wdl
@@ -4,6 +4,10 @@ import "GATKSVPipelineSingleSample.wdl" as module
 import "TestUtils.wdl" as utils
 
 workflow GATKSVPipelineSingleSampleTest {
+  meta {
+    allowNestedInputs: true
+  }
+
   input {
     String test_name
     String case_sample

--- a/wdl/Module01Test.wdl
+++ b/wdl/Module01Test.wdl
@@ -5,6 +5,10 @@ import "Module01Metrics.wdl" as metrics
 import "TestUtils.wdl" as utils
 
 workflow Module01Test {
+  meta {
+    allowNestedInputs: true
+  }
+
   input {
     String test_name
     Array[String] samples

--- a/wdl/Module03Test.wdl
+++ b/wdl/Module03Test.wdl
@@ -5,6 +5,10 @@ import "Module03Metrics.wdl" as metrics
 import "TestUtils.wdl" as utils
 
 workflow Module03Test {
+  meta {
+    allowNestedInputs: true
+  }
+
   input {
     String test_name
     Array[String] samples

--- a/wdl/Module04Test.wdl
+++ b/wdl/Module04Test.wdl
@@ -5,6 +5,10 @@ import "Module04Metrics.wdl" as metrics
 import "TestUtils.wdl" as utils
 
 workflow Module04Test {
+  meta {
+    allowNestedInputs: true
+  }
+
   input {
     String test_name
     Array[String] samples

--- a/wdl/Module05_06Test.wdl
+++ b/wdl/Module05_06Test.wdl
@@ -5,6 +5,10 @@ import "Module05_06Metrics.wdl" as metrics
 import "TestUtils.wdl" as utils
 
 workflow Module05_06Test {
+  meta {
+    allowNestedInputs: true
+  }
+
   input {
     String test_name
     Array[String] samples


### PR DESCRIPTION
This fixes another error that cropped up in the annotation module with empty shards (ie chromsome-shard vcfs with no variants). The only change to logic is in `AnnotateChromosome.wdl`. Although `svtk annotate` had been modified to not fail in this case, the subsequent `grep` commands that counted variants could return with a non-zero exit code and cause the entire command block to fail.

The other changed files are updates to make WDLs and inputs validate with cromwell/womtool v 51+.