### PR TITLE
Remove PESR_GT_OVERDISPERSION filter from single sample pipeline

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -12,7 +12,7 @@
   "samtools_cloud_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/samtools-cloud:mw-gnomad-02-6a66c96",
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:mw-gnomad-02-6a66c96",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:mw-gnomad-02-6a66c96",
-  "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-base:mw-gnomad-02-6a66c96",
+  "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline-base:cw-pesrgtfilter-5bb73a",
   "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:mw-xz-fixes-7cbffee",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-qc:mw-xz-fixes-7cbffee",
   "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-rdtest:mw-gnomad-02-6a66c96",

--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -14,7 +14,7 @@
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:mw-gnomad-02-6a66c96",
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-base:mw-gnomad-02-6a66c96",
   "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:mw-xz-fixes-7cbffee",
-  "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-qc:mw-xz-fixes-7cbffee",
+  "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-qc:mw-xz-fixes-7cbffee",
   "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-rdtest:mw-gnomad-02-6a66c96",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa"
 }

--- a/src/svtest/svtest/cli/vcf.py
+++ b/src/svtest/svtest/cli/vcf.py
@@ -178,6 +178,9 @@ def get_metrics(ftest, fbase_vcf, fbase_bed, contigs, variant_types, min_ro, pad
         test_tree = iu.create_trees_from_records(test_records, variant_types, contigs, padding=padding)
         base_tree = iu.create_trees_from_bed_records(base_records, variant_types, contigs, padding=padding)
         base_pass_tree = None
+    else:
+        base_tree = None
+        base_pass_tree = None
 
     if base_tree is not None:
         metrics, fp_intervals, fn_intervals = add_evaluation_metrics(metrics, test_tree, base_tree, variant_types, min_ro, metric_prefix)

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -966,10 +966,19 @@ workflow GATKSVPipelineSingleSample {
         sv_base_mini_docker=sv_base_mini_docker
     }
 
+  call SingleSampleFiltering.ResetFilter as ResetPESRTGTOverdispersionFilter {
+    input:
+      single_sample_vcf=ResetBothsidesSupportFilter.out,
+      single_sample_vcf_idx=ResetBothsidesSupportFilter.out_idx,
+      filter_to_reset="PESR_GT_OVERDISPERSION",
+      info_header_line='##INFO=<ID=BOTHSIDES_SUPPORT,Number=0,Type=Flag,Description="Sites with a high count of samples with PESR genotype estimates greater than two">',
+      sv_base_mini_docker=sv_base_mini_docker
+  }
+
   call m08.Module08Annotation {
        input:
-        vcf = ResetBothsidesSupportFilter.out,
-        vcf_idx = ResetBothsidesSupportFilter.out_idx,
+        vcf = ResetPESRTGTOverdispersionFilter.out,
+        vcf_idx = ResetPESRTGTOverdispersionFilter.out_idx,
         prefix = batch,
         contig_list = primary_contigs_list,
         protein_coding_gtf = protein_coding_gtf,

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -971,7 +971,7 @@ workflow GATKSVPipelineSingleSample {
       single_sample_vcf=ResetBothsidesSupportFilter.out,
       single_sample_vcf_idx=ResetBothsidesSupportFilter.out_idx,
       filter_to_reset="PESR_GT_OVERDISPERSION",
-      info_header_line='##INFO=<ID=BOTHSIDES_SUPPORT,Number=0,Type=Flag,Description="Sites with a high count of samples with PESR genotype estimates greater than two">',
+      info_header_line='##INFO=<ID=PESR_GT_OVERDISPERSION,Number=0,Type=Flag,Description="Sites with a high count of samples with PESR genotype estimates greater than two">',
       sv_base_mini_docker=sv_base_mini_docker
   }
 

--- a/wdl/SingleSampleFiltering.wdl
+++ b/wdl/SingleSampleFiltering.wdl
@@ -421,7 +421,7 @@ task ResetFilter {
   echo '~{info_header_line}' > header.txt
 
   bcftools filter -i 'FILTER ~ "~{filter_to_reset}"' ~{single_sample_vcf} | bgzip -c > sites.vcf.gz
-  tabix hsrb.vcf.gz
+  tabix sites.vcf.gz
 
   bcftools annotate \
     -k \

--- a/wdl/SingleSampleFiltering.wdl
+++ b/wdl/SingleSampleFiltering.wdl
@@ -420,12 +420,12 @@ task ResetFilter {
 
   echo '~{info_header_line}' > header.txt
 
-  bcftools filter -i 'FILTER ~ "~{filter_to_reset}"' ~{single_sample_vcf} | bgzip -c > hsrb.vcf.gz
+  bcftools filter -i 'FILTER ~ "~{filter_to_reset}"' ~{single_sample_vcf} | bgzip -c > sites.vcf.gz
   tabix hsrb.vcf.gz
 
   bcftools annotate \
     -k \
-    -a hsrb.vcf.gz \
+    -a sites.vcf.gz \
     -m ~{filter_to_reset} \
     -h header.txt \
     -x FILTER/~{filter_to_reset} \


### PR DESCRIPTION
Changing to median-based genotyping caused many additional variants to be filtered with `PESR_GT_OVERDISPERSION` in the single sample results. Analysis of concordance with PacBio calls showed that this filter was not particularly good at filtering out false positives in the single sample context under either the original or changed genotyping schemes. This PR turns the `PESR_GT_OVERDISPERSION` filter into an INFO flag at the end of the single sample pipeline.

Also includes an fix to the `dockers.json` specification of the location of `sv_pipeline_qc_docker` and a fix for a bug in svtest vcf analysis code that was causing an error in the single sample pipeline.