### PR TITLE
Fix one more empty-file bug in Module07

### DIFF
--- a/wdl/ChromosomeAlleleFrequencies.wdl
+++ b/wdl/ChromosomeAlleleFrequencies.wdl
@@ -105,7 +105,11 @@ task ShardVcf {
       ~{contig}.vcf.gz \
       ~{sv_per_shard} \
       "vcf.shard."
-  
+
+    # if there were no shards created just make an empty one
+    if [ ! -e vcf.shard.000000.vcf.gz ]; then
+      cp ~{contig}.vcf.gz vcf.shard.000000.vcf.gz
+    fi
   >>>
   
   #########################


### PR DESCRIPTION
This fixes one more error that can occur in Module07 when a sample has no variants called on a contig. Modified the `ChromosomeAlleleFrequencies` workflow's `ShardVcf` task to always create at least one VCF shard (an empty one), even if there are no variants in the input VCF. 

I was able to verify that the original input VCF to Module07 that caused this error is now able to run through to completion of Module07 successfully.