### PR TITLE
single sample pipeline sample QC

### DIFF
--- a/input_values/ref_panel_1kg_v2.json
+++ b/input_values/ref_panel_1kg_v2.json
@@ -1090,7 +1090,7 @@
     "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/NA21122.split.txt.gz",
     "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/NA21133.split.txt.gz"
   ],
-  "qc_definitions" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/qc/single_sample.qc_definitions.tsv",
+  "qc_definitions" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/single_sample.qc_definitions.tsv",
   "requester_pays_crams" : "true",
   "samples":  [
     "HG00096",

--- a/input_values/resources_hg38.json
+++ b/input_values/resources_hg38.json
@@ -49,7 +49,6 @@
   "segdups" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.SD_gaps_Cen_Tel_Heter_Satellite_lumpy.blacklist.sorted.merged.bed.gz",
   "seed_cutoffs" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/seed_cutoff.txt",
   "sanders_2015_tarball" : "gs://gatk-sv-resources-secure/resources/Sanders_2015_hg38.tar.gz",
-  "single_sample_qc_definitions" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/qc/single_sample.qc_definitions.tsv",
   "thousand_genomes_tarballs" : [
     "gs://gatk-sv-resources-secure/resources/hg38_benchmarking/1000G_Sudmant/1000G_Sudmant.SV.AFR.bed.gz",
     "gs://gatk-sv-resources-secure/resources/hg38_benchmarking/1000G_Sudmant/1000G_Sudmant.SV.ALL.bed.gz",

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -1003,7 +1003,7 @@ workflow GATKSVPipelineSingleSample {
       sv_pipeline_base_docker=sv_pipeline_base_docker,
   }
 
-call m08.Module08Annotation {
+  call m08.Module08Annotation {
        input:
         vcf = FilterSample.out,
         vcf_idx = FilterSample.out_idx,

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -973,7 +973,7 @@ workflow GATKSVPipelineSingleSample {
       ref_samples = ref_samples,
       case_sample = sample_id,
       wgd_scores = Module00b.WGD_scores,
-      sample_counts = select_first([Module00a.coverage_counts]),
+      sample_counts = case_counts_file_,
       contig_list = primary_contigs_list,
       linux_docker = linux_docker,
       sv_pipeline_base_docker = sv_pipeline_base_docker

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -979,19 +979,6 @@ workflow GATKSVPipelineSingleSample {
       sv_pipeline_base_docker = sv_pipeline_base_docker
   }
 
-  call utils.RunQC as SampleFilterQC {
-      input:
-        name=batch,
-        qc_metrics=SampleFilterMetrics.out,
-        qc_definitions = qc_definitions,
-        sv_pipeline_base_docker=sv_pipeline_base_docker
-  }
-
-  call SingleSampleFiltering.SampleQC {
-      input:
-
-  }
-
   call SingleSampleFiltering.ResetFilter as ResetPESRTGTOverdispersionFilter {
     input:
       single_sample_vcf=ResetBothsidesSupportFilter.out,
@@ -1001,10 +988,25 @@ workflow GATKSVPipelineSingleSample {
       sv_base_mini_docker=sv_base_mini_docker
   }
 
-  call m08.Module08Annotation {
+  call utils.RunQC as SampleFilterQC {
+    input:
+      name=batch,
+      metrics=SampleFilterMetrics.metrics_file,
+      qc_definitions = qc_definitions,
+      sv_pipeline_base_docker=sv_pipeline_base_docker
+  }
+
+  call SingleSampleFiltering.SampleQC as FilterSample {
+    input:
+      vcf=ResetPESRTGTOverdispersionFilter.out,
+      sample_filtering_qc_file=SampleFilterQC.out,
+      sv_pipeline_base_docker=sv_pipeline_base_docker,
+  }
+
+call m08.Module08Annotation {
        input:
-        vcf = ResetPESRTGTOverdispersionFilter.out,
-        vcf_idx = ResetPESRTGTOverdispersionFilter.out_idx,
+        vcf = FilterSample.out,
+        vcf_idx = FilterSample.out_idx,
         prefix = batch,
         contig_list = primary_contigs_list,
         protein_coding_gtf = protein_coding_gtf,

--- a/wdl/GATKSVPipelineSingleSampleMetrics.wdl
+++ b/wdl/GATKSVPipelineSingleSampleMetrics.wdl
@@ -7,16 +7,16 @@ workflow SingleSampleMetrics {
     String name
     Array[String] ref_samples
     String case_sample
-    File wgd_scores
-    File sample_pe
-    File sample_sr
-    File sample_counts
+    File? wgd_scores
+    File? sample_pe
+    File? sample_sr
+    File? sample_counts
 
-    File cleaned_vcf
-    File final_vcf
-    File genotyped_pesr_vcf
-    File genotyped_depth_vcf
-    File non_genotyped_unique_depth_calls_vcf
+    File? cleaned_vcf
+    File? final_vcf
+    File? genotyped_pesr_vcf
+    File? genotyped_depth_vcf
+    File? non_genotyped_unique_depth_calls_vcf
 
     File? baseline_cleaned_vcf
     File? baseline_final_vcf
@@ -31,92 +31,110 @@ workflow SingleSampleMetrics {
 
   Array[String] samples = flatten([[case_sample], ref_samples])
 
-  call tu.SRMetrics {
-    input:
-      sr_file = sample_sr,
-      samples = [case_sample],
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+  if (defined(sample_sr)) {
+    call tu.SRMetrics {
+      input:
+        sr_file = sample_sr,
+        samples = [case_sample],
+        sv_pipeline_base_docker = sv_pipeline_base_docker
+    }
   }
 
-  call tu.PEMetrics {
-    input:
-      pe_file = sample_pe,
-      samples = [case_sample],
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+  if (defined(sample_pe)) {
+    call tu.PEMetrics {
+      input:
+        pe_file = sample_pe,
+        samples = [case_sample],
+        sv_pipeline_base_docker = sv_pipeline_base_docker
+    }
   }
 
-  call tu.CountsMetrics {
-    input:
-      counts_file = sample_counts,
-      sample_id = case_sample,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+  if (defined(sample_counts)) {
+    call tu.CountsMetrics {
+      input:
+        counts_file = sample_counts,
+        sample_id = case_sample,
+        sv_pipeline_base_docker = sv_pipeline_base_docker
+    }
   }
 
-  call tu.VCFMetrics as Cleaned_VCF_Metrics {
-    input:
-      vcf = cleaned_vcf,
-      baseline_vcf = baseline_cleaned_vcf,
-      samples = samples,
-      prefix = "cleaned",
-      types = "DEL,DUP,INS,INV,CTX,CNV,CPX,BND",
-      contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+  if (defined(cleaned_vcf)) {
+    call tu.VCFMetrics as Cleaned_VCF_Metrics {
+      input:
+        vcf = cleaned_vcf,
+        baseline_vcf = baseline_cleaned_vcf,
+        samples = samples,
+        prefix = "cleaned",
+        types = "DEL,DUP,INS,INV,CTX,CNV,CPX,BND",
+        contig_list = contig_list,
+        sv_pipeline_base_docker = sv_pipeline_base_docker
+    }
   }
 
-  call tu.VCFMetrics as Final_VCF_Metrics {
-    input:
-      vcf = final_vcf,
-      baseline_vcf = baseline_final_vcf,
-      samples = samples,
-      prefix = "final",
-      types = "DEL,DUP,INS,INV,CTX,CNV,CPX,BND",
-      contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+  if (defined(final_vcf)) {
+    call tu.VCFMetrics as Final_VCF_Metrics {
+      input:
+        vcf = final_vcf,
+        baseline_vcf = baseline_final_vcf,
+        samples = samples,
+        prefix = "final",
+        types = "DEL,DUP,INS,INV,CTX,CNV,CPX,BND",
+        contig_list = contig_list,
+        sv_pipeline_base_docker = sv_pipeline_base_docker
+    }
   }
 
-  call tu.VCFMetrics as Genotyped_PESR_VCF_Metrics {
-    input:
-      vcf = genotyped_pesr_vcf,
-      baseline_vcf = baseline_genotyped_pesr_vcf,
-      samples = samples,
-      prefix = "genotyped_pesr",
-      types = "DEL,DUP,INS,INV,BND",
-      contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+  if (defined(genotyped_pesr_vcf)) {
+    call tu.VCFMetrics as Genotyped_PESR_VCF_Metrics {
+      input:
+        vcf = genotyped_pesr_vcf,
+        baseline_vcf = baseline_genotyped_pesr_vcf,
+        samples = samples,
+        prefix = "genotyped_pesr",
+        types = "DEL,DUP,INS,INV,BND",
+        contig_list = contig_list,
+        sv_pipeline_base_docker = sv_pipeline_base_docker
+    }
   }
 
-  call tu.VCFMetrics as Genotyped_Depth_VCF_Metrics {
-    input:
-      vcf = genotyped_depth_vcf,
-      baseline_vcf = baseline_genotyped_depth_vcf,
-      samples = samples,
-      prefix = "genotyped_depth",
-      types = "DEL,DUP",
-      contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+  if (defined(genotyped_depth_vcf)) {
+    call tu.VCFMetrics as Genotyped_Depth_VCF_Metrics {
+      input:
+        vcf = genotyped_depth_vcf,
+        baseline_vcf = baseline_genotyped_depth_vcf,
+        samples = samples,
+        prefix = "genotyped_depth",
+        types = "DEL,DUP",
+        contig_list = contig_list,
+        sv_pipeline_base_docker = sv_pipeline_base_docker
+    }
   }
 
-  call tu.VCFMetrics as NonGenotypedUniqueDepthCallsVCFMetrics {
-    input:
-      vcf = non_genotyped_unique_depth_calls_vcf,
-      baseline_vcf = baseline_non_genotyped_unique_depth_calls_vcf,
-      samples = samples,
-      prefix = "non_genotyped_uniq_depth",
-      types = "DEL,DUP",
-      contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+  if (defined(non_genotyped_unique_depth_calls_vcf)) {
+    call tu.VCFMetrics as NonGenotypedUniqueDepthCallsVCFMetrics {
+      input:
+        vcf = non_genotyped_unique_depth_calls_vcf,
+        baseline_vcf = baseline_non_genotyped_unique_depth_calls_vcf,
+        samples = samples,
+        prefix = "non_genotyped_uniq_depth",
+        types = "DEL,DUP",
+        contig_list = contig_list,
+        sv_pipeline_base_docker = sv_pipeline_base_docker
+    }
   }
 
-  call SingleSampleWGDMetrics {
-    input:
-      wgd_scores = wgd_scores,
-      linux_docker = linux_docker
+  if (defined(wgd_scores)) {
+    call SingleSampleWGDMetrics {
+      input:
+        wgd_scores = wgd_scores,
+        linux_docker = linux_docker
+    }
   }
 
   call tu.CatMetrics {
     input:
       prefix = "single_sample." + name,
-      metric_files = [SingleSampleWGDMetrics.out, SRMetrics.out, PEMetrics.out, CountsMetrics.out, Genotyped_PESR_VCF_Metrics.out, Genotyped_Depth_VCF_Metrics.out, Cleaned_VCF_Metrics.out, Final_VCF_Metrics.out, NonGenotypedUniqueDepthCallsVCFMetrics.out],
+      metric_files = select_all([SingleSampleWGDMetrics.out, SRMetrics.out, PEMetrics.out, CountsMetrics.out, Genotyped_PESR_VCF_Metrics.out, Genotyped_Depth_VCF_Metrics.out, Cleaned_VCF_Metrics.out, Final_VCF_Metrics.out, NonGenotypedUniqueDepthCallsVCFMetrics.out]),
       search_string = case_sample,
       replace_string = "sample",
       linux_docker = linux_docker

--- a/wdl/GATKSVPipelineSingleSampleMetrics.wdl
+++ b/wdl/GATKSVPipelineSingleSampleMetrics.wdl
@@ -34,7 +34,7 @@ workflow SingleSampleMetrics {
   if (defined(sample_sr)) {
     call tu.SRMetrics {
       input:
-        sr_file = sample_sr,
+        sr_file = select_first([sample_sr]),
         samples = [case_sample],
         sv_pipeline_base_docker = sv_pipeline_base_docker
     }
@@ -43,7 +43,7 @@ workflow SingleSampleMetrics {
   if (defined(sample_pe)) {
     call tu.PEMetrics {
       input:
-        pe_file = sample_pe,
+        pe_file = select_first([sample_pe]),
         samples = [case_sample],
         sv_pipeline_base_docker = sv_pipeline_base_docker
     }
@@ -52,7 +52,7 @@ workflow SingleSampleMetrics {
   if (defined(sample_counts)) {
     call tu.CountsMetrics {
       input:
-        counts_file = sample_counts,
+        counts_file = select_first([sample_counts]),
         sample_id = case_sample,
         sv_pipeline_base_docker = sv_pipeline_base_docker
     }
@@ -61,7 +61,7 @@ workflow SingleSampleMetrics {
   if (defined(cleaned_vcf)) {
     call tu.VCFMetrics as Cleaned_VCF_Metrics {
       input:
-        vcf = cleaned_vcf,
+        vcf = select_first([cleaned_vcf]),
         baseline_vcf = baseline_cleaned_vcf,
         samples = samples,
         prefix = "cleaned",
@@ -74,7 +74,7 @@ workflow SingleSampleMetrics {
   if (defined(final_vcf)) {
     call tu.VCFMetrics as Final_VCF_Metrics {
       input:
-        vcf = final_vcf,
+        vcf = select_first([final_vcf]),
         baseline_vcf = baseline_final_vcf,
         samples = samples,
         prefix = "final",
@@ -87,7 +87,7 @@ workflow SingleSampleMetrics {
   if (defined(genotyped_pesr_vcf)) {
     call tu.VCFMetrics as Genotyped_PESR_VCF_Metrics {
       input:
-        vcf = genotyped_pesr_vcf,
+        vcf = select_first([genotyped_pesr_vcf]),
         baseline_vcf = baseline_genotyped_pesr_vcf,
         samples = samples,
         prefix = "genotyped_pesr",
@@ -100,7 +100,7 @@ workflow SingleSampleMetrics {
   if (defined(genotyped_depth_vcf)) {
     call tu.VCFMetrics as Genotyped_Depth_VCF_Metrics {
       input:
-        vcf = genotyped_depth_vcf,
+        vcf = select_first([genotyped_depth_vcf]),
         baseline_vcf = baseline_genotyped_depth_vcf,
         samples = samples,
         prefix = "genotyped_depth",
@@ -113,7 +113,7 @@ workflow SingleSampleMetrics {
   if (defined(non_genotyped_unique_depth_calls_vcf)) {
     call tu.VCFMetrics as NonGenotypedUniqueDepthCallsVCFMetrics {
       input:
-        vcf = non_genotyped_unique_depth_calls_vcf,
+        vcf = select_first([non_genotyped_unique_depth_calls_vcf]),
         baseline_vcf = baseline_non_genotyped_unique_depth_calls_vcf,
         samples = samples,
         prefix = "non_genotyped_uniq_depth",
@@ -126,7 +126,7 @@ workflow SingleSampleMetrics {
   if (defined(wgd_scores)) {
     call SingleSampleWGDMetrics {
       input:
-        wgd_scores = wgd_scores,
+        wgd_scores = select_first([wgd_scores]),
         linux_docker = linux_docker
     }
   }

--- a/wdl/SingleSampleFiltering.wdl
+++ b/wdl/SingleSampleFiltering.wdl
@@ -639,3 +639,48 @@ task VcfToBed {
   }
 }
 
+task SampleQC {
+  input {
+    File vcf
+    File sample_filtering_qc_file
+    String sv_pipeline_base_docker
+    RuntimeAttr? runtime_attr_override
+  }
+
+  RuntimeAttr default_attr = object {
+                               cpu_cores: 1,
+                               mem_gb: 3.75,
+                               disk_gb: 10,
+                               boot_disk_gb: 10,
+                               preemptible_tries: 3,
+                               max_retries: 1
+                             }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+  String filebase = basename(vcf, ".vcf.gz")
+  String outfile = "~{filebase}.sample_qc.vcf.gz"
+
+  output {
+    File out = "~{outfile}"
+    File out_idx = "~{outfile}.tbi"
+  }
+
+  command <<<
+    cat
+
+    svtk vcf2bed ~{vcf} ~{prefix}.bed -i ALL --include-filters
+
+  >>>
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: sv_pipeline_docker
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
+  }
+
+}
+
+

--- a/wdl/SingleSampleFiltering.wdl
+++ b/wdl/SingleSampleFiltering.wdl
@@ -671,8 +671,9 @@ task SampleQC {
     wgdPF=`cat ~{sample_filtering_qc_file} | awk '$1 == "wgd_score_sample" {print $5}'`
     if [ $wgdPF = "FAIL" ]
     then
-      bcftools filter -O z -e 'SVTYPE!="BND"' -m + -s SAMPLE_WGD_OUTLIER ~{vcf} \
+      bcftools filter -e 'SVTYPE!="BND"' -m + -s SAMPLE_WGD_OUTLIER ~{vcf} \
         | sed 's/ID=SAMPLE_WGD_OUTLIER,Description=".*"/ID=SAMPLE_WGD_OUTLIER,Description="Case sample is an outlier for WGD dosage score compared to reference panel"/' \
+        | bgzip -c \
         > wgd_filtered.vcf.gz
     else
       cp ~{vcf} wgd_filtered.vcf.gz
@@ -681,8 +682,9 @@ task SampleQC {
     coveragePF=`cat ~{sample_filtering_qc_file} | awk '$1 == "rd_mean_sample" {print $5}'`
     if [ $coveragePF = "FAIL" ]
     then
-      bcftools filter -O z -e 'SVTYPE!="BND"' -m + -s SAMPLE_COVERAGE_OUTLIER wgd_filtered.vcf.gz \
+      bcftools filter -e 'SVTYPE!="BND"' -m + -s SAMPLE_COVERAGE_OUTLIER wgd_filtered.vcf.gz \
         | sed 's/ID=SAMPLE_COVERAGE_OUTLIER,Description=".*"/ID=SAMPLE_COVERAGE_OUTLIER,Description="Case sample is an outlier for coverage compared to reference panel"/' \
+        | bgzip -c \
       > ~{outfile}
     else
       cp wgd_filtered.vcf.gz ~{outfile}

--- a/wdl/SingleSampleFiltering.wdl
+++ b/wdl/SingleSampleFiltering.wdl
@@ -669,9 +669,9 @@ task SampleQC {
     set -euo pipefail
 
     wgdPF=`cat ~{sample_filtering_qc_file} | awk '$1 == "wgd_score_sample" {print $5}'`
-    if [ $wgdPF -eq "FAIL" ]
+    if [ $wgdPF = "FAIL" ]
     then
-      bcftools filter -e 'SVTYPE!="BND"' -m + -s SAMPLE_WGD_OUTLIER ${vcf} \
+      bcftools filter -O z -e 'SVTYPE!="BND"' -m + -s SAMPLE_WGD_OUTLIER ~{vcf} \
         | sed 's/ID=SAMPLE_WGD_OUTLIER,Description=".*"/ID=SAMPLE_WGD_OUTLIER,Description="Case sample is an outlier for WGD dosage score compared to reference panel"/' \
         > wgd_filtered.vcf.gz
     else
@@ -679,13 +679,13 @@ task SampleQC {
     fi
 
     coveragePF=`cat ~{sample_filtering_qc_file} | awk '$1 == "rd_mean_sample" {print $5}'`
-    if [ $coveragePF -eq "FAIL" ]
+    if [ $coveragePF = "FAIL" ]
     then
-      bcftools filter -e 'SVTYPE!="BND"' -m + -s SAMPLE_COVERAGE_OUTLIER wgd_filtered.vcf.gz \
+      bcftools filter -O z -e 'SVTYPE!="BND"' -m + -s SAMPLE_COVERAGE_OUTLIER wgd_filtered.vcf.gz \
         | sed 's/ID=SAMPLE_COVERAGE_OUTLIER,Description=".*"/ID=SAMPLE_COVERAGE_OUTLIER,Description="Case sample is an outlier for coverage compared to reference panel"/' \
       > ~{outfile}
     else
-    cp wgd_filtered.vcf.gz ~{outfile}
+      cp wgd_filtered.vcf.gz ~{outfile}
     fi
 
     tabix ~{outfile}


### PR DESCRIPTION
This modifies the single sample pipeline to apply a filter to all of the variants in the final VCF if the sample fails the QC check for WGD score or rm_mean_depth, or both. This is intended to make it more clear when a sample is incompatible with the reference panel and the results should be analyzed carefully before being accepted.

 Also updates the qc definitions file to add depth as a metric and relaxes the expected counts of variants to make it less likely for good samples to have failing qc metrics.