### PR TITLE
Single sample pipeline CTX BND representation issues

### DIFF
--- a/inputs/GATKSVPipelineBatch.ref_panel_1kg.json
+++ b/inputs/GATKSVPipelineBatch.ref_panel_1kg.json
@@ -782,7 +782,7 @@
   "GATKSVPipelineBatch.sv_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base:tb_update_gcnv_version_88bfceb",
   "GATKSVPipelineBatch.sv_pipeline_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline-base:tb_update_gcnv_version_88bfceb",
   "GATKSVPipelineBatch.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "GATKSVPipelineBatch.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "GATKSVPipelineBatch.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "GATKSVPipelineBatch.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineBatch.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",

--- a/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
+++ b/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json
@@ -33,7 +33,7 @@
   "GATKSVPipelineSingleSample.sv_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base:tb_update_gcnv_version_88bfceb",
   "GATKSVPipelineSingleSample.sv_pipeline_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline-base:tb_update_gcnv_version_88bfceb",
   "GATKSVPipelineSingleSample.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "GATKSVPipelineSingleSample.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "GATKSVPipelineSingleSample.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",

--- a/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json
+++ b/inputs/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json
@@ -34,7 +34,7 @@
   "GATKSVPipelineSingleSample.sv_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base:tb_update_gcnv_version_88bfceb",
   "GATKSVPipelineSingleSample.sv_pipeline_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline-base:tb_update_gcnv_version_88bfceb",
   "GATKSVPipelineSingleSample.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "GATKSVPipelineSingleSample.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "GATKSVPipelineSingleSample.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",

--- a/scripts/docker/update_json_docker.sh
+++ b/scripts/docker/update_json_docker.sh
@@ -68,7 +68,7 @@ JSONS=$(printf "%s "  "${JSON_ARR[@]}")
 for name in "${DOCKER_NAME_ARR[@]}"; do
   docker_var=$(tr '-' '_' <<< "${name}")"_docker"
   docker_regex='\.'"${docker_var}"'"\s*:\s*".+\/.+:.+"'
-  cmd="perl -pi -e 's/${docker_regex}/.${docker_var}\": \"${DOCKER_ROOT}\/${name}:${DOCKER_TAG}\"/g' ${JSONS}"
+  cmd="perl -pi -e 's|${docker_regex}|.${docker_var}\": \"${DOCKER_ROOT}\/${name}:${DOCKER_TAG}\"|g' ${JSONS}"
   echo "${cmd}"
   eval "${cmd}"
 done

--- a/src/sv-pipeline/scripts/single_sample/update_variant_representations.py
+++ b/src/sv-pipeline/scripts/single_sample/update_variant_representations.py
@@ -74,7 +74,10 @@ def make_reciprocal_translocation_bnds(record, ref_fasta):
     chr1_pos2 = chr1_pos1 + 1
     chr1_pos2_ref = get_ref_base(chr1, chr1_pos2, ref_fasta)
     chr2 = record.info['CHR2']
-    chr2_pos1 = record.stop
+    if 'END2' in record.info.keys():
+        chr2_pos1 = int(record.info['END2'])
+    else:
+        chr2_pos1 = record.stop
     chr2_pos1_ref = get_ref_base(chr2, chr2_pos1, ref_fasta)
     chr2_pos2 = chr2_pos1 + 1
     chr2_pos2_ref = get_ref_base(chr2, chr2_pos2, ref_fasta)

--- a/test/batch/GATKSVPipelineBatch.test_large.json
+++ b/test/batch/GATKSVPipelineBatch.test_large.json
@@ -351,7 +351,7 @@
   "GATKSVPipelineBatch.sv_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base:tb_update_gcnv_version_88bfceb",
   "GATKSVPipelineBatch.sv_pipeline_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline-base:tb_update_gcnv_version_88bfceb",
   "GATKSVPipelineBatch.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "GATKSVPipelineBatch.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "GATKSVPipelineBatch.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "GATKSVPipelineBatch.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineBatch.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00a/Module00aBatch.test_large.json
+++ b/test/module00a/Module00aBatch.test_large.json
@@ -18,7 +18,7 @@
 
   "Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatch.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module00aBatch.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module00aBatch.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module00aBatch.delly_docker": "gatksv/delly:8645aa",
   "Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",

--- a/test/module00a/Module00aBatch.test_small.json
+++ b/test/module00a/Module00aBatch.test_small.json
@@ -18,7 +18,7 @@
 
   "Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatch.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module00aBatch.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module00aBatch.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",
   "Module00aBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00a/Module00aBatchTest.test_large.json
+++ b/test/module00a/Module00aBatchTest.test_large.json
@@ -454,7 +454,7 @@
 
   "Module00aBatchTest.Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatchTest.Module00aBatch.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module00aBatchTest.Module00aBatch.delly_docker": "gatksv/delly:8645aa",
   "Module00aBatchTest.Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatchTest.Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",

--- a/test/module00a/Module00aBatchTest.test_small.json
+++ b/test/module00a/Module00aBatchTest.test_small.json
@@ -75,7 +75,7 @@
 
   "Module00aBatchTest.Module00aBatch.samtools_cloud_docker": "gatksv/samtools-cloud:b3af2e3",
   "Module00aBatchTest.Module00aBatch.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module00aBatchTest.Module00aBatch.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module00aBatchTest.Module00aBatch.manta_docker": "gatksv/manta:8645aa",
   "Module00aBatchTest.Module00aBatch.melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:8645aa",
   "Module00aBatchTest.Module00aBatch.wham_docker": "gatksv/wham:8645aa",

--- a/test/module00b/Module00b.test_large.json
+++ b/test/module00b/Module00b.test_large.json
@@ -1,7 +1,7 @@
 {
   "Module00b.run_vcf_qc" : "true",
   "Module00b.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module00b.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module00b.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module00b.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00b.wgd_scoring_mask": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/wgd_scoring_mask.hg38.gnomad_v3.bed",
   "Module00b.genome_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.genome",

--- a/test/module00b/Module00b.test_small.json
+++ b/test/module00b/Module00b.test_small.json
@@ -1,7 +1,7 @@
 {
   "Module00b.run_vcf_qc" : "true",
   "Module00b.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module00b.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module00b.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module00b.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00b.wgd_scoring_mask": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/wgd_scoring_mask.hg38.gnomad_v3.bed",
   "Module00b.genome_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.genome",

--- a/test/module00c/Module00c.test_large.json
+++ b/test/module00c/Module00c.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module00c.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module00c.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module00c.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00c.test_small.json
+++ b/test/module00c/Module00c.test_small.json
@@ -1,6 +1,6 @@
 {
   "Module00c.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module00c.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module00c.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_baf_from_vcf.json
+++ b/test/module00c/Module00cTest.test_baf_from_vcf.json
@@ -440,7 +440,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module00cTest.Module00c.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module00cTest.Module00c.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_large.json
+++ b/test/module00c/Module00cTest.test_large.json
@@ -440,7 +440,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module00cTest.Module00c.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module00cTest.Module00c.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module00c/Module00cTest.test_small.json
+++ b/test/module00c/Module00cTest.test_small.json
@@ -60,7 +60,7 @@
   ],
 
   "Module00cTest.Module00c.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module00cTest.Module00c.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module00cTest.Module00c.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module00cTest.Module00c.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "Module00cTest.Module00c.cnmops_docker": "gatksv/cnmops:b3af2e3",
   "Module00cTest.Module00c.linux_docker" : "ubuntu:18.04",

--- a/test/module01/Module01.test_large.json
+++ b/test/module01/Module01.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module01.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module01.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module01.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
 
   "Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01.test_small.json
+++ b/test/module01/Module01.test_small.json
@@ -1,6 +1,6 @@
 {
   "Module01.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module01.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module01.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
 
   "Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01Test.test_large.json
+++ b/test/module01/Module01Test.test_large.json
@@ -125,7 +125,7 @@
   "Module01Test.Module01Metrics.wham_metrics.mem_gib" : 3.75,
 
   "Module01Test.Module01.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module01Test.Module01.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module01Test.Module01.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
 
   "Module01Test.Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01Test.Module01.depth_flags": "--merge-coordinates",

--- a/test/module01/Module01Test.test_small.json
+++ b/test/module01/Module01Test.test_small.json
@@ -25,7 +25,7 @@
   "Module01Test.Module01Metrics.baseline_melt_vcf" : "gs://gatk-sv-resources/test/module01/small/output/test_small.melt.vcf.gz",
 
   "Module01Test.Module01.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module01Test.Module01.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module01Test.Module01.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
 
   "Module01Test.Module01.contigs": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "Module01Test.Module01.depth_flags": "--merge-coordinates",

--- a/test/module02/Module02.test_large.json
+++ b/test/module02/Module02.test_large.json
@@ -1,5 +1,5 @@
 {
-  "Module02.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module02.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
   "Module02.sv_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base:tb_update_gcnv_version_88bfceb",

--- a/test/module02/Module02.test_small.json
+++ b/test/module02/Module02.test_small.json
@@ -1,5 +1,5 @@
 {
-  "Module02.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module02.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
   "Module02.sv_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base:tb_update_gcnv_version_88bfceb",

--- a/test/module02/Module02Test.test_large.json
+++ b/test/module02/Module02Test.test_large.json
@@ -114,7 +114,7 @@
   "Module02Test.Module02Metrics.linux_docker" : "ubuntu:18.04",
   "Module02Test.Module02Metrics.contig_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list",
 
-  "Module02Test.Module02.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module02Test.Module02.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module02Test.Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02Test.Module02.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
   "Module02Test.Module02.sv_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base:tb_update_gcnv_version_88bfceb",

--- a/test/module02/Module02Test.test_small.json
+++ b/test/module02/Module02Test.test_small.json
@@ -19,7 +19,7 @@
   "Module02Test.Module02Metrics.linux_docker" : "ubuntu:18.04",
   "Module02Test.Module02Metrics.contig_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list",
 
-  "Module02Test.Module02.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module02Test.Module02.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module02Test.Module02.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module02Test.Module02.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
   "Module02Test.Module02.sv_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base:tb_update_gcnv_version_88bfceb",

--- a/test/module03/Module03.test_large.json
+++ b/test/module03/Module03.test_large.json
@@ -1,5 +1,5 @@
 {
-  "Module03.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module03.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module03.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
   "Module03.linux_docker" : "ubuntu:18.04",
 

--- a/test/module03/Module03Qc.test_large.json
+++ b/test/module03/Module03Qc.test_large.json
@@ -25,7 +25,7 @@
   "Module03Qc.werling_2018_tarball": "gs://gatk-sv-resources-secure/resources/Werling_2018_hg38.tar.gz",
 
   
-  "Module03Qc.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module03Qc.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module03Qc.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
   "Module03Qc.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
 

--- a/test/module03/Module03Test.test_large.json
+++ b/test/module03/Module03Test.test_large.json
@@ -120,7 +120,7 @@
   "Module03Test.Module03Metrics.PESR_VCF_Metrics.mem_gib" : "3.75",
   "Module03Test.Module03Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
 
-  "Module03Test.Module03.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module03Test.Module03.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module03Test.Module03.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
   "Module03Test.Module03.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04/MergeCohortVcfs.test.json
+++ b/test/module04/MergeCohortVcfs.test.json
@@ -1,5 +1,5 @@
 {
-  "MergeCohortVcfs.sv_pipeline_docker": "epiercehoffman/sv-pipeline:eph_records_match_by_chrom_mergevcfs-4a380e0",
+  "MergeCohortVcfs.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "MergeCohortVcfs.pesr_vcfs": ["gs://gatk-sv-resources/test/module03/large/output/test_large.filtered_pesr_merged.vcf.gz"],
   "MergeCohortVcfs.depth_vcfs": ["gs://gatk-sv-resources/test/module03/large/output/test_large.depth.outliers_removed.vcf.gz"],
   "MergeCohortVcfs.cohort": "test_large",

--- a/test/module04/Module04.test_large.json
+++ b/test/module04/Module04.test_large.json
@@ -1,6 +1,6 @@
 {
   "Module04.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module04.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module04.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module04.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04/Module04Test.test_large.json
+++ b/test/module04/Module04Test.test_large.json
@@ -121,7 +121,7 @@
   "Module04Test.Module04Metrics.Depth_VCF_Metrics.mem_gib" : "1.5",
 
   "Module04Test.Module04.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module04Test.Module04.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module04Test.Module04.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module04Test.Module04.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04Test.Module04.linux_docker" : "ubuntu:18.04",
 

--- a/test/module04b/Module04b.test.json
+++ b/test/module04b/Module04b.test.json
@@ -2,7 +2,7 @@
   "Module04b.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module04b.sv_pipeline_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline-base:tb_update_gcnv_version_88bfceb",
   "Module04b.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module04b.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module04b.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module04b.n_RdTest_bins": "100000",
   "Module04b.n_per_split": "5000",
 

--- a/test/module05_06/Module05_06.test_large.json
+++ b/test/module05_06/Module05_06.test_large.json
@@ -38,7 +38,7 @@
   "Module05_06.max_shards_per_chrom": 100,
   "Module05_06.min_variants_per_shard": 30,
 
-  "Module05_06.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module05_06.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module05_06.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
   "Module05_06.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module05_06.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",

--- a/test/module05_06/Module05_06Test.test_large.json
+++ b/test/module05_06/Module05_06Test.test_large.json
@@ -159,7 +159,7 @@
   "Module05_06Test.Module05_06.max_shards_per_chrom": 100,
   "Module05_06Test.Module05_06.min_variants_per_shard": 30,
 
-  "Module05_06Test.Module05_06.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "Module05_06Test.Module05_06.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "Module05_06Test.Module05_06.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
   "Module05_06Test.Module05_06.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "Module05_06Test.Module05_06.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",

--- a/test/module07/Module07.test.json
+++ b/test/module07/Module07.test.json
@@ -18,5 +18,5 @@
   "Module07.prefix" :       "Talkowski_SV_PCR-free_WGS_144",
 
   "Module07.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module07.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb"
+  "Module07.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818"
 }

--- a/test/module07/Module07Preprocessing.wdl.example.json
+++ b/test/module07/Module07Preprocessing.wdl.example.json
@@ -7,6 +7,6 @@
   "Module07Preprocessing.promoter_window": 1000, 
 
   "Module07Preprocessing.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "Module07Preprocessing.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb"
+  "Module07Preprocessing.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818"
 }
 

--- a/test/module07/PrepareGencode.wdl.example.json
+++ b/test/module07/PrepareGencode.wdl.example.json
@@ -7,6 +7,6 @@
   "PrepareGencode.promoter_window": 1000, 
 
   "PrepareGencode.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "PrepareGencode.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb"
+  "PrepareGencode.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818"
 }
 

--- a/test/mosaic/Mosaics.json
+++ b/test/mosaic/Mosaics.json
@@ -3,7 +3,7 @@
   "MosaicManualCheck.outlier": "gs://gatk-sv-resources/resources/outlier.txt",
   "MosaicManualCheck.famfile": "gs://gatk-sv-resources/test/module03/large/output/test_large.outlier_samples_removed.fam",
   "MosaicManualCheck.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
-  "MosaicManualCheck.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "MosaicManualCheck.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "MosaicManualCheck.agg_metrics": ["gs://gatk-sv-resources/test/module02/large/output/test_large.metrics"],
   "MosaicManualCheck.per_batch_clustered_pesr_vcf_list": ["gs://gatk-sv-resources/test/mosaic/pesr_list.txt"],
   "MosaicManualCheck.clustered_depth_vcfs": ["gs://gatk-sv-resources/test/module01/large/output/test_large.depth.vcf.gz"],

--- a/test/phase1/GATKSVPipelinePhase1.test_large.json
+++ b/test/phase1/GATKSVPipelinePhase1.test_large.json
@@ -2,7 +2,7 @@
   "GATKSVPipelinePhase1.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
   "GATKSVPipelinePhase1.sv_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base:tb_update_gcnv_version_88bfceb",
   "GATKSVPipelinePhase1.sv_pipeline_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline-base:tb_update_gcnv_version_88bfceb",
-  "GATKSVPipelinePhase1.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "GATKSVPipelinePhase1.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "GATKSVPipelinePhase1.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelinePhase1.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelinePhase1.linux_docker" : "ubuntu:18.04",

--- a/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
+++ b/test/single-sample/GATKSVPipelineSingleSampleTest.test_na19240.json
@@ -139,7 +139,7 @@
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base:tb_update_gcnv_version_88bfceb",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_base_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline-base:tb_update_gcnv_version_88bfceb",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-base-mini:tb_update_gcnv_version_88bfceb",
-  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:tb_update_gcnv_version_88bfceb",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_ctx_fixes_d1e9818",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "epiercehoffman/sv-pipeline-qc:eph_03qc_variables-e597d85",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "gatksv/sv-pipeline-rdtest:b3af2e3",
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.wham_docker": "gatksv/wham:8645aa",


### PR DESCRIPTION
This fixes a couple of bugs that cropped up in a single sample run that called a reciprocal translocation:

I was basing the second coordinate off of the END tag for the variant but in this case it had already been reset to POS + 1, so we should use the END2 tag, if it's available, for the second breakpoint.

The metrics module doesn't like encountering PASS BND records that don't have SVLEN -- modified the scripts to not try to gather SVLEN for BND records.