### PR TITLE
Rewrite Module04b.GetMedianSubset in python for memory scalability

### DIFF
--- a/wdl/CombineReassess.wdl
+++ b/wdl/CombineReassess.wdl
@@ -4,31 +4,35 @@ import "Structs.wdl"
 
 workflow CombineReassess {
   input {
-      File samplelist
-      File regeno_file
-      File regeno_sample_ids_lookup
-      Array[File] vcfs 
-      String sv_pipeline_base_docker
-      String sv_pipeline_docker
-      RuntimeAttr? runtime_attr_vcf2bed
+    File samplelist
+    File regeno_file
+    File regeno_sample_ids_lookup
+    Array[File] vcfs 
+    String sv_pipeline_base_docker
+    String sv_pipeline_docker
+    RuntimeAttr? runtime_attr_vcf2bed
+    RuntimeAttr? runtime_attr_merge_list_creassess
   }
   scatter(vcf in vcfs){
-      call Vcf2Bed{
-        input:
-            vcf=vcf,
-            regeno_file=regeno_file,
-            sv_pipeline_docker=sv_pipeline_docker,
-            runtime_attr_override=runtime_attr_vcf2bed}
+    call Vcf2Bed{
+      input:
+        vcf = vcf,
+        regeno_file = regeno_file,
+        sv_pipeline_docker = sv_pipeline_docker,
+        runtime_attr_override = runtime_attr_vcf2bed
+    }
   }
   call MergeList{
     input:
-        nonempty_txt=Vcf2Bed.nonempty,
-        regeno_file=regeno_file,
-        regeno_sample_ids_lookup=regeno_sample_ids_lookup,
-        samplelist=samplelist,
-        sv_pipeline_base_docker=sv_pipeline_base_docker}
+      nonempty_txt = Vcf2Bed.nonempty,
+      regeno_file = regeno_file,
+      regeno_sample_ids_lookup = regeno_sample_ids_lookup,
+      samplelist = samplelist,
+      runtime_attr_override = runtime_attr_merge_list_creassess,
+      sv_pipeline_base_docker = sv_pipeline_base_docker
+  }
   output {
-    File regeno_variants=MergeList.regeno_var
+    File regeno_variants = MergeList.regeno_var
   }
 }
 
@@ -49,16 +53,16 @@ task Vcf2Bed{
     max_retries: 1
   }
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
-    command<<<
-        set -euo pipefail
-        svtk vcf2bed ~{vcf} ~{vcf}.bed 
-        awk '{if($6!="")print $0}' ~{vcf}.bed >~{vcf}.nonempty.bed  
-        cut -f 4 ~{regeno_file} >regeno_variants.txt
-        fgrep -f regeno_variants.txt ~{vcf}.nonempty.bed> nonempty.txt        
-    >>>
-    output{
-        File nonempty="nonempty.txt"
-    }
+  command <<<
+    set -euo pipefail
+    svtk vcf2bed ~{vcf} ~{vcf}.bed
+    awk '{if($6!="")print $0}' ~{vcf}.bed >~{vcf}.nonempty.bed
+    cut -f 4 ~{regeno_file} >regeno_variants.txt
+    fgrep -f regeno_variants.txt ~{vcf}.nonempty.bed> nonempty.txt
+  >>>
+  output {
+    File nonempty="nonempty.txt"
+  }
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
@@ -71,13 +75,13 @@ task Vcf2Bed{
 }
 
 task MergeList{
-    input {
-        File samplelist
-        File regeno_file
-        Array[File] nonempty_txt
-        File regeno_sample_ids_lookup
-        String sv_pipeline_base_docker
-        RuntimeAttr? runtime_attr_override
+  input {
+    File samplelist
+    File regeno_file
+    Array[File] nonempty_txt
+    File regeno_sample_ids_lookup
+    String sv_pipeline_base_docker
+    RuntimeAttr? runtime_attr_override
   }
   RuntimeAttr default_attr = object {
     cpu_cores: 1, 
@@ -88,67 +92,67 @@ task MergeList{
     max_retries: 1
   }
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
-    command<<<
-        set -e
-        cut -f 4 ~{regeno_file} >regeno_variants.txt
-        fgrep -f regeno_variants.txt ~{regeno_sample_ids_lookup} > cohort.regeno_var.combined.bed
-        cat ~{sep=' ' nonempty_txt}|sort -k1,1V -k2,2n -k3,3n |bgzip -c > nonempty.bed.gz
-        tabix nonempty.bed.gz
-        # For each variant in regeno_file, take variants across all batches
-        while read chr start end var type;do
-            samplelist=$(tabix nonempty.bed.gz $chr:$start-$end |awk -v var="$var" '{if($4==var)print $6}' |tr "\n" ",")
-            printf "$chr\t$start\t$end\t$var\t$samplelist\n" 
-        done<~{regeno_file} >regeno_variant_sample.txt
-        # Use cohort cluster file, add samples that are clustered with the variant in question across whole cohort
-        while read chr start end var sample;do
-            expected_samples=$(fgrep $var: cohort.regeno_var.combined.bed |cut -f8)
-            printf "$var\t$sample\t$expected_samples\n"
-        done<regeno_variant_sample.txt > reassesss_by_var.txt
-        python3 <<CODE
-        import numpy as np
-        dct={}
-        def count(ln):
-            dat=ln.split("\t")
-            slist=dat[1].split(',')
-            for s in slist:
-                try:
-                    dct[s]+=1
-                except:
-                    pass
-        with open("~{samplelist}",'r') as f:
-            for line in f:
-                dct[line.rstrip()]=0
-        # Reject all outliers
-        with open("reassesss_by_var.txt",'r') as f: #
-            for line in f:
-                count(line)
-        counts=np.array([int(dct[x]) for x in dct.keys()])
-        def reject_outliers(data, m=3):
-            return data[abs(data - np.mean(data)) > m * np.std(data)]
-        outliers=reject_outliers(counts)
-        outlier_samples=set([x for x in dct.keys() if dct[x] in outliers])
-        with open("reassess_nonzero_overlap.txt",'w') as g, open("reassesss_by_var.txt",'r') as f:
-            for line in f:
-                dat=line.rstrip().split('\t')
-                regeno=dat[1][0:-1].split(',') # extra comma in the end
-                expected=dat[2][0:-1].split(',')
-                regeno=set([item for item in regeno if item not in outlier_samples])
-                expected=set([item for item in expected if item not in outlier_samples])
-                if not regeno.isdisjoint(expected):
-                    regeno_in_expected=[x for x in regeno if x in expected]
-                    overlap_over_regeno=str(len(regeno_in_expected)/len(regeno))
-                    overlap_over_expected=str(len(regeno_in_expected)/len(expected))
-                    g.write(dat[0]+"\t"+",".join(regeno)+'\t'+",".join(expected)+'\t'+overlap_over_regeno+'\t'+overlap_over_expected+"\n")
-        CODE
-        awk '{if($4>0.7 && $5>0.7)print $1}' reassess_nonzero_overlap.txt > regeno_var_filtered.txt
-        fgrep -w -f regeno_var_filtered.txt ~{regeno_file}> regeno.filtered.bed
-    >>>
-    output{
-        File reassess_nonzero="reassess_nonzero_overlap.txt"
-        File regeno_filtered="regeno.filtered.bed"
-        File regeno_var="regeno_var_filtered.txt"
-        File nonempty_bed="nonempty.bed.gz"
-    }
+  command <<<
+    set -e
+    cut -f 4 ~{regeno_file} >regeno_variants.txt
+    fgrep -f regeno_variants.txt ~{regeno_sample_ids_lookup} > cohort.regeno_var.combined.bed
+    cat ~{sep=' ' nonempty_txt}|sort -k1,1V -k2,2n -k3,3n |bgzip -c > nonempty.bed.gz
+    tabix nonempty.bed.gz
+    # For each variant in regeno_file, take variants across all batches
+    while read chr start end var type;do
+        samplelist=$(tabix nonempty.bed.gz $chr:$start-$end |awk -v var="$var" '{if($4==var)print $6}' |tr "\n" ",")
+        printf "$chr\t$start\t$end\t$var\t$samplelist\n" 
+    done<~{regeno_file} >regeno_variant_sample.txt
+    # Use cohort cluster file, add samples that are clustered with the variant in question across whole cohort
+    while read chr start end var sample;do
+        expected_samples=$(fgrep $var: cohort.regeno_var.combined.bed |cut -f8)
+        printf "$var\t$sample\t$expected_samples\n"
+    done<regeno_variant_sample.txt > reassesss_by_var.txt
+    python3 <<CODE
+    import numpy as np
+    dct={}
+    def count(ln):
+        dat=ln.split("\t")
+        slist=dat[1].split(',')
+        for s in slist:
+            try:
+                dct[s]+=1
+            except:
+                pass
+    with open("~{samplelist}",'r') as f:
+        for line in f:
+            dct[line.rstrip()]=0
+    # Reject all outliers
+    with open("reassesss_by_var.txt",'r') as f: #
+        for line in f:
+            count(line)
+    counts=np.array([int(dct[x]) for x in dct.keys()])
+    def reject_outliers(data, m=3):
+        return data[abs(data - np.mean(data)) > m * np.std(data)]
+    outliers=reject_outliers(counts)
+    outlier_samples=set([x for x in dct.keys() if dct[x] in outliers])
+    with open("reassess_nonzero_overlap.txt",'w') as g, open("reassesss_by_var.txt",'r') as f:
+        for line in f:
+            dat=line.rstrip().split('\t')
+            regeno=dat[1][0:-1].split(',') # extra comma in the end
+            expected=dat[2][0:-1].split(',')
+            regeno=set([item for item in regeno if item not in outlier_samples])
+            expected=set([item for item in expected if item not in outlier_samples])
+            if not regeno.isdisjoint(expected):
+                regeno_in_expected=[x for x in regeno if x in expected]
+                overlap_over_regeno=str(len(regeno_in_expected)/len(regeno))
+                overlap_over_expected=str(len(regeno_in_expected)/len(expected))
+                g.write(dat[0]+"\t"+",".join(regeno)+'\t'+",".join(expected)+'\t'+overlap_over_regeno+'\t'+overlap_over_expected+"\n")
+    CODE
+    awk '{if($4>0.7 && $5>0.7)print $1}' reassess_nonzero_overlap.txt > regeno_var_filtered.txt
+    fgrep -w -f regeno_var_filtered.txt ~{regeno_file}> regeno.filtered.bed
+  >>>
+  output {
+    File reassess_nonzero="reassess_nonzero_overlap.txt"
+    File regeno_filtered="regeno.filtered.bed"
+    File regeno_var="regeno_var_filtered.txt"
+    File nonempty_bed="nonempty.bed.gz"
+  }
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"

--- a/wdl/Genotype_2.wdl
+++ b/wdl/Genotype_2.wdl
@@ -99,7 +99,7 @@ workflow Regenotype {
       depth_vcf=depth_vcf,
       regeno_vcfs=AddGenotypesRegeno.genotyped_vcf,
       bed=regeno_bed,
-      runtime_attr_override = runtime_attr_concat_regenotyped_vcfs_g2
+      runtime_attr_override = runtime_attr_concat_regenotyped_vcfs_g2,
       sv_base_mini_docker=sv_base_mini_docker
   }
   output {

--- a/wdl/Module04b.wdl
+++ b/wdl/Module04b.wdl
@@ -193,22 +193,25 @@ workflow Module04b {
         runtime_attr_merge_list_creassess = runtime_attr_merge_list_creassess,
         runtime_attr_vcf2bed = runtime_attr_vcf2bed
     }
-      
-    scatter (i in range(length(Genotype_2.genotyped_vcf))) {
-      call ConcatRegenotypedVcfs{
-        input:
-          depth_vcf=depth_vcfs[i],
-          batch = batches[i],
-          regeno_vcf = Genotype_2.genotyped_vcf[i],
-          regeno_variants = CombineReassess.regeno_variants,
-          runtime_attr_override = runtime_attr_concat_regenotyped_vcfs,
-          sv_pipeline_docker = sv_pipeline_docker
+    
+    if (CombineReassess.num_regeno_filtered > 0) {
+      scatter (i in range(length(Genotype_2.genotyped_vcf))) {
+        call ConcatRegenotypedVcfs {
+          input:
+            depth_vcf=depth_vcfs[i],
+            batch = batches[i],
+            regeno_vcf = Genotype_2.genotyped_vcf[i],
+            regeno_variants = CombineReassess.regeno_variants,
+            runtime_attr_override = runtime_attr_concat_regenotyped_vcfs,
+            sv_pipeline_docker = sv_pipeline_docker
+        }
       }
     }
   }
   output {
     Array[File] regenotyped_depth_vcfs = select_first([ConcatRegenotypedVcfs.genotyped_vcf, depth_vcfs])
     File number_regenotyped_file = MergeList.num_regeno_file
+    File number_regenotyped_filtered_file = select_first([CombineReassess.num_regeno_filtered_file, MergeList.num_regeno_file])
   }
 }
 

--- a/wdl/Module04b.wdl
+++ b/wdl/Module04b.wdl
@@ -2,10 +2,9 @@ version 1.0
 
 import "Genotype_2.wdl" as g2
 import "CombineReassess.wdl" as creassess
-import "Genotype_3.wdl" as g3
 
-workflow Module04b{
-  input{
+workflow Module04b {
+  input {
     String sv_base_mini_docker
     String sv_pipeline_docker
     String sv_pipeline_base_docker
@@ -35,12 +34,26 @@ workflow Module04b{
     RuntimeAttr? runtime_attr_concat_samplecountlookup
     RuntimeAttr? runtime_attr_concat_sampleidlookup
 
-    RuntimeAttr? runtime_attr_vcf2bed
     RuntimeAttr? runtime_attr_merge_list
     RuntimeAttr? runtime_attr_get_count_cohort_samplelist
     RuntimeAttr? runtime_attr_get_regeno
     RuntimeAttr? runtime_attr_get_median_subset
     RuntimeAttr? runtime_attr_median_intersect
+    RuntimeAttr? runtime_attr_concat_regenotyped_vcfs
+
+    # Genotype_2
+    RuntimeAttr? runtime_attr_add_batch_samples
+    RuntimeAttr? runtime_attr_get_regeno_g2
+    RuntimeAttr? runtime_attr_split_beds
+    RuntimeAttr? runtime_attr_make_subset_vcf
+    RuntimeAttr? runtime_attr_rd_test_gt_regeno
+    RuntimeAttr? runtime_attr_integrate_depth_gq
+    RuntimeAttr? runtime_attr_add_genotypes
+    RuntimeAttr? runtime_attr_concat_regenotyped_vcfs_g2
+
+    #CombineReassess
+    RuntimeAttr? runtime_attr_vcf2bed
+    RuntimeAttr? runtime_attr_merge_list_creassess 
   }
 
   call ClusterMergedDepthBeds {
@@ -157,7 +170,15 @@ workflow Module04b{
           samples_list=samples_lists[i],
           sv_pipeline_docker=sv_pipeline_docker,
           sv_base_mini_docker=sv_base_mini_docker,
-          sv_pipeline_rdtest_docker=sv_pipeline_rdtest_docker
+          sv_pipeline_rdtest_docker=sv_pipeline_rdtest_docker,
+          runtime_attr_add_batch_samples = runtime_attr_add_batch_samples,
+          runtime_attr_get_regeno_g2 = runtime_attr_get_regeno_g2,
+          runtime_attr_split_beds = runtime_attr_split_beds,
+          runtime_attr_make_subset_vcf = runtime_attr_make_subset_vcf,
+          runtime_attr_rd_test_gt_regeno = runtime_attr_rd_test_gt_regeno,
+          runtime_attr_integrate_depth_gq = runtime_attr_integrate_depth_gq,
+          runtime_attr_add_genotypes = runtime_attr_add_genotypes,
+          runtime_attr_concat_regenotyped_vcfs_g2 = runtime_attr_concat_regenotyped_vcfs_g2
       }
     }
 
@@ -169,6 +190,7 @@ workflow Module04b{
         vcfs = Genotype_2.genotyped_vcf,
         sv_pipeline_docker = sv_pipeline_docker,
         sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_merge_list_creassess = runtime_attr_merge_list_creassess,
         runtime_attr_vcf2bed = runtime_attr_vcf2bed
     }
       
@@ -179,11 +201,12 @@ workflow Module04b{
           batch = batches[i],
           regeno_vcf = Genotype_2.genotyped_vcf[i],
           regeno_variants = CombineReassess.regeno_variants,
+          runtime_attr_override = runtime_attr_concat_regenotyped_vcfs,
           sv_pipeline_docker = sv_pipeline_docker
       }
     }
   }
-  output{
+  output {
     Array[File] regenotyped_depth_vcfs = select_first([ConcatRegenotypedVcfs.genotyped_vcf, depth_vcfs])
     File number_regenotyped_file = MergeList.num_regeno_file
   }

--- a/wdl/Module04b.wdl
+++ b/wdl/Module04b.wdl
@@ -569,18 +569,12 @@ task GetMedianSubset{
         fields = line.strip().split('\t')
         # first 4 fields are variant info (chr, start, end, varID)
         var_info = fields[0:4]
-        # next len-4 fields are sample coverage medians for each sample in the batch
-        try:
-          coverage_medians = [float(x) for x in fields[4:]]
-        except ValueError as e:
-          if str(e) == "could not convert string to float: '.'":
-            # if missing data, print variant ID and chrom:start-end in case follow-up desired
-            print("Empty coverage data for variant %s at %s:%s-%s" % (var_info[3], var_info[0], var_info[1], var_info[2]))
-            # then skip
-            continue
-          else:
-            raise ValueError(str(e)) # other types of ValueErrors should be treated as errors
-        med = median(coverage_medians)
+        if any([x == '.' for x in fields[4:]]):
+          # skip variants with empty coverage data
+          continue
+        # else:
+        # last len-4 fields are sample coverage medians for each sample in the batch
+        med = median([float(x) for x in fields[4:]])
         if (0.85 < med < 0.97) or (1.03 < med < 1.65):
           outp.write('\t'.join(var_info) + "\n")
     CODE


### PR DESCRIPTION
### Changes
* Rewrite Module04b.GetMedianSubset in python for memory scalability. Also adds explicit handling of variants with empty coverage data, and allows for first variant in file to be added to regenotyping list (previously ignored and treated as "header").
* Handle case where filtering in CombineReassess.MergeList removes all regenotyped variants - similar to earlier in the module, processing will stop if this is the case, and the number of filtered variants will be returned, and the output file will point to the input VCF from 04
* Remove Genotype_3 import as it is not used - should it be deleted from the repo as well?
* Fix spacing in several places
* Add top-level runtime attributes for several tasks

### Testing
* Ran test_large data through Module04b with latest master & my changes - both were successful. I compared the output of Module04b.GetMedianSubset and found that my version contains one more line - the first variant, which appears to have erroneously ignored in the master version.
* Tested one gnomAD batch and saw a massive performance improvement: 6 minutes with max 0.64 GB RAM, compared to 30 minutes using 13.5 GB RAM with the latest master version. Latest master version also produced a file of NAs due to unknown errors, while new version produces a file with the expected format. Note that the WDL used for testing was slightly modified from the one on this branch because 04b expects the full cohort rather than a partial cohort
* Tested with 6 gnomAD batches successfully 