### PR TITLE
Standardize SVTYPE nomenclature for INS variants after minGQ

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -13,7 +13,7 @@
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:mw-gnomad-02-6a66c96",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:mw-gnomad-02-6a66c96",
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline-base:cw-pesrgtfilter-5bb73a",
-  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw-end2header-69e9e19",
+  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:rlc-vcf-qc-mei-2fd09c8",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-qc:mw-xz-fixes-7cbffee",
   "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-rdtest:mw-gnomad-02-6a66c96",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa"

--- a/src/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py
+++ b/src/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py
@@ -357,6 +357,9 @@ def main():
     parser.add_argument('--dropEmpties', default=False, action='store_true',
                         help='After GT reassignments, drop any SV with no remaining ' + 
                         ' non-ref samples (default: keep all SV).')
+    parser.add_argument('--simplify-INS-SVTYPEs', default=False, action='store_true',
+                        help='Resets the SVTYPE of all INS variants, including MEIs, ' + 
+                        'to be SVTYPE=INS (default: keep original SVTYPEs).')    
     parser.add_argument('--maxNCR', help='Max no-call rate among all ' + 
                         'samples before adding a flag to the record\'s FILTER field' + 
                         ' (default: 0.005)', 
@@ -414,7 +417,11 @@ def main():
             for key in 'AN AC AF N_BI_GENOS N_HOMREF N_HET N_HOMALT FREQ_HOMREF FREQ_HET FREQ_HOMALT'.split(' '):
                 if key in record.info.keys():
                     record.info.pop(key)
-        
+
+        # Standardize SVTYPE for all INS variants, if optioned
+        if args.simplify_INS_SVTYPEs and 'INS' in record.info['SVTYPE']:
+            record.info['SVTYPE'] = 'INS'
+
         if args.dropEmpties:
             samps = svu.get_called_samples(record, include_null=False)
             if len(samps) > 0:

--- a/wdl/MasterVcfQc.wdl
+++ b/wdl/MasterVcfQc.wdl
@@ -17,7 +17,7 @@ import "PerSampleExternalBenchmark.wdl" as PerSampleExternalBenchmark
 import "Tasks0506.wdl" as MiniTasks
 
 # Master workflow to perform comprehensive quality control (QC) on
-# an SV VCF output by the Talkowski lab SV pipeline
+# an SV VCF output by GATK-SV
 workflow MasterVcfQc {
   input {
     File vcf

--- a/wdl/minGQ.wdl
+++ b/wdl/minGQ.wdl
@@ -792,6 +792,7 @@ task ApplyMinGQFilter {
     /opt/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py \
       --minGQ "~{global_minGQ}" \
       --maxNCR "~{maxNCR}" \
+      --simplify-INS-SVTYPEs \
       --cleanAFinfo \
       --prefix "~{PCR_status}" \
       "~{vcf}" \


### PR DESCRIPTION
[A recent PR](https://github.com/broadinstitute/gatk-sv/pull/93) split out mobile element insertions (MEIs) from non-MEI insertions during minGQ filtering, as the properties of MEIs and non-MEIs appeared to be different enough to warrant separate treatment during minGQ. This was accomplished by rewriting `SVTYPE` with the `ALT` allele for MEIs such that minGQ would treat them as a separate SV type during filtering.

However, this `SVTYPE` rewrite is never corrected after the filter is applied, meaning that the current output of minGQ includes records with multipartite insertion `SVTYPE`s, such as `SVTYPE=INS:ME:SVA`. This behavior is undesirable because our other filtering, annotation, and analysis workflows downstream of minGQ assume all insertion variants should have `SVTYPE=INS`, which is no longer the case.

In this PR, I have modified `apply_minGQ_filter.py` and `minGQ.wdl` to include a `--simplify-INS-SVTYPEs` option, which simplifies all SVTYPEs containing the substring `INS` after applying the minGQ filter cutoffs.