### PR TITLE
Scatter and reduce RAM in MergeCohortVcfs for scaling

### DIFF
--- a/test/module04/MergeCohortVcfs.test.json
+++ b/test/module04/MergeCohortVcfs.test.json
@@ -2,5 +2,7 @@
   "MergeCohortVcfs.sv_pipeline_docker": "epiercehoffman/sv-pipeline:eph_records_match_by_chrom_mergevcfs-4a380e0",
   "MergeCohortVcfs.pesr_vcfs": ["gs://gatk-sv-resources/test/module03/large/output/test_large.filtered_pesr_merged.vcf.gz"],
   "MergeCohortVcfs.depth_vcfs": ["gs://gatk-sv-resources/test/module03/large/output/test_large.depth.outliers_removed.vcf.gz"],
-  "MergeCohortVcfs.cohort": "test_large"
+  "MergeCohortVcfs.cohort": "test_large",
+  "MergeCohortVcfs.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
+  "MergeCohortVcfs.contig_list": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list"
 }

--- a/wdl/MergeCohortVcfs.wdl
+++ b/wdl/MergeCohortVcfs.wdl
@@ -23,7 +23,8 @@ workflow MergeCohortVcfs {
     RuntimeAttr? runtime_attr_cohort_sort
     RuntimeAttr? runtime_attr_cohort_combined
     RuntimeAttr? runtime_attr_cluster_dups_combined
-    RuntimeAttr? runtime_attr_concat_bed
+    RuntimeAttr? runtime_attr_concat_masterclusterdups
+    RuntimeAttr? runtime_attr_concat_clustercombined
   }
 
   Array[Array[String]] contigs = read_tsv(contig_list)
@@ -78,7 +79,7 @@ workflow MergeCohortVcfs {
       bed_shards = MakeClusterDupsCombinedBed.lookup,
       filename = cohort + ".master_cluster_dups.bed",
       sv_base_mini_docker = sv_base_mini_docker,
-      runtime_attr_override = runtime_attr_concat_bed
+      runtime_attr_override = runtime_attr_concat_masterclusterdups
   }
 
   call ConcatBed as ConcatClusterCombinedBed {
@@ -86,7 +87,7 @@ workflow MergeCohortVcfs {
       bed_shards = MakeClusterDupsCombinedBed.cluster_combined,
       filename = cohort + ".cluster.combined.bed",
       sv_base_mini_docker = sv_base_mini_docker,
-      runtime_attr_override = runtime_attr_concat_bed
+      runtime_attr_override = runtime_attr_concat_clustercombined
   }
 
   output {

--- a/wdl/MergeCohortVcfs.wdl
+++ b/wdl/MergeCohortVcfs.wdl
@@ -15,13 +15,18 @@ workflow MergeCohortVcfs {
     Array[File] depth_vcfs    # Filtered depth VCFs across batches
     Array[File] pesr_vcfs     # Filtered PESR VCFs across batches
     String cohort             # Cohort name or project prefix for all cohort-level outputs
+    File contig_list
     String sv_pipeline_docker
+    String sv_base_mini_docker
     RuntimeAttr? runtime_attr_merge_pesr
     RuntimeAttr? runtime_attr_merge_depth
     RuntimeAttr? runtime_attr_cohort_sort
     RuntimeAttr? runtime_attr_cohort_combined
     RuntimeAttr? runtime_attr_cluster_dups_combined
+    RuntimeAttr? runtime_attr_concat_bed
   }
+
+  Array[Array[String]] contigs = read_tsv(contig_list)
 
   call MergeVcfs as MergePESRVcfs {
     input:
@@ -56,24 +61,41 @@ workflow MergeCohortVcfs {
       runtime_attr_override = runtime_attr_cohort_combined
   }
 
-  call MakeClusterDupsCombinedBed {
-    input:
-      cohort_combined = MakeCohortCombinedBed.cohort_combined,
-      cohort_cluster = MergeDepthVcfs.cluster,
-      cohort = cohort,
-      sv_pipeline_docker = sv_pipeline_docker,
-      runtime_attr_override = runtime_attr_cluster_dups_combined
+  scatter (contig in contigs) {
+    call MakeClusterDupsCombinedBed {
+      input:
+        cohort_combined = MakeCohortCombinedBed.cohort_combined,
+        cohort_cluster = MergeDepthVcfs.cluster,
+        cohort = cohort,
+        contig = contig[0],
+        sv_pipeline_docker = sv_pipeline_docker,
+        runtime_attr_override = runtime_attr_cluster_dups_combined
+    }
   }
 
+  call ConcatBed as ConcatMasterClusterDupsBed {
+    input: 
+      bed_shards = MakeClusterDupsCombinedBed.lookup,
+      filename = cohort + ".master_cluster_dups.bed",
+      sv_base_mini_docker = sv_base_mini_docker,
+      runtime_attr_override = runtime_attr_concat_bed
+  }
 
+  call ConcatBed as ConcatClusterCombinedBed {
+    input: 
+      bed_shards = MakeClusterDupsCombinedBed.cluster_combined,
+      filename = cohort + ".cluster.combined.bed",
+      sv_base_mini_docker = sv_base_mini_docker,
+      runtime_attr_override = runtime_attr_concat_bed
+  }
 
   output {
     File cohort_pesr_vcf = MergePESRVcfs.merged_vcf
     File cohort_depth_vcf = MergeDepthVcfs.merged_vcf
     File cohort_combined = MakeCohortCombinedBed.cohort_combined
     File cohort_sort = MakeCohortSortBed.cohort_sort
-    File lookup = MakeClusterDupsCombinedBed.lookup
-    File cluster_combined = MakeClusterDupsCombinedBed.cluster_combined
+    File lookup = ConcatMasterClusterDupsBed.concat_bed
+    File cluster_combined = ConcatClusterCombinedBed.concat_bed
   }
 }
 
@@ -269,6 +291,7 @@ task MakeClusterDupsCombinedBed {
     File cohort_combined
     File cohort_cluster
     String cohort
+    String contig
     String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
@@ -284,23 +307,28 @@ task MakeClusterDupsCombinedBed {
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 
   output {
-    File lookup = "~{cohort}.master_cluster_dups.bed"
-    File cluster_combined="~{cohort}.cluster.combined.bed"
+    File lookup = "~{contig}.master_cluster_dups.bed"
+    File cluster_combined="~{contig}.cluster.combined.bed"
   }
   command <<<
 
     set -euxo pipefail
+    # select rows of BED files pertaining to contig - chrom is 1st column of each BED file
+    awk -F "\t" -v OFS="\t" '{ if ($1 == "~{contig}") { print > "~{contig}.cohort.combined.bed" } }' ~{cohort_combined}
+    awk -F "\t" -v OFS="\t" '{ if ($1 == "~{contig}") { print > "~{contig}.cluster.bed" } }' ~{cohort_cluster}
     python3 <<CODE
+    import sys
     samp={}
     var={}
-    with open("~{cohort_combined}","r") as f: # for EACH variant ID, a list of duplicate variants and samples
+    with open("~{contig}.cohort.combined.bed","r") as f: # for EACH variant ID, a list of duplicate variants and samples
         for line in f:
             dat=line.split('\t')        
             for variant in dat[3].split(":")[0:-1]:
                 samp[variant]=dat[4].split(',')[0:-1]
                 var[variant]=dat[3].split(":")[0:-1]
-    with open("~{cohort}.master_cluster_dups.bed",'w') as g: # Using cluster.bed, for each 
-        with open("~{cohort_cluster}","r") as f:
+    print("Read ~{contig} cohort combined into dictionary", file = sys.stderr)
+    with open("~{contig}.master_cluster_dups.bed",'w') as g: # Using cluster.bed, for each 
+        with open("~{contig}.cluster.bed","r") as f:
             for line in f:
                 samples=[]
                 variants=[]
@@ -311,8 +339,9 @@ task MakeClusterDupsCombinedBed {
                     variants=variants+var[variant]
                     variants=list(set(variants))
                 g.write(dat[0]+'\t'+dat[1]+'\t'+dat[2]+'\t'+dat[3]+'\t'+dat[4]+'\t'+dat[5]+'\t'+":".join(variants)+':\t'+str(len(samples))+'\n')
-    with open("~{cohort}.cluster.combined.bed",'w') as g:
-        with open("~{cohort_cluster}","r") as f:
+    print("Wrote ~{contig} master cluster dups", file = sys.stderr)
+    with open("~{contig}.cluster.combined.bed",'w') as g:
+        with open("~{contig}.cluster.bed","r") as f:
             for line in f:
                 samples=[]
                 variants=[]
@@ -323,6 +352,7 @@ task MakeClusterDupsCombinedBed {
                     variants=variants+var[variant]
                     variants=list(set(variants))
                 g.write(dat[0]+'\t'+dat[1]+'\t'+dat[2]+'\t'+dat[3]+'\t'+dat[4]+'\t'+dat[5]+'\t'+":".join(variants)+':\t'+','.join(samples)+',\n')
+    print("Wrote ~{contig} cohort combined", file = sys.stderr)
     CODE
   >>>
   runtime {
@@ -331,6 +361,44 @@ task MakeClusterDupsCombinedBed {
     disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
     docker: sv_pipeline_docker
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
+  }
+}
+
+task ConcatBed {
+  input {
+    Array[File] bed_shards
+    String filename
+    String sv_base_mini_docker
+    RuntimeAttr? runtime_attr_override
+  }
+
+  RuntimeAttr default_attr = object {
+    cpu_cores: 1, 
+    mem_gb: 3.75, 
+    disk_gb: 10,
+    boot_disk_gb: 10,
+    preemptible_tries: 3,
+    max_retries: 1
+  }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+  output {
+    File concat_bed = "~{filename}"
+  }
+  command <<<
+    set -euxo pipefail
+    while read bed_shard; do
+      cat $bed_shard >> ~{filename} # all BED files are headless and sorted so can just concatenate in order
+    done < ~{write_lines(bed_shards)}
+  >>>
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: sv_base_mini_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }

--- a/wdl/MergeCohortVcfs.wdl
+++ b/wdl/MergeCohortVcfs.wdl
@@ -318,7 +318,6 @@ task MakeClusterDupsCombinedBed {
     awk -F "\t" -v OFS="\t" '{ if ($1 == "~{contig}") { print > "~{contig}.cohort.combined.bed" } }' ~{cohort_combined}
     awk -F "\t" -v OFS="\t" '{ if ($1 == "~{contig}") { print > "~{contig}.cluster.bed" } }' ~{cohort_cluster}
     python3 <<CODE
-    import sys
     # dictionary of (samples, varIDs) for de-duplicated variant for EACH varID corresponding to that unique variant
     varID_data = {} 
     with open("~{contig}.cohort.combined.bed","r") as f: # for EACH variant ID, a list of duplicate variants and samples

--- a/wdl/MergeCohortVcfs.wdl
+++ b/wdl/MergeCohortVcfs.wdl
@@ -299,7 +299,7 @@ task MakeClusterDupsCombinedBed {
 
   RuntimeAttr default_attr = object {
     cpu_cores: 1, 
-    mem_gb: 6, 
+    mem_gb: 3.75, 
     disk_gb: 10,
     boot_disk_gb: 10,
     preemptible_tries: 3,


### PR DESCRIPTION
### Changes
* Scatter MakeClusterDupsCombinedBed task by chromosome, and add concatenation steps to re-join genome-wide BED files
* Reduce RAM in MakeClusterDupsCombinedBed task by changing dictionary structure, using references to repetitive lists rather than making copies
* Set new memory defaults to reflect reduction in RAM after changes
* Update test JSON with contig list and mini docker for scatter/concat tasks

### Testing
* Accuracy testing: ran MergeCohortVcfs.wdl on GMKF cohort (job ID: `8234b329-5cb3-402a-8209-999c9ebb288f`) and verified output was identical to previous version of master (apart from a different order of sample & variant IDs in the BED files). The MakeClusterDupsCombinedBed task & concatenation tasks cost about 2 cents for this cohort, so although the scattering is not necessary for cohorts of this size, the extra spin-up costs associated with sharding are minimal.
* Stress testing: ran MergeCohortVcfs.wdl on Module01 calls from gnomAD-v3 and observed greatly reduced memory for MakeClusterDupsCombinedBed task (from >400 GB and still OOM to a max of 8.21 GB RAM per shard), making scaling to ~140k genomes possible for this step