### PR TITLE
Fix MEI SVTYPE issue in output from minGQ - take 2

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -13,7 +13,7 @@
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:mw-gnomad-02-6a66c96",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:mw-gnomad-02-6a66c96",
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline-base:cw-pesrgtfilter-5bb73a",
-  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:rlc-vcf-qc-mei-2fd09c8",
+  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:rlc-mei-mingq-fix-2-a591fdb",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-qc:mw-xz-fixes-7cbffee",
   "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-rdtest:mw-gnomad-02-6a66c96",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa"

--- a/src/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py
+++ b/src/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py
@@ -419,8 +419,9 @@ def main():
                     record.info.pop(key)
 
         # Standardize SVTYPE for all INS variants, if optioned
-        if args.simplify_INS_SVTYPEs and 'INS' in record.info['SVTYPE']:
-            record.info['SVTYPE'] = 'INS'
+        if any([keyword in record.info['SVTYPE'].split(':') for keyword in 'INS MEI'.split()]):
+            if args.simplify_INS_SVTYPEs:
+                record.info['SVTYPE'] = 'INS'
 
         if args.dropEmpties:
             samps = svu.get_called_samples(record, include_null=False)


### PR DESCRIPTION
My [previous PR](https://github.com/broadinstitute/gatk-sv/commit/044b12a5710af8c999e1d331acd14ae5fe94461a) failed to correct the underlying issue of SVTYPE misspecification for MEI records in the output VCF of `Module07minGQ.WDL`.

This PR contains a corrected `apply_minGQ_filter.py` that I have tested as follows to confirm the changes indeed fix our issue:

```
#!/usr/bin/env bash

# Step 1: Reproduce issue with existing code
# Run in current pipeline docker
docker run --rm -it us.gcr.io/broad-dsde-methods/markw/sv-pipeline:rlc-vcf-qc-mei-2fd09c8

# Download necessary data
gsutil -m cp gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/ref_panel_1kg_v2.cleaned.vcf.gz.tbi ./
tabix -h gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/ref_panel_1kg_v2.cleaned.vcf.gz chr22 \
| head -n2000 | cut -f1-109 | bgzip -c \
> test.subset.vcf.gz
tabix -f test.subset.vcf.gz
gsutil -m cp gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/mingq/1KGP_2504_and_698_with_GIAB.1perc_fdr.PCRMINUS.minGQ.filter_lookup_table.txt ./

# Need to add AFs to VCF prior to minGQ
/opt/sv-pipeline/05_annotation/scripts/compute_AFs.py test.subset.vcf.gz stdout \
| bgzip -c > test.subset.wAFs.vcf.gz
tabix -f test.subset.wAFs.vcf.gz

# Need to run MEI SVTYPE conversion to input VCF prior to minGQ
# Code taken from Module07MinGQ.wdl
export vcf=test.subset.wAFs.vcf.gz
export prefix=test_forMinGQ
zcat ${vcf} | grep '#' > ${prefix}.vcf
zcat ${vcf} | grep -v '#' | grep "INS:ME" | sed -e "s/SVTYPE=INS/SVTYPE=MEI/" >> ${prefix}.vcf
zcat ${vcf} | grep -v '#' | grep -v "INS:ME"  >> ${prefix}.vcf
vcf-sort -t tmp/ ${prefix}.vcf | bgzip > ${prefix}.vcf.gz
tabix -p vcf ${prefix}.vcf.gz

# Confirm there are SVTYPE=MEI in the input VCF
tabix ${prefix}.vcf.gz chr22 | cut -f8 | sed 's/;/\n/g' | fgrep SVTYPE | sort | uniq -c
# RESULTS:
#  69 SVTYPE=BND
#  16 SVTYPE=CNV
#   8 SVTYPE=CPX
# 536 SVTYPE=DEL
# 180 SVTYPE=DUP
# 110 SVTYPE=INS
# 121 SVTYPE=MEI

# Set inputs as would be passed in WDL
export global_minGQ=0
export maxNCR=0.07
export prefix=test_filtered
export vcf=test_forMinGQ.vcf.gz
export minGQ_lookup_table=1KGP_2504_and_698_with_GIAB.1perc_fdr.PCRMINUS.minGQ.filter_lookup_table.txt

# Rerun minGQ filtering (command copied from minGQ.wdl)
/opt/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py \
  --minGQ "${global_minGQ}" \
  --maxNCR "${maxNCR}" \
  --simplify-INS-SVTYPEs \
  --cleanAFinfo \
  --prefix "${PCR_status}" \
  "${vcf}" \
  "${minGQ_lookup_table}" \
  stdout \
| fgrep -v "##INFO=<ID=AN," \
| fgrep -v "##INFO=<ID=AC," \
| fgrep -v "##INFO=<ID=AF," \
| fgrep -v "##INFO=<ID=N_BI_GENOS," \
| fgrep -v "##INFO=<ID=N_HOMREF," \
| fgrep -v "##INFO=<ID=N_HET," \
| fgrep -v "##INFO=<ID=N_HOMALT," \
| fgrep -v "##INFO=<ID=FREQ_HOMREF," \
| fgrep -v "##INFO=<ID=FREQ_HET," \
| fgrep -v "##INFO=<ID=FREQ_HOMALT," \
| bgzip -c \
> "${prefix}.minGQ_filtered.vcf.gz"
tabix -f ${prefix}.minGQ_filtered.vcf.gz

# Confirm there are SVTYPE=MEI in the output VCF
tabix ${prefix}.minGQ_filtered.vcf.gz chr22 | cut -f8 | sed 's/;/\n/g' | fgrep SVTYPE | sort | uniq -c
# RESULTS:
#  69 SVTYPE=BND
#  16 SVTYPE=CNV
#   8 SVTYPE=CPX
# 536 SVTYPE=DEL
# 180 SVTYPE=DUP
# 110 SVTYPE=INS
# 121 SVTYPE=MEI



# Step 2. Show issue is corrected with new script
# Copy revised script from local:
# docker cp ~/Desktop/Collins/Talkowski/code/gatk-sv/src/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py busy_panini:/
# Rerun with revised script
export prefix=minGQ_filtered_take2
/apply_minGQ_filter.py \
  --minGQ "${global_minGQ}" \
  --maxNCR "${maxNCR}" \
  --simplify-INS-SVTYPEs \
  --cleanAFinfo \
  --prefix "${PCR_status}" \
  "${vcf}" \
  "${minGQ_lookup_table}" \
  stdout \
| fgrep -v "##INFO=<ID=AN," \
| fgrep -v "##INFO=<ID=AC," \
| fgrep -v "##INFO=<ID=AF," \
| fgrep -v "##INFO=<ID=N_BI_GENOS," \
| fgrep -v "##INFO=<ID=N_HOMREF," \
| fgrep -v "##INFO=<ID=N_HET," \
| fgrep -v "##INFO=<ID=N_HOMALT," \
| fgrep -v "##INFO=<ID=FREQ_HOMREF," \
| fgrep -v "##INFO=<ID=FREQ_HET," \
| fgrep -v "##INFO=<ID=FREQ_HOMALT," \
| bgzip -c \
> "${prefix}.minGQ_filtered.vcf.gz"
tabix -f ${prefix}.minGQ_filtered.vcf.gz

# Confirm no SVTYPE=MEI records remain in corrected output
tabix ${prefix}.minGQ_filtered.vcf.gz chr22 | cut -f8 | sed 's/;/\n/g' | fgrep SVTYPE | sort | uniq -c
# RESULTS:
#  69 SVTYPE=BND
#  16 SVTYPE=CNV
#   8 SVTYPE=CPX
# 536 SVTYPE=DEL
# 180 SVTYPE=DUP
# 231 SVTYPE=INS
```