### PR TITLE
Add SV count outlier cutoff table to Module03 and bug fix for MasterVcfQC

### DIFF
--- a/dockerfiles/sv-pipeline-qc/Dockerfile
+++ b/dockerfiles/sv-pipeline-qc/Dockerfile
@@ -6,17 +6,21 @@ FROM ${SV_PIPELINE_BASE_R_IMAGE}
 
 # R packages
 ARG DEBIAN_FRONTEND=noninteractive
+ARG GERT_DEPENDENCY_R_PKGS="openssl credentials askpass"
 ARG SV_PIPELINE_R_PKGS="beeswarm devtools HardyWeinberg nloptr RColorBrewer vioplot zoo"
 ARG SLIM_R_LIB_CMD="find . -type d \\( -name \"help\" -o -name \"doc\" -o -name \"html\" -o -name \"htmlwidgets\" -o -name \"demo\" -o -name \"demodata\" -o -name \"examples\" -o -name \"exampleData\" -o -name \"unitTests\" -o -name \"tests\" -o -name \"testdata\" -o -name \"shiny\" \\) | xargs rm -rf"
 RUN apt-get -qqy update --fix-missing && \
     apt-get -qqy dist-upgrade && \
     apt-get -qqy install --no-install-recommends \
                  make cmake automake \
+                 libgit2-dev \
                  libssh2-1-dev \
                  libxml2-dev \
                  libssl-dev && \
     mkdir -p /tmp/R_pkg_download/ && \
     cd /opt/ && \
+    Rscript --vanilla install_R_packages.R ${GERT_DEPENDENCY_R_PKGS} && \
+    /opt/install_deprecated_R_package.sh "https://cran.r-project.org/src/contrib/Archive/gert/gert_0.3.tar.gz" && \
     Rscript --vanilla install_R_packages.R ${SV_PIPELINE_R_PKGS} && \
     cd "/usr/local/lib/R/site-library" && eval ${SLIM_R_LIB_CMD} && \
     cd "/usr/lib/R/site-library" && eval ${SLIM_R_LIB_CMD} && \

--- a/input_templates/GATKSVPipelineBatch.ref_panel_1kg.json.tmpl
+++ b/input_templates/GATKSVPipelineBatch.ref_panel_1kg.json.tmpl
@@ -103,6 +103,7 @@
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.rmsk": {{ reference_resources.rmsk | tojson }},
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.segdups": {{ reference_resources.segdups | tojson }},
 
+  "GATKSVPipelineBatch.GATKSVPipelinePhase1.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.outlier_cutoff_nIQR": "999999",
 
   "GATKSVPipelineBatch.Module04.n_RD_genotype_bins": "100000",

--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -13,8 +13,8 @@
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:mw-gnomad-02-6a66c96",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:mw-gnomad-02-6a66c96",
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-base:mw-gnomad-02-6a66c96",
-  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:mw-xz-fixes-427c0d",
-  "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-qc:mw-gnomad-02-6a66c96",
+  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:mw-xz-fixes-7cbffee",
+  "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-qc:mw-xz-fixes-7cbffee",
   "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-rdtest:mw-gnomad-02-6a66c96",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa"
 }

--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -13,7 +13,7 @@
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:mw-gnomad-02-6a66c96",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:mw-gnomad-02-6a66c96",
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-base:mw-gnomad-02-6a66c96",
-  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:mw-gnomad-02-6a66c96",
+  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:mw-xz-fixes-427c0d",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-qc:mw-gnomad-02-6a66c96",
   "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-rdtest:mw-gnomad-02-6a66c96",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa"

--- a/input_values/ref_panel_1kg.json
+++ b/input_values/ref_panel_1kg.json
@@ -613,6 +613,7 @@
     "gs://fc-56ac46ea-efc4-4683-b6d5-6d95bed41c5e/CCDG_13607/Project_CCDG_13607_B01_GRM_WGS.gVCF.2019-02-06/Sample_NA21122/analysis/NA21122.haplotypeCalls.er.raw.g.vcf.gz",
     "gs://fc-56ac46ea-efc4-4683-b6d5-6d95bed41c5e/CCDG_13607/Project_CCDG_13607_B01_GRM_WGS.gVCF.2019-02-06/Sample_NA21133/analysis/NA21133.haplotypeCalls.er.raw.g.vcf.gz"
   ],
+  "outlier_cutoff_table" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v1/module03_outlier_cutoff_table.tsv",
   "ped_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/ref-panel/1KG/v1/ped/1kg_ref_panel_v1.ped",
   "PE_metrics" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/ref-panel/1KG/v1/genotyping/pe_metric_file.txt",
   "pesr_disc_files" : [

--- a/input_values/ref_panel_1kg_v2.json
+++ b/input_values/ref_panel_1kg_v2.json
@@ -771,6 +771,7 @@
     "gs://fc-56ac46ea-efc4-4683-b6d5-6d95bed41c5e/CCDG_13607/Project_CCDG_13607_B01_GRM_WGS.gVCF.2019-02-06/Sample_NA21122/analysis/NA21122.haplotypeCalls.er.raw.g.vcf.gz",
     "gs://fc-56ac46ea-efc4-4683-b6d5-6d95bed41c5e/CCDG_13607/Project_CCDG_13607_B01_GRM_WGS.gVCF.2019-02-06/Sample_NA21133/analysis/NA21133.haplotypeCalls.er.raw.g.vcf.gz"
   ],
+  "outlier_cutoff_table" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v1/module03_outlier_cutoff_table.tsv",
   "ped_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/ref-panel/1KG/v1/ped/1kg_ref_panel_v1.ped",
   "PE_metrics" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/pe_metric_file.txt",
   "pesr_disc_files" : [

--- a/input_values/ref_panel_v1b.json
+++ b/input_values/ref_panel_v1b.json
@@ -609,6 +609,7 @@
     "gs://fc-da43a147-98a4-4f53-a622-833382946d80/dd07c524-a737-4a37-a791-b92a99603d1e/HaplotypeCallerGvcf_GATK4/2b2e3866-70e5-4d97-9182-a4c47106252f/call-MergeGVCFs/TCGA-W9-A837-10A-01D-A706-36.g.vcf.gz"
   ],
   "PE_metrics" : "gs://gatk-sv-resources/clinical/reference_panel_v1b/genotyping/pe_metric_file.txt",
+  "outlier_cutoff_table" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v1/module03_outlier_cutoff_table.tsv",
   "ped_file" : "gs://gatk-sv-resources/clinical/reference_panel_v1b/ped/ref_panel_v1b.ped",
   "pesr_disc_files" : [
     "gs://gatk-sv-resources/clinical/reference_panel_v1b/pesr/SM-BZNZQ.disc.txt.gz",

--- a/input_values/test_batch_large.json
+++ b/input_values/test_batch_large.json
@@ -1727,6 +1727,7 @@
     "gs://gatk-sv-resources/test/module00a/large/outputs/pesr_disc/TCGA-SS-A7HO-10A-01D-A703-36.disc.txt.gz",
     "gs://gatk-sv-resources/test/module00a/large/outputs/pesr_disc/TCGA-W9-A837-10A-01D-A706-36.disc.txt.gz"
   ],
+  "outlier_cutoff_table" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v1/module03_outlier_cutoff_table.tsv",
   "ped_file" : "gs://gatk-sv-resources/test/resources/ref_panel_v1.ped",
   "qc_definitions" : "gs://gatk-sv-resources/test/batch/batch_sv.test_large.qc_definitions.tsv",
   "raw_sr_bothside_pass_files" : "gs://gatk-sv-resources/test/module04/large/output/test_large.genotype_SR_part2_bothside_pass.txt",

--- a/input_values/test_batch_small.json
+++ b/input_values/test_batch_small.json
@@ -457,6 +457,7 @@
     "gs://gatk-sv-resources/test/module00a/large/outputs/pesr_disc/SM-GZQMC.disc.txt.gz",
     "gs://gatk-sv-resources/test/module00a/large/outputs/pesr_disc/SM-HXUD2.disc.txt.gz"
   ],
+  "outlier_cutoff_table" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v1/module03_outlier_cutoff_table.tsv",
   "ped_file" : "gs://gatk-sv-resources/test/resources/ref_panel_v1.ped",
   "samples": [
     "SM-GN4BI",

--- a/src/sv-pipeline/03_variant_filtering/scripts/get_outliers_from_svcounts.helper_V2.R
+++ b/src/sv-pipeline/03_variant_filtering/scripts/get_outliers_from_svcounts.helper_V2.R
@@ -5,6 +5,9 @@
 # Distributed under terms of the MIT license.
 
 # Helper script to return list of outlier samples from an svcounts.txt file
+# an example of svcounts.txt these columns: svtype count
+# CutoffFile should include these columns: algorithm       svtype  lower_cff       higher_cff
+
 
 # Read command line arguments
 options(stringsAsFactors=F)
@@ -12,29 +15,32 @@ args <- commandArgs(trailingOnly=TRUE)
 if(length(args)!=4){
   stop("Four positional arguments expected: svcounts.txt, CutoffFile, OUTFILE and algorithm")
 }
-countsfile <- as.character(args[1])
+CountsFile <- as.character(args[1])
 CutoffFile<- as.character(args[2])
-OUTFILE <- as.character(args[3])
-algorithm <- as.character(args[4])
+OutFile <- as.character(args[3])
+Algorithm <- as.character(args[4])
 
-# Read counts
-counts <- read.table(countsfile,header=T,sep="\t")
-cffs <-read.table(CutoffFile, header=T, sep='\t')
-# Determine outlier samples
-fails <- unique(as.character(unlist(sapply(unique(counts$svtype),function(svtype){
-  # Get counts corresponding to svtype
-  vals <- counts$count[which(counts$svtype==svtype)]
-  
-  # Determine cutoff
-  quartiles <- as.numeric(quantile(vals,probs=c(0.25,0.75),na.rm=T))
+main<-function(CountsFile, CutoffFile,OutFile,  Algorithm){
+  # Read counts
+  counts <- read.table(CountsFile,header=T,sep="\t")
+  cffs <-read.table(CutoffFile, header=T, sep='\t')
+  # Determine outlier samples
+  fails <- unique(as.character(unlist(sapply(unique(counts$svtype),function(svtype){
+    # Get counts corresponding to svtype
+    vals <- counts$count[which(counts$svtype==svtype)]
+    
+    # Determine cutoff
+    quartiles <- as.numeric(quantile(vals,probs=c(0.25,0.75),na.rm=T))
 
-  cutoffs <- c(cffs[cffs$algorithm==algorithm & cffs$svtype == svtype,c(3,4)])
-  # Return list of sample IDs failing cutoffs
-  fails <- counts$sample[which(counts$svtype==svtype
-                      & (counts$count<cutoffs[1] | counts$count>cutoffs[2]))]
-  return(fails)
-}))))
+    cutoffs <- c(cffs[cffs$algorithm==Algorithm & cffs$svtype == svtype,c('lower_cff','higher_cff')])
+    # Return list of sample IDs failing cutoffs
+    fails <- counts$sample[which(counts$svtype==svtype
+                        & (counts$count<cutoffs[1] | counts$count>cutoffs[2]))]
+    return(fails)
+  }))))
 
-#Write list of fail samples to OUTFILE
-write.table(fails,OUTFILE,col.names=F,row.names=F,quote=F)
+  #Write list of fail samples to OutFile
+  write.table(fails,OutFile,col.names=F,row.names=F,quote=F)
+}
 
+main(CountsFile, CutoffFile,OutFile,  Algorithm)

--- a/src/sv-pipeline/scripts/downstream_analysis_and_filtering/plot_svcount_outliers.R
+++ b/src/sv-pipeline/scripts/downstream_analysis_and_filtering/plot_svcount_outliers.R
@@ -1,0 +1,89 @@
+getJitter <- function(x,dens){
+  jit <- dens$y[head(which(dens$x>=x),1)]
+  return(jit)
+}
+jitterX <- function(y,dens){
+  return(jitter(1,amount=getJitter(y,dens)))
+}
+
+
+library(optparse)
+###List of command-line options
+option_list <- list(
+  make_option(c("-i","--input"), type="character", 
+              help="stat table with count of SVs per sample"),
+  make_option(c("-s","--svcount"), type="character", 
+              help="stat table with count of overall SVs sites"),
+  make_option(c("-o","--outputpath"), type="character", 
+              help="output folder for all plots"),  
+  make_option(c("-m","--max"), type="integer",
+              help="max number of IQR to plot")
+ )
+
+
+###Get command-line arguments & options
+args <- parse_args(OptionParser(usage="%prog INFILE OUTDIR",
+                                option_list=option_list),
+                   positional_arguments=TRUE)
+
+opts <- args$options
+dat=read.table(opts$input, header = T)
+all_counts=read.table(opts$svcount)
+all_counts=all_counts[all_counts[,1]>0,]
+output_prefix = gsub('.txt','',opts$input)
+
+svtype=unique(dat$svtype)
+x_max= opts$max
+for(i in svtype){
+  pdf(paste(outputpath,'/',output_prefix,'.',i,'.pdf',sep=''))
+
+  tmp = dat[dat$svtype==i,]
+  quantil_list=quantile(tmp$count)
+  iqr = IQR(tmp$count)
+
+  par(fig=c(0,1,.6,1))
+  par(mar=c(2,4,2,4))
+  plot(c(0,x_max), c(max(min(tmp$count), quantil_list[2]-x_max*iqr), min(max(tmp$count),quantil_list[4]+x_max*iqr) ), frame.plot = F, type = 'n', xlab = 'n * IQR', ylab = 'Count of SVs', las=2, xaxt='n', main=i)
+  axis(1)
+  
+  abline(h=quantil_list[3], col='grey', lty=1,lwd=2)
+  for(n in c(0:x_max)){
+    abline(h=quantil_list[4]+n*iqr, col='grey', lty=2)
+    abline(h=quantil_list[2]-n*iqr, col='grey', lty=2)
+  }
+  
+  sample_counts = data.frame('iqr'=0,'sample_counts'=0)
+  rec=0
+  for(j in c(1:x_max)){
+    cff = c(quantil_list[2]-j*iqr, quantil_list[4]+j*iqr)
+    tmp2=tmp[tmp$count<cff[2] & tmp$count>cff[1],]
+    
+    vals=tmp2$count
+    dens <- density(vals, na.rm=T)
+    df_x = sapply(vals,function(y){jitterX(y,dens)})
+    df_y = vals
+    dens$y <- 0.35*dens$y/max(dens$y,na.rm=T)
+    polygon(x=c(-dens$y,rev(dens$y))+j,y=c(dens$x,rev(dens$x)),
+            border=adjustcolor("darkgreen",alpha=0.3),col=NA, yaxt='n', lwd=2)
+    points(df_x + j-1,df_y,pch=21,lwd=1.5,cex=0.1,col="darkgreen")
+    
+    rec=rec+1
+    sample_counts[rec,1]=j
+    sample_counts[rec,2]=nrow(tmp2)
+  }
+  
+  par(fig=c(0,1,.3,.6), new=T)
+  tmp = all_counts[all_counts[,4]==i,]
+  plot(c(0,x_max), c(min(tmp[,3]),max(tmp[,3])), frame.plot = F, type = 'n', xlab = 'n * IQR', ylab = '# SV Sites', las=2, xaxt='n')
+  axis(1)
+  lines(tmp[,1],tmp[,3], pch=18, lwd=2, type='b', cex=2)
+  
+  par(fig=c(0,1,0,.3),new=T)
+  par(mar=c(4,4,2,4), new=T)
+  plot(c(0,x_max), c(min(tmp[,2]),max(tmp[,2])), frame.plot = F, type = 'n', xlab = 'n * IQR', ylab = '# Outlier Samples', las=2, xaxt='n')
+  lines(tmp[,1],tmp[,2], pch=18, lwd=2, type='b', cex=2)
+  axis(1)
+  lines(tmp[,1],tmp[,2], pch=18, lwd=2, type='b', cex=2)
+  dev.off()
+}
+

--- a/src/sv-pipeline/scripts/downstream_analysis_and_filtering/plot_svcount_outliers.R
+++ b/src/sv-pipeline/scripts/downstream_analysis_and_filtering/plot_svcount_outliers.R
@@ -1,3 +1,5 @@
+library(optparse)
+
 getJitter <- function(x,dens){
   jit <- dens$y[head(which(dens$x>=x),1)]
   return(jit)
@@ -6,8 +8,6 @@ jitterX <- function(y,dens){
   return(jitter(1,amount=getJitter(y,dens)))
 }
 
-
-library(optparse)
 ###List of command-line options
 option_list <- list(
   make_option(c("-i","--input"), type="character", 
@@ -35,30 +35,30 @@ output_prefix = gsub('.txt','',opts$input)
 svtype=unique(dat$svtype)
 x_max= opts$max
 for(i in svtype){
-  pdf(paste(outputpath,'/',output_prefix,'.',i,'.pdf',sep=''))
+  pdf(paste(opts$outputpath,'/',output_prefix,'.',i,'.pdf',sep=''))
 
-  tmp = dat[dat$svtype==i,]
-  quantil_list=quantile(tmp$count)
-  iqr = IQR(tmp$count)
+  svtype_counts = dat[dat$svtype==i,]
+  quantile_list=quantile(svtype_counts$count)
+  iqr = IQR(svtype_counts$count)
 
   par(fig=c(0,1,.6,1))
   par(mar=c(2,4,2,4))
-  plot(c(0,x_max), c(max(min(tmp$count), quantil_list[2]-x_max*iqr), min(max(tmp$count),quantil_list[4]+x_max*iqr) ), frame.plot = F, type = 'n', xlab = 'n * IQR', ylab = 'Count of SVs', las=2, xaxt='n', main=i)
+  plot(c(0,x_max), c(max(min(svtype_counts$count), quantile_list[2]-x_max*iqr), min(max(svtype_counts$count),quantile_list[4]+x_max*iqr) ), frame.plot = F, type = 'n', xlab = 'n * IQR', ylab = 'Count of SVs', las=2, xaxt='n', main=i)
   axis(1)
   
-  abline(h=quantil_list[3], col='grey', lty=1,lwd=2)
+  abline(h=quantile_list[3], col='grey', lty=1,lwd=2)
   for(n in c(0:x_max)){
-    abline(h=quantil_list[4]+n*iqr, col='grey', lty=2)
-    abline(h=quantil_list[2]-n*iqr, col='grey', lty=2)
+    abline(h=quantile_list[4]+n*iqr, col='grey', lty=2)
+    abline(h=quantile_list[2]-n*iqr, col='grey', lty=2)
   }
   
   sample_counts = data.frame('iqr'=0,'sample_counts'=0)
   rec=0
-  for(j in c(1:x_max)){
-    cff = c(quantil_list[2]-j*iqr, quantil_list[4]+j*iqr)
-    tmp2=tmp[tmp$count<cff[2] & tmp$count>cff[1],]
+  for(j in 1:x_max){
+    cutoffs = c(quantile_list[2]-j*iqr, quantile_list[4]+j*iqr)
+    counts_outside_cutoffs=svtype_counts[svtype_counts$count<cutoffs[2] & svtype_counts$count>cutoffs[1],]
     
-    vals=tmp2$count
+    vals=counts_outside_cutoffs$count
     dens <- density(vals, na.rm=T)
     df_x = sapply(vals,function(y){jitterX(y,dens)})
     df_y = vals
@@ -69,21 +69,21 @@ for(i in svtype){
     
     rec=rec+1
     sample_counts[rec,1]=j
-    sample_counts[rec,2]=nrow(tmp2)
+    sample_counts[rec,2]=nrow(counts_outside_cutoffs)
   }
   
   par(fig=c(0,1,.3,.6), new=T)
-  tmp = all_counts[all_counts[,4]==i,]
-  plot(c(0,x_max), c(min(tmp[,3]),max(tmp[,3])), frame.plot = F, type = 'n', xlab = 'n * IQR', ylab = '# SV Sites', las=2, xaxt='n')
+  counts_for_svtype = all_counts[all_counts[,4]==i,]
+  plot(c(0,x_max), c(min(counts_for_svtype[,3]),max(counts_for_svtype[,3])), frame.plot = F, type = 'n', xlab = 'n * IQR', ylab = '# SV Sites', las=2, xaxt='n')
   axis(1)
-  lines(tmp[,1],tmp[,3], pch=18, lwd=2, type='b', cex=2)
+  lines(counts_for_svtype[,1],counts_for_svtype[,3], pch=18, lwd=2, type='b', cex=2)
   
   par(fig=c(0,1,0,.3),new=T)
   par(mar=c(4,4,2,4), new=T)
-  plot(c(0,x_max), c(min(tmp[,2]),max(tmp[,2])), frame.plot = F, type = 'n', xlab = 'n * IQR', ylab = '# Outlier Samples', las=2, xaxt='n')
-  lines(tmp[,1],tmp[,2], pch=18, lwd=2, type='b', cex=2)
+  plot(c(0,x_max), c(min(counts_for_svtype[,2]),max(counts_for_svtype[,2])), frame.plot = F, type = 'n', xlab = 'n * IQR', ylab = '# Outlier Samples', las=2, xaxt='n')
+  lines(counts_for_svtype[,1],counts_for_svtype[,2], pch=18, lwd=2, type='b', cex=2)
   axis(1)
-  lines(tmp[,1],tmp[,2], pch=18, lwd=2, type='b', cex=2)
+  lines(counts_for_svtype[,1],counts_for_svtype[,2], pch=18, lwd=2, type='b', cex=2)
   dev.off()
 }
 

--- a/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R
+++ b/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R
@@ -1344,7 +1344,6 @@ if(nrow(trios)>0){
   #Read data
   trio.dat <- apply(trios[,2:4],1,function(IDs){
     IDs <- as.character(IDs)
-    print(IDs)
     return(getFamDat(dat=dat,proband=IDs[1],father=IDs[2],mother=IDs[3],biallelic=!multiallelics))
   })
   names(trio.dat) <- trios[,1]

--- a/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R
+++ b/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R
@@ -125,12 +125,17 @@ getFamDat <- function(dat,proband,father=NA,mother=NA,biallelic=T,nocall.placeho
                    sort=F,by="VID",all=T,suffixes=c(".pro",".mo"))
   }
   #Only retain sites where all three samples are not null genotype (no-call, ./., nocall.placeholder)
-  exclude <- which(sapply(vlist[,c(2,4,6)],
+  exclude <- sapply(vlist[,c(2,4,6)],
                           function(vals){
-    any(as.numeric(vals)==nocall.placeholder)
-  }))
-  if(length(exclude) > 0){
-    vlist <- vlist[-exclude,]
+    which(as.numeric(vals)==nocall.placeholder)
+  })
+
+  exclude_out = c()
+  for(exclude_x in exclude){  exclude_out=c(exclude_out,exclude_x) }
+  exclude_out=unique(exclude_out)
+
+  if(length(exclude_out) > 0){
+    vlist <- vlist[-exclude_out,]
   }
   #Convert remaining NA allele counts to 0s
   vlist[,c(2,4,6)] <- apply(vlist[,c(2,4,6)],2,function(vals){
@@ -1339,8 +1344,8 @@ if(nrow(trios)>0){
   #Read data
   trio.dat <- apply(trios[,2:4],1,function(IDs){
     IDs <- as.character(IDs)
-    return(getFamDat(dat=dat,proband=IDs[1],father=IDs[2],
-                     mother=IDs[3],biallelic=!multiallelics))
+    print(IDs)
+    return(getFamDat(dat=dat,proband=IDs[1],father=IDs[2],mother=IDs[3],biallelic=!multiallelics))
   })
   names(trio.dat) <- trios[,1]
   
@@ -1370,34 +1375,4 @@ if(nrow(trios)>0){
   })
 }
 
-# ###Performs duo analyses, if any duos exist
-# if(nrow(duos)>0){
-#   #Read data
-#   duo.dat <- apply(duos[,2:4],1,function(IDs){
-#     IDs <- as.character(IDs)
-#     return(getFamDat(dat=dat,proband=IDs[1],father=IDs[2],
-#                      mother=IDs[3],biallelic=!multiallelics))
-#   })
-#   names(duo.dat) <- duos[,1]
-#   
-#   #Master wrapper
-#   masterInhWrapper(fam.dat.list=duo.dat,fam.type="duo")
-#   #Standard inheritance panels
-#   sapply(c("variants","alleles"),function(count){
-#     wrapperInheritancePlots(fam.dat.list=duo.dat,
-#                             fam.type="duo",
-#                             count=count)  
-#   })
-#   #De novo rate panels
-#   sapply(c("variants","alleles"),function(count){
-#     wrapperDeNovoRateLines(fam.dat.list=duo.dat,
-#                            fam.type="duo",
-#                            count=count)  
-#   })
-#   #De novo rate heatmaps
-#   sapply(c("variants","alleles"),function(count){
-#     wrapperDeNovoRateHeats(fam.dat.list=duo.dat,
-#                            fam.type="duo",
-#                            count=count)  
-#   })
-# }
+

--- a/test_input_templates/batch/GATKSVPipelineBatch.json.tmpl
+++ b/test_input_templates/batch/GATKSVPipelineBatch.json.tmpl
@@ -101,6 +101,7 @@
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.rmsk": {{ reference_resources.rmsk | tojson }},
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.segdups": {{ reference_resources.segdups | tojson }},
 
+  "GATKSVPipelineBatch.GATKSVPipelinePhase1.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.outlier_cutoff_nIQR": "999999",
 
   "GATKSVPipelineBatch.Module04.n_RD_genotype_bins": "100000",

--- a/test_input_templates/module03/Module03.json.tmpl
+++ b/test_input_templates/module03/Module03.json.tmpl
@@ -6,6 +6,7 @@
   "Module03.outlier_cutoff_nIQR": "10000",
 
   "Module03.batch": {{ test_batch.batch_name | tojson }},
+  "Module03.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
   "Module03.ped_file": {{ test_batch.ped_file | tojson }},
   "Module03.depth_vcf" : {{ test_batch.merged_depth_vcf | tojson }},
   "Module03.manta_vcf" : {{ test_batch.merged_manta_vcf | tojson }},

--- a/test_input_templates/module03/Module03Test.json.tmpl
+++ b/test_input_templates/module03/Module03Test.json.tmpl
@@ -15,6 +15,7 @@
   "Module03Test.Module03.linux_docker" : {{ dockers.linux_docker | tojson }},
 
   "Module03Test.Module03.outlier_cutoff_nIQR": "10000",
+  "Module03Test.Module03.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
 
   "Module03Test.Module03.batch": {{ test_batch.batch_name | tojson }},
   "Module03Test.Module03.ped_file": {{ test_batch.ped_file | tojson }},

--- a/test_input_templates/phase1/GATKSVPipelinePhase1.json.tmpl
+++ b/test_input_templates/phase1/GATKSVPipelinePhase1.json.tmpl
@@ -40,6 +40,8 @@
   "GATKSVPipelinePhase1.autosome_contigs": {{ reference_resources.autosome_file | tojson }},
   "GATKSVPipelinePhase1.rmsk": {{ reference_resources.rmsk | tojson }},
   "GATKSVPipelinePhase1.segdups": {{ reference_resources.segdups | tojson }},
+
+  "GATKSVPipelinePhase1.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
   "GATKSVPipelinePhase1.outlier_cutoff_nIQR": "6",
 
   "GATKSVPipelinePhase1.ploidy_sample_psi_scale": "0.001",

--- a/wdl/GATKSVPipelinePhase1.wdl
+++ b/wdl/GATKSVPipelinePhase1.wdl
@@ -212,6 +212,7 @@ workflow GATKSVPipelinePhase1 {
     ## Module 03
     ############################################################
 
+    File outlier_cutoff_table
     Int outlier_cutoff_nIQR
 
     RuntimeAttr? runtime_attr_adjudicate
@@ -412,6 +413,7 @@ workflow GATKSVPipelinePhase1 {
       wham_vcf=Module01.wham_vcf,
       melt_vcf=Module01.melt_vcf,
       depth_vcf=Module01.depth_vcf,
+      outlier_cutoff_table=outlier_cutoff_table,
       ped_file=ped_file,
       evidence_metrics=Module02.metrics,
       evidence_metrics_common=Module02.metrics_common,

--- a/wdl/Module03.wdl
+++ b/wdl/Module03.wdl
@@ -24,7 +24,7 @@ workflow Module03 {
     File evidence_metrics_common
 
     Int outlier_cutoff_nIQR
-    File cutoff_table
+    File outlier_cutoff_table
 
     String sv_pipeline_docker
     String sv_base_mini_docker
@@ -91,7 +91,7 @@ workflow Module03 {
     input:
       batch = batch,
       algorithms = algorithms,
-      cutoff_table = cutoff_table,
+      outlier_cutoff_table = outlier_cutoff_table,
       N_IQR_cutoff = outlier_cutoff_nIQR,
       vcfs = FilterAnnotateVcf.annotated_vcf,
       samples = GetSampleIdsFromVcf.out_array,

--- a/wdl/Module03.wdl
+++ b/wdl/Module03.wdl
@@ -22,7 +22,9 @@ workflow Module03 {
     File ped_file
     File evidence_metrics
     File evidence_metrics_common
+
     Int outlier_cutoff_nIQR
+    File cutoff_table
 
     String sv_pipeline_docker
     String sv_base_mini_docker
@@ -87,14 +89,15 @@ workflow Module03 {
 
   call filter_outliers.FilterOutlierSamples as FilterOutlierSamples {
     input:
-      vcfs = FilterAnnotateVcf.annotated_vcf,
-      N_IQR_cutoff = outlier_cutoff_nIQR,
       batch = batch,
-      samples = GetSampleIdsFromVcf.out_array,
       algorithms = algorithms,
+      cutoff_table = cutoff_table,
+      N_IQR_cutoff = outlier_cutoff_nIQR,
+      vcfs = FilterAnnotateVcf.annotated_vcf,
+      samples = GetSampleIdsFromVcf.out_array,
+      linux_docker = linux_docker,
       sv_pipeline_docker = sv_pipeline_docker,
       sv_base_mini_docker = sv_base_mini_docker,
-      linux_docker = linux_docker,
       runtime_attr_identify_outliers = runtime_attr_identify_outliers,
       runtime_attr_exclude_outliers= runtime_attr_exclude_outliers,
       runtime_attr_cat_outliers = runtime_attr_cat_outliers,

--- a/wdl/Module07MinGQ.wdl
+++ b/wdl/Module07MinGQ.wdl
@@ -1,8 +1,10 @@
-##########################
-## EXPERIMENTAL WORKFLOW
-##########################
+##########################################################################################
 
 ## Base script:   https://portal.firecloud.org/#methods/Talkowski-SV/minGQ_filter_procedure_v2_Harold_temp_copy/18
+
+## Github commit: talkowski-lab/gatk-sv-v1:<ENTER HASH HERE IN FIRECLOUD>
+
+##########################################################################################
 
 version 1.0
 
@@ -13,7 +15,7 @@ import "Structs.wdl"
 import "Tasks0506.wdl" as MiniTasks
 
 
-workflow MinGQ {
+workflow Module07MinGQ {
   input{
     String sv_base_mini_docker
     String sv_pipeline_docker
@@ -56,15 +58,23 @@ workflow MinGQ {
 
   Array[Array[String]] contigs = read_tsv(contiglist)
 
+  # Get svtype of MEI
+  call ReviseSVtypeMEI{
+    input:
+      vcf = vcf,
+      vcf_idx = vcf_idx,
+      sv_base_mini_docker = sv_base_mini_docker,
+      prefix = prefix
+  }
 
   # Get list of PCRMINUS samples
   call GetSampleLists {
     input:
-      vcf=vcf,
-      vcf_idx=vcf_idx,
-      pcrplus_samples_list=pcrplus_samples_list,
-      prefix=prefix,
-      sv_base_mini_docker=sv_base_mini_docker
+      vcf = ReviseSVtypeMEI.updated_vcf,
+      vcf_idx = ReviseSVtypeMEI.updated_vcf_idx,
+      pcrplus_samples_list = pcrplus_samples_list,
+      prefix = prefix,
+      sv_base_mini_docker = sv_base_mini_docker
   }
 
   # Shard VCF per-chromosome and add AF annotation
@@ -72,8 +82,8 @@ workflow MinGQ {
     #Split VCF into PCR+ and PCR-
     call calcAF.CalcAF as getAFs {
       input:
-        vcf=vcf,
-        vcf_idx=vcf_idx,
+        vcf=ReviseSVtypeMEI.updated_vcf,
+        vcf_idx=ReviseSVtypeMEI.updated_vcf_idx,
         contig=contig[0],
         sv_per_shard=1000,
         prefix=prefix,
@@ -90,8 +100,8 @@ workflow MinGQ {
       # Annotate PCR-specific AFs
       call calcAF.CalcAF as getAFs_byPCR {
         input:
-          vcf=vcf,
-          vcf_idx=vcf_idx,
+          vcf=ReviseSVtypeMEI.updated_vcf,
+          vcf_idx=ReviseSVtypeMEI.updated_vcf_idx,
           contig=contig[0],
           sv_per_shard=1000,
           prefix=prefix,
@@ -252,6 +262,53 @@ workflow MinGQ {
     File filtered_vcf = CombineVcfs.concat_vcf
     File filtered_vcf_idx = CombineVcfs.concat_vcf_idx
     File? AF_table_preMinGQ_PCRMINUS = cat_AF_table_PCRMINUS.merged_file
+    File? filter_lookup_table = build_tree_PCRMINUS.filter_lookup_table
+  }
+}
+
+# revise svtype of MEIs to SVTYPE=MEI
+task ReviseSVtypeMEI{
+  input{
+    File vcf
+    File vcf_idx
+    String prefix
+    String sv_base_mini_docker
+    RuntimeAttr? runtime_attr_override
+  }
+
+  RuntimeAttr default_attr = object {
+    cpu_cores: 1, 
+    mem_gb: 3.75, 
+    disk_gb: 100,
+    boot_disk_gb: 10,
+    preemptible_tries: 3,
+    max_retries: 1
+  }
+  
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+  
+  command <<<
+    zcat ~{vcf} | grep '#' > ~{prefix}.vcf
+    zcat ~{vcf} | grep -v '#' | grep "INS:ME" | sed -e "s/SVTYPE=INS/SVTYPE=MEI/" >> ~{prefix}.vcf
+    zcat ~{vcf} | grep -v '#' | grep -v "INS:ME"  >> ~{prefix}.vcf
+    mkdir tmp
+    vcf-sort -t tmp/ ~{prefix}.vcf | bgzip > ~{prefix}.vcf.gz
+    tabix -p vcf ~{prefix}.vcf.gz
+  >>>
+
+  output{
+    File updated_vcf = "~{prefix}.vcf.gz"
+    File updated_vcf_idx = "~{prefix}.vcf.gz.tbi"
+  }
+
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: sv_base_mini_docker
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }
 }
 
@@ -266,7 +323,8 @@ task GetSampleLists {
     String prefix
     RuntimeAttr? runtime_attr_override
   }
-   RuntimeAttr default_attr = object {
+
+  RuntimeAttr default_attr = object {
     cpu_cores: 1, 
     mem_gb: 3.75, 
     disk_gb: 50,


### PR DESCRIPTION
This is a rebase of #65 with some cleanup and updated dockers. 

Type- and algorithm-specific SV count ranges can now be specified in a table for filtering outlier samples in Module03 (in addition to the current IQR cutoffs). 

Also includes a bug fix to `analyze_fams.R` in MasterVcfQc.