### PR TITLE
Fix the header line for the INFO field END2 in `postCPX_cleanup.py`

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -13,7 +13,7 @@
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:mw-gnomad-02-6a66c96",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:mw-gnomad-02-6a66c96",
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline-base:cw-pesrgtfilter-5bb73a",
-  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:mw-xz-fixes-7cbffee",
+  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw-end2header-69e9e19",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-qc:mw-xz-fixes-7cbffee",
   "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-rdtest:mw-gnomad-02-6a66c96",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa"

--- a/src/sv-pipeline/04_variant_resolution/scripts/postCPX_cleanup.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/postCPX_cleanup.py
@@ -24,7 +24,7 @@ INS_ALT_INFO = [
 
 # info keys we need to make sure we have
 INFO_KEYS = {
-    'END2' : '##INFO=<ID=END2,Type=Integer,Number=1,Description="Position of breakpoint on CHR2">',
+    'END2' : '##INFO=<ID=END2,Number=1,Type=Integer,Description="Position of breakpoint on CHR2">',
     'CHR2' : '##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome for END2 coordinate">',
     'UNRESOLVED' : '##INFO=<ID=UNRESOLVED,Number=0,Type=Flag,Description="Variant is unresolved.">',
     'UNRESOLVED_TYPE' : '##INFO=<ID=UNRESOLVED_TYPE,Number=1,Type=String,Description="Class of unresolved variant.">'


### PR DESCRIPTION
One of the scripts that writes an END2 header line was writing it with the `Type` and `Number` fields in the wrong order, which was causing htsjdk-based tools to throw an error when parsing it. Fixes https://github.com/broadinstitute/gatk-sv/issues/66.