### PR TITLE
Regeno coverage medians handling: streamline and bug fixes

### DIFF
--- a/input_values/test_batch_large.json
+++ b/input_values/test_batch_large.json
@@ -1731,6 +1731,7 @@
   "qc_definitions" : "gs://gatk-sv-resources/test/batch/batch_sv.test_large.qc_definitions.tsv",
   "raw_sr_bothside_pass_files" : "gs://gatk-sv-resources/test/module04/large/output/test_large.genotype_SR_part2_bothside_pass.txt",
   "raw_sr_background_fail_files" : "gs://gatk-sv-resources/test/module04/large/output/test_large.genotype_SR_part2_background_fail.txt",
+  "regeno_coverage_medians": ["gs://gatk-sv-resources/test/module04b/input/test_large.regeno.coverage_medians_merged.bed"],
   "samples" : [
     "SM-BZNZQ",
     "SM-BZNZR",

--- a/test_input_templates/module04b/Module04b.test.json.tmpl
+++ b/test_input_templates/module04b/Module04b.test.json.tmpl
@@ -8,9 +8,9 @@
 
   "Module04b.cohort": {{ test_batch.batch_name | tojson }},
   "Module04b.contig_list": {{ reference_resources.primary_contigs_list | tojson }},
-  "Module04b.regeno_coverage_medians": ["gs://broad-dsde-methods-eph/Module04StressTest/Module04/2430c16a-23ee-44b4-9305-b35bcba352d9/call-GenotypeDepthPart2/GenotypeDepthPart2/f1483c4e-9e57-47ff-926f-3b354a2aa678/call-MergeRegenoCoverageMedians/test_large.regeno.coverage_medians_merged.bed"],
+  "Module04b.regeno_coverage_medians": {{ test_batch.regeno_coverage_medians | tojson }},
 
-  "Module04b.RD_depth_sepcutoffs": ["gs://talkowskicromwellresults/M04/Module04/89617399-fcaa-4aef-9759-7f3d04f328d3/call-GenotypeDepthPart1/GenotypeDepthPart1/dd257617-3e1f-47b5-b17b-2144c1931986/call-TrainRDGenotyping/TrainRDGenotyping/8b8ea223-1bc1-4e7b-a07c-ca2b47e8e699/call-UpdateCutoff/depth_sepcutoff.txt"],
+  "Module04b.RD_depth_sepcutoffs": [{{ test_batch.depth_gt_rd_sep_file | tojson }}],
 
   "Module04b.cohort_depth_vcf": {{ test_batch.cohort_depth_vcf | tojson }},
 
@@ -18,7 +18,7 @@
   "Module04b.batch_depth_vcfs": [{{ test_batch.filtered_depth_vcf | tojson }}],
   "Module04b.samples_lists": [{{ test_batch.cohort_samplelist | tojson }}],
 
-  "Module04b.depth_vcfs": ["gs://talkowskicromwellresults/M04/Module04/89617399-fcaa-4aef-9759-7f3d04f328d3/call-GenotypeDepthPart2/GenotypeDepthPart2/afcbb44e-d36a-44a1-b007-69b16d4f754a/call-ConcatGenotypedVcfs/test_large.depth.vcf.gz"],
+  "Module04b.depth_vcfs": [{{ test_batch.genotyped_depth_vcf | tojson }}],
   "Module04b.coveragefiles": [{{ test_batch.merged_coverage_file | tojson }}],
   "Module04b.coveragefile_idxs": [{{ test_batch.merged_coverage_file_idx| tojson }}],
   "Module04b.medianfiles": [{{ test_batch.medianfile | tojson }}],

--- a/test_input_templates/module04b/Module04b.test.json.tmpl
+++ b/test_input_templates/module04b/Module04b.test.json.tmpl
@@ -8,10 +8,7 @@
 
   "Module04b.cohort": {{ test_batch.batch_name | tojson }},
   "Module04b.contig_list": {{ reference_resources.primary_contigs_list | tojson }},
-  "Module04b.regeno_coverage_medians": [
-    "gs://broad-dsde-methods-eph/Module04StressTest/Module04/6d90e729-0cd1-4752-94b3-e0ad128c6dc4/call-GenotypeDepthPart2/GenotypeDepthPart2/2b962a21-897e-49ac-8055-118ba459f7e4/call-RDTestGenotypeOver5kb/shard-0/cacheCopy/gt5kb.aaaaaa.bed.median_geno",
-    "gs://broad-dsde-methods-eph/Module04StressTest/Module04/6d90e729-0cd1-4752-94b3-e0ad128c6dc4/call-GenotypeDepthPart2/GenotypeDepthPart2/2b962a21-897e-49ac-8055-118ba459f7e4/call-RDTestGenotypeOver5kb/shard-1/cacheCopy/gt5kb.aaaaab.bed.median_geno"
-  ],
+  "Module04b.regeno_coverage_medians": ["gs://broad-dsde-methods-eph/Module04StressTest/Module04/2430c16a-23ee-44b4-9305-b35bcba352d9/call-GenotypeDepthPart2/GenotypeDepthPart2/f1483c4e-9e57-47ff-926f-3b354a2aa678/call-MergeRegenoCoverageMedians/test_large.regeno.coverage_medians_merged.bed"],
 
   "Module04b.RD_depth_sepcutoffs": ["gs://talkowskicromwellresults/M04/Module04/89617399-fcaa-4aef-9759-7f3d04f328d3/call-GenotypeDepthPart1/GenotypeDepthPart1/dd257617-3e1f-47b5-b17b-2144c1931986/call-TrainRDGenotyping/TrainRDGenotyping/8b8ea223-1bc1-4e7b-a07c-ca2b47e8e699/call-UpdateCutoff/depth_sepcutoff.txt"],
 

--- a/wdl/GenotypeDepthPart2.wdl
+++ b/wdl/GenotypeDepthPart2.wdl
@@ -242,7 +242,7 @@ task MergeRegenoCoverageMedians {
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
     disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
-    docker: sv_pipeline_docker
+    docker: sv_base_mini_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }

--- a/wdl/GenotypeDepthPart2.wdl
+++ b/wdl/GenotypeDepthPart2.wdl
@@ -234,7 +234,7 @@ task MergeRegenoCoverageMedians {
     File regeno_coverage_medians = "~{batch}.regeno.coverage_medians_merged.bed"
   }
   command <<<
-    cat ~{sep=' ' regeno_coverage_medians_array} | fgrep -v "start" > ~{batch}.regeno.coverage_medians_merged.bed
+    cat ~{sep=' ' regeno_coverage_medians_array} | fgrep -v $'chr\tstart\tend\tcnvID' > ~{batch}.regeno.coverage_medians_merged.bed
   >>>
 
   runtime {

--- a/wdl/GenotypeDepthPart2.wdl
+++ b/wdl/GenotypeDepthPart2.wdl
@@ -36,6 +36,7 @@ workflow GenotypeDepthPart2 {
     RuntimeAttr? runtime_attr_integrate_depth_gq
     RuntimeAttr? runtime_attr_add_genotypes
     RuntimeAttr? runtime_attr_concat_vcfs
+    RuntimeAttr? runtime_attr_merge_regeno_cov_med
   }
 
   File bin_exclude_idx = bin_exclude + ".tbi"
@@ -144,6 +145,14 @@ workflow GenotypeDepthPart2 {
     }
   }
 
+  call MergeRegenoCoverageMedians {
+    input:
+      regeno_coverage_medians_array = RDTestGenotypeOver5kb.copy_states,
+      batch = batch,
+      sv_base_mini_docker = sv_base_mini_docker,
+      runtime_attr_override = runtime_attr_merge_regeno_cov_med
+  }
+
   call tasks04.ConcatGenotypedVcfs as ConcatGenotypedVcfs {
     input:
       lt5kb_vcfs = AddGenotypesUnder5kb.genotyped_vcf,
@@ -157,7 +166,7 @@ workflow GenotypeDepthPart2 {
   output {
     File genotyped_vcf = ConcatGenotypedVcfs.genotyped_vcf
     File genotyped_vcf_index = ConcatGenotypedVcfs.genotyped_vcf_index
-    Array[File] regeno_coverage_medians = RDTestGenotypeOver5kb.copy_states
+    File regeno_coverage_medians = MergeRegenoCoverageMedians.regeno_coverage_medians
   }
 }
 
@@ -192,6 +201,42 @@ task IntegrateDepthGq {
       ~{RD_vargq}
   
   >>>
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: sv_pipeline_docker
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
+  }
+}
+
+task MergeRegenoCoverageMedians {
+  input {
+    Array[File] regeno_coverage_medians_array
+    String batch
+    String sv_base_mini_docker
+    RuntimeAttr? runtime_attr_override
+  }
+
+  RuntimeAttr default_attr = object {
+    cpu_cores: 1, 
+    mem_gb: 3.75,
+    disk_gb: 10,
+    boot_disk_gb: 10,
+    preemptible_tries: 3,
+    max_retries: 1
+  }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+  output {
+    File regeno_coverage_medians = "~{batch}.regeno.coverage_medians_merged.bed"
+  }
+  command <<<
+    cat ~{sep=' ' regeno_coverage_medians_array} | fgrep -v "start" > ~{batch}.regeno.coverage_medians_merged.bed
+  >>>
+
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"

--- a/wdl/Module04.wdl
+++ b/wdl/Module04.wdl
@@ -266,7 +266,7 @@ workflow Module04 {
     File genotyped_depth_vcf_index = GenotypeDepthPart2.genotyped_vcf_index
     File genotyped_pesr_vcf = GenotypePESRPart2.genotyped_vcf
     File genotyped_pesr_vcf_index = GenotypePESRPart2.genotyped_vcf_index
-    Array[File] regeno_coverage_medians = GenotypeDepthPart2.regeno_coverage_medians
+    File regeno_coverage_medians = GenotypeDepthPart2.regeno_coverage_medians
   }
 }
 

--- a/wdl/Module04.wdl
+++ b/wdl/Module04.wdl
@@ -92,6 +92,7 @@ workflow Module04 {
     # Depth part 2
     RuntimeAttr? runtime_attr_integrate_depth_gq
     RuntimeAttr? runtime_attr_concat_vcfs
+    RuntimeAttr? runtime_attr_merge_regeno_cov_med
 
   }
 
@@ -248,7 +249,8 @@ workflow Module04 {
       runtime_attr_make_subset_vcf = runtime_attr_make_subset_vcf,
       runtime_attr_integrate_depth_gq = runtime_attr_integrate_depth_gq,
       runtime_attr_add_genotypes = runtime_attr_add_genotypes,
-      runtime_attr_concat_vcfs = runtime_attr_concat_vcfs
+      runtime_attr_concat_vcfs = runtime_attr_concat_vcfs,
+      runtime_attr_merge_regeno_cov_med = runtime_attr_merge_regeno_cov_med
   }
   output {
     File sr_bothside_pass = GenotypePESRPart2.bothside_pass

--- a/wdl/Module04b.wdl
+++ b/wdl/Module04b.wdl
@@ -185,6 +185,7 @@ workflow Module04b{
   }
   output{
     Array[File] regenotyped_depth_vcfs = select_first([ConcatRegenotypedVcfs.genotyped_vcf, depth_vcfs])
+    File number_regenotyped_file = MergeList.num_regeno_file
   }
 }
 
@@ -634,6 +635,7 @@ task MergeList {
   output {
     File master_regeno="~{prefix}.bed"
     Int num_regeno = read_int("regeno_num_lines.txt")
+    File num_regeno_file = "regeno_num_lines.txt"
   }
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])

--- a/wdl/Module04b.wdl
+++ b/wdl/Module04b.wdl
@@ -137,7 +137,7 @@ workflow Module04b{
       sv_base_mini_docker=sv_base_mini_docker,
       runtime_attr_override=runtime_attr_merge_list
   }
-  
+
   if (MergeList.num_regeno > 0) {
     scatter (i in range(length(batches))) {
       call g2.Regenotype as Genotype_2 {
@@ -184,7 +184,7 @@ workflow Module04b{
     }
   }
   output{
-    Array[File] regenotyped_depth_vcfs = if (MergeList.num_regeno > 0) then ConcatRegenotypedVcfs.genotyped_vcf else depth_vcfs
+    Array[File] regenotyped_depth_vcfs = select_first([ConcatRegenotypedVcfs.genotyped_vcf, depth_vcfs])
   }
 }
 

--- a/wdl/Module04b.wdl
+++ b/wdl/Module04b.wdl
@@ -630,7 +630,10 @@ task MergeList {
 
   command {
     cat ~{sep=' ' regeno_beds} | sort -k1,1V -k2,2n -k3,3n > ~{prefix}.bed
-    grep -c '[^[:space:]]' ~{prefix}.bed > regeno_num_lines.txt # count non-empty lines in regeno bed file to determine if empty or not
+    # count non-empty lines in regeno bed file to determine if empty or not --> proceed with regenotyping or stop here?
+    # the OR clause is to ignore return code = 1 because that isn't an error, it just means there were 0 matched lines (but don't ignore real error codes > 1)
+    NUM_REGENO=$(grep -c '[^[:space:]]' ~{prefix}.bed || [[ $? == 1 ]] ) 
+    echo $NUM_REGENO > regeno_num_lines.txt
   }
   output {
     File master_regeno="~{prefix}.bed"


### PR DESCRIPTION
### Updates
* Merge `regeno_coverage_medians` files for each batch before outputting from Module04, to make inputs/outputs for large datasets easier to wrangle
* Fix bug in 04b that would have improperly handled multi-batch `regeno_coverage_medians` (without merging files from 04, would have needed Array[Array[File]] input to account for multiple batches)
* Fix bug in 04b that failed when no variants to regenotype (#77)
  * New behavior: if the file from MergeList contains no non-empty lines (no variants to regenotype), the regenotyping is skipped and the output VCFs are just copies of the input VCFs
  * Also added an output to 04b called `number_regenotyped_file` which contains the number of lines from `MergeList`, so that it's easy to tell if regenotyping occurred (number > 0) or not (number = 0) without doing a `diff` on the input/output VCFs
* Formatting, indentation, and spacing improvements

### Testing
Completed:
* Tested running with one batch (`test_large` data) through Module04 and Module04b. It previously had 2 `regeno_coverage_medians` files, so the merge task in 04 was not superfluous & the effects of that change in 04b could be tested. It had 406 variants to regenotype, so it ran the full 04b workflow. Both workflows completed successfully and output was identical to latest master code. The default `regeno_coverage_medians` input to 04b was updated in the JSON template to use the file from this test run.
* Tested Module04 and Module04b two GMKF batches to confirm that a multi-batch run of Module04b was successful. It had over 60k variants to regenotype, so the full 04b workflow ran to completion.
* Tested partial workflow with dummy empty `regeno_beds` input to `MergeList` (all other inputs used `test_large` data) and verified that the run was successful, that the number of variants counted for regenotyping was 0 and that was reflected in the output file, that the regenotyping tasks were not executed, and that the output VCF was identical to the input depth VCF. 

Caveats:
* No comparison to latest master was made for multi-batch test because it took so long to run everything
* Did not test a full workflow with a real batch that produced empty `regeno_beds`