### PR TITLE
Get specified output paths for multiple batches & workflows w/o metadata download

### DIFF
--- a/scripts/cromwell/get_output_paths.py
+++ b/scripts/cromwell/get_output_paths.py
@@ -197,7 +197,7 @@ def format_multifile_line(batch, output_names, batch_outputs):
   for name in output_names:
     file_list = batch_outputs[name]
     if file_list == "":
-      continue
+      batch_line += "\t"
     elif len(file_list) == 1:
       batch_line += "\t" + file_list[0]
     else:

--- a/scripts/cromwell/get_output_paths.py
+++ b/scripts/cromwell/get_output_paths.py
@@ -4,7 +4,8 @@ import argparse
 import json
 import logging
 import re
-from os.path import isfile, getsize
+import os.path
+from urllib.parse import urlparse
 
 from google.cloud import storage
 
@@ -53,13 +54,15 @@ Author: Emma Pierce-Hoffman (epierceh@broadinstitute.org)
 
 
 def check_file_nonempty(f):
-    if not isfile(f):
+    # Validate existence of file and that it is > 0 bytes
+    if not os.path.isfile(f):
         raise RuntimeError("Required input file %s does not exist." % f)
-    elif getsize(f) == 0:
+    elif os.path.getsize(f) == 0:
         raise RuntimeError("Required input file %s is empty." % f)
 
 
 def read_entities_file(entities_file):
+    # Get list of entities from -e entities file
     entities = []
     if entities_file is not None:
         # proceed with reading file - must not be None at this point
@@ -71,44 +74,54 @@ def read_entities_file(entities_file):
 
 
 def load_filenames(filenames):
+    # Read -f filenames / output names JSON
     files_dict = json.load(open(filenames, 'r'))
     output_names = sorted(files_dict.keys())
     return files_dict, output_names
 
 
 def split_bucket_subdir(directory):
-    regex = r'^(gs://)?([^/]+)(/)?(.*)'
-    bucket = re.match(regex, directory).group(2)
-    subdir = re.match(regex, directory).group(4)
-    if subdir[-1] != '/':
-        subdir += "/"
-    return bucket, subdir
+    # Parse -b URI input into top-level bucket name (no gs://) and subdirectory path
+    uri = urlparse(directory)
+    return uri.netloc, uri.path.lstrip("/")
 
 
 def get_batch_dirs(workflows, workflow_id, directory):
+    # Return list of (batch_name, batch_subdirectory) and top-level bucket parsed from -b URI input
     batches_dirs = []  # to hold tuples of (batch, dir) in order given in input
     bucket, subdir = split_bucket_subdir(directory)
+    # If using -i input, just add workflow ID to subdirectory path and return
     if workflow_id is not None:
-        return [("placeholder_batch", subdir + workflow_id + "/")], bucket
+        return [("placeholder_batch", os.path.join(subdir, workflow_id))], bucket
+    # If using -w input, read workflows file to get batch names and workflow IDs
     with open(workflows, 'r') as inp:
         for line in inp:
             if line.strip() == "":
                 continue
             (batch, workflow) = line.strip().split('\t')
-            batch_dir = subdir + workflow + "/"
+            batch_dir = os.path.join(subdir, workflow)
             batches_dirs.append((batch, batch_dir))
     return batches_dirs, bucket
 
 
-def file_search(blobs, names_left, files_dict, num_found, bucket, output_names):
-    # go through each object in bucket once, checking if it matches any filenames not yet found
+def find_batch_output_files(batch, bucket, prefix, files_dict, output_names, num_outputs):
+    # Search batch directory for files with specified prefixes
+
+    # Get all objects in directory
+    storage_client = storage.Client()
+    blobs = storage_client.list_blobs(bucket, prefix=prefix,
+                                      delimiter=None)  # only one workflow per batch - assumes caching if multiple
+
+    # Go through each object in directory once, checking if it matches any filenames not yet found
     batch_outputs = {file: None for file in output_names}
+    names_left = list(output_names)
+    num_found = 0
     for blob in blobs:
         blob_name = blob.name.strip()
         # in case multiple files, continue matching on suffixes even if already found file match(es)
         for name in output_names:
             if blob_name.endswith(files_dict[name]):
-                blob_path = "gs://" + bucket + "/" + blob_name  # reconstruct URI
+                blob_path = os.path.join("gs://", bucket, blob_name)  # reconstruct URI
                 if batch_outputs[name] is None:
                     num_found += 1
                     names_left.remove(name)
@@ -116,27 +129,18 @@ def file_search(blobs, names_left, files_dict, num_found, bucket, output_names):
                 else:
                     batch_outputs[name].append(blob_path)
                 break
-    return batch_outputs, num_found, names_left
 
-
-def find_batch_output_files(batch, bucket, prefix, files_dict, output_names, num_outputs):
-    num_found = 0
-    storage_client = storage.Client()
-    blobs = storage_client.list_blobs(bucket, prefix=prefix,
-                                      delimiter=None)  # only one workflow per batch - assumes caching if multiple
-    names_left = list(output_names)
-
-    batch_outputs, num_found, names_left = file_search(blobs, names_left, files_dict,
-                                                       num_found, bucket, output_names)
-    # warn if some outputs not found
+    # Warn if some outputs not found
     if num_found < num_outputs:
         for name in names_left:
             logging.warning(f"{batch} output file {name} not found in gs://{bucket}/{prefix}. Outputting empty string")
             batch_outputs[name] = ""
+
     return batch_outputs
 
 
 def sort_files_by_shard(file_list):
+    # Attempt to sort file list by shard number based on last occurrence of "shard-" in URI
     regex = r'^(shard-)([0-9]+)(/.*)'  # extract shard number for sorting - group 2
     shard_numbers = []
     check_different_shard = None
@@ -157,63 +161,60 @@ def sort_files_by_shard(file_list):
 
 
 def format_batch_line(batch, output_names, batch_outputs):
+    # Format line with batch and outputs (if not using entities option)
     batch_line = batch
     for name in output_names:
         file_list = batch_outputs[name]
+        # If could not find a file, make sure to add an offset tab to create an empty entry
         if file_list == "":
             batch_line += "\t"
+        # Single File output
         elif len(file_list) == 1:
             batch_line += "\t" + file_list[0]
+        # Array[File] output - attempt sorting by shard
         else:
             batch_line += '\t["' + '", "'.join(sort_files_by_shard(file_list)) + '"]'
     batch_line += "\n"
     return batch_line
 
 
-def get_entity_outputs(output_names, batch_outputs, entities, entity_outputs):
-    # edit entity_outputs dict in place
-    for name in output_names:
+def update_entity_outputs(output_names, batch_outputs, entities, entity_outputs):
+    # Edit entity_outputs dict in place: add new batch outputs to each corresponding entity
+    for output_index, name in enumerate(output_names):
         filepaths = batch_outputs[name]
         filenames = [path.split("/")[-1] for path in filepaths]
         for entity in entities:  # not efficient but should be <500 entities and filenames to search
-            found = False
             for i, filename in enumerate(filenames):
-                if entity in filename:
+                # cannot handle Array[File] output for one entity
+                if entity in filename and entity_outputs[entity][output_index] == "":
+                    entity_outputs[entity][output_index] = filepaths[i]
                     entity_outputs[entity].append(filepaths[i])
                     filenames.remove(filename)
                     filepaths.remove(filepaths[i])
-                    found = True
                     break
-            if not found:
-                # logging.warning(f"{entity} output file {name} not found in provided directories. "
-                #                 f"Outputting empty string")
-                entity_outputs[entity].append("")
-    entities_left = []
+
+
+def write_entity_outputs(entity_outputs, keep_all_entities, entities, output_stream):
+    # Check, format, and write entity outputs
+    # do write inside function to be able to print line-by-line
     for entity in entities:
+        # check for blank entities
         if all(element == "" for element in entity_outputs[entity]):
-            entity_outputs[entity] = []
-            entities_left.append(entity)
-    return entities_left
-
-
-def format_entity_outputs(entity_outputs, keep_all_entities, entities):
-    output_string = ""
-    for entity in entities:
-        if not keep_all_entities and all(element == "" for element in entity_outputs[entity]):
-            logging.info(f"No output files found for {entity} in provided directories. Omitting from output")
-            continue
-        output_string += entity + "\t" + "\t".join(entity_outputs[entity]) + "\n"
-    return output_string
+            if keep_all_entities:
+                logging.info(f"No output files found for entity '{entity}' in provided directories. "
+                             f"Outputting blank entry. Remove -k argument to exclude empty entities.")
+            else:
+                logging.info(f"No output files found for entity '{entity}' in provided directories. "
+                             f"Omitting from output. Use -k argument to include empty entities.")
+                continue
+        output_stream.write(entity + "\t" + "\t".join(entity_outputs[entity]) + "\n")
 
 
 def retrieve_and_write_output_files(batches_dirs, bucket, files_dict, output_names, output_file,
                                     entities, entity_type, keep_all_entities):
     num_outputs = len(output_names)
     num_entities = len(entities)
-    entity_outputs = None
-    if num_entities > 0:
-        entities_left = list(entities)
-        entity_outputs = {entity: [] for entity in entities}
+    entity_outputs = {entity: [""] * num_outputs for entity in entities}  # empty if entities is empty
     logging.info("Writing %s" % output_file)
     with open(output_file, 'w') as out:
         out.write(entity_type + "\t" + "\t".join(output_names) + "\n")
@@ -221,12 +222,12 @@ def retrieve_and_write_output_files(batches_dirs, bucket, files_dict, output_nam
             logging.info("Searching for outputs for %s" % batch)
             batch_outputs = find_batch_output_files(batch, bucket, batch_dir, files_dict, output_names, num_outputs)
             if num_entities > 0:
-                entities_left = get_entity_outputs(output_names, batch_outputs, entities_left, entity_outputs)
+                update_entity_outputs(output_names, batch_outputs, entities, entity_outputs)
             else:
                 batch_line = format_batch_line(batch, output_names, batch_outputs)
                 out.write(batch_line)
         if num_entities > 0:
-            out.write(format_entity_outputs(entity_outputs, keep_all_entities, entities))
+            write_entity_outputs(entity_outputs, keep_all_entities, entities, out)
     logging.info("Done!")
 
 
@@ -246,7 +247,7 @@ def main():
     parser.add_argument("-o", "--output-file", required=True, help="Output file path")
     parser.add_argument("-b", "--bucket", required=True,
                         help="Google bucket path to search for files - should include all subdirectories "
-                             "preceding workflow ID")
+                             "preceding workflow ID, including the workflow name.")
     parser.add_argument("-l", "--log-level", required=False, default="INFO",
                         help="Specify level of logging information, ie. info, warning, error (not case-sensitive). "
                              "Default: INFO")
@@ -265,24 +266,29 @@ def main():
                              "output files are found.")
     args = parser.parse_args()
 
+    # Set logging level from -l input
     log_level = args.log_level
     numeric_level = getattr(logging, log_level.upper(), None)
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: %s' % log_level)
     logging.basicConfig(level=numeric_level, format='%(levelname)s: %(message)s')
 
+    # Set required arguments. Validate existence of & read filenames JSON
     filenames, output_file, bucket = args.filenames, args.output_file, args.bucket  # required
     check_file_nonempty(filenames)
     files_dict, output_names = load_filenames(filenames)
 
+    # Determine workflow IDs from -w or -i arguments. Get subdirectories
     workflows, workflow_id = args.workflows_file, args.workflow_id
     if workflows is not None:
         check_file_nonempty(workflows)
     batches_dirs, bucket = get_batch_dirs(workflows, workflow_id, bucket)
 
+    # Set entity arguments and read entities file
     entity_type, entities_file, keep_all_entities = args.entity_type, args.entities_file, args.keep_all_entities
     entities = read_entities_file(entities_file)
 
+    # Core functionality
     retrieve_and_write_output_files(batches_dirs, bucket, files_dict, output_names, output_file,
                                     entities, entity_type, keep_all_entities)
 

--- a/scripts/cromwell/get_output_paths.py
+++ b/scripts/cromwell/get_output_paths.py
@@ -227,10 +227,10 @@ def main():
     parser.add_argument("-e", "--entities-file", required=False,
                         help="Newline-separated text file of entity (ie. sample, batch) names (no header). "
                              "Entity here refers to units, like samples within a batch or batches within a cohort, "
-                             "for which the workflow(s) produced outputs; "
-                             "the script expects one output per entity for all outputs, with the filename "
-                             "containing the entity ID provided in the entities file. Output will have one "
-                             "line per entity in the order provided. If multiple batches, outputs will be concatenated.")
+                             "for which the workflow(s) produced outputs; the script expects one output per entity "
+                             "for all outputs, with the filename containing the entity ID provided in the entities "
+                             "file. Output will have one line per entity in the order provided. "
+                             "If multiple batches, outputs will be concatenated and order may be affected.")
     parser.add_argument("-t", "--entity-type", required=False, default="batch",
                         help="Entity type (ie. sample, batch) of each line of output. If using -e, then define "
                              "what each entity name in the file is (ie. a sample, a batch). Otherwise, define "

--- a/scripts/cromwell/get_output_paths.py
+++ b/scripts/cromwell/get_output_paths.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 from google.cloud import storage
 
 """
-Summary: Find GCS paths for specified workflow file outputs for multiple batches without downloading metadata.
+Summary: Find GCS paths for specified workflow file outputs for multiple workflows at once without downloading metadata.
     
 Caveats: Assumes cromwell file structure. Recommended for use with cromwell final_workflow_outputs_dir
     to reduce number of files to search. Requires file suffixes for each output file that are
@@ -227,10 +227,10 @@ def main():
     parser.add_argument("-e", "--entities-file", required=False,
                         help="Newline-separated text file of entity (ie. sample, batch) names (no header). "
                              "Entity here refers to units, like samples within a batch or batches within a cohort, "
-                             "for which the workflow(s) produced outputs; the script expects one output per entity "
-                             "for all outputs, with the filename containing the entity ID provided in the entities "
-                             "file. Output will have one line per entity in the order provided. "
-                             "If multiple batches, outputs will be concatenated and order may be affected.")
+                             "for which the workflow(s) produced outputs; "
+                             "the script expects one output per entity for all outputs, with the filename "
+                             "containing the entity ID provided in the entities file. Output will have one "
+                             "line per entity in the order provided. If multiple batches, outputs will be concatenated.")
     parser.add_argument("-t", "--entity-type", required=False, default="batch",
                         help="Entity type (ie. sample, batch) of each line of output. If using -e, then define "
                              "what each entity name in the file is (ie. a sample, a batch). Otherwise, define "

--- a/scripts/cromwell/get_output_paths.py
+++ b/scripts/cromwell/get_output_paths.py
@@ -7,6 +7,28 @@ import subprocess
 import json
 
 
+"""
+Summary: find GCS paths for specified outputs for multiple batches without downloading metadata
+
+Usage:
+  python get_output_paths.py -w workflows.tsv -f filenames.json -o output.tsv -b gs://bucket/ [-l LEVEL]
+
+Parameters:
+  Required:
+  -w,--workflows: TSV file (no header) with batch (or sample) names and workflow IDs (comma-separated if multiple)
+  -f,--filenames: JSON file with output names and filename suffixes (assumes ONE file per output, not an array, string, or int)
+  -o,--output_file: Output file path (TSV)
+  -b,--bucket: Google bucket path to search for files (common to all workflows)
+  Optional:
+  -l,--log-level LEVEL (specify level of logging information to print, ie. INFO, WARNING, ERROR - not case-sensitive)
+
+Outputs:
+  - TSV file with columns for batch and each output variable, a row for each batch, containing GCS output paths
+
+Author: Emma Pierce-Hoffman (epierceh@broadinstitute.org)
+"""
+
+
 def check_file_nonempty(f):
   if not isfile(f):
     raise RuntimeError("Required input file %s does not exist." % f)

--- a/scripts/cromwell/get_output_paths.py
+++ b/scripts/cromwell/get_output_paths.py
@@ -3,22 +3,23 @@
 import argparse
 from os.path import isfile, getsize
 import logging
-import subprocess
 import json
+from google.cloud import storage
+import re
 
 
 """
 Summary: find GCS paths for specified outputs for multiple batches without downloading metadata
 
 Usage:
-  python get_output_paths.py -w workflows.tsv -f filenames.json -o output.tsv -b gs://bucket/ [-l LEVEL]
+  python get_output_paths.py -w workflows.tsv -f filenames.json -o output.tsv -b gs://bucket/workflow-name [-l LEVEL]
 
 Parameters:
   Required:
-  -w,--workflows: TSV file (no header) with batch (or sample) names and workflow IDs (comma-separated if multiple)
+  -w,--workflows: TSV file (no header) with batch (or sample) names and workflow IDs (one per batch)
   -f,--filenames: JSON file with output names and filename suffixes (assumes ONE file per output, not an array, string, or int)
   -o,--output_file: Output file path (TSV)
-  -b,--bucket: Google bucket path to search for files (common to all workflows)
+  -b,--bucket: Google bucket path to search for files (common to all workflows, should include all subdirectories preceding workflow ID)
   Optional:
   -l,--log-level LEVEL (specify level of logging information to print, ie. INFO, WARNING, ERROR - not case-sensitive)
 
@@ -36,51 +37,69 @@ def check_file_nonempty(f):
     raise RuntimeError("Required input file %s is empty." % f)
 
 
-def make_batch_dir_dict(workflows, bucket):
+def load_filenames(filenames):
+  files_dict = json.load(open(filenames, 'r'))
+  output_names = sorted(files_dict.keys())
+  num_outputs = len(output_names)
+  return files_dict, output_names, num_outputs
+
+
+def split_bucket_subdir(directory):
+  regex = r'^(gs://)?([^/]+)(/)?(.*)'
+  bucket = re.match(regex, directory).group(2)
+  subdir = re.match(regex, directory).group(4)
+  if subdir[-1] != '/':
+    subdir += "/"
+  return bucket, subdir
+
+
+def make_batch_dir_dict(workflows, directory):
   batch_dirs = {}
-  batches = [] # to hold batches in order given in input
-  if bucket[-1] != '/':
-    bucket += "/"
+  batches = []  # to hold batches in order given in input
+  bucket, subdir = split_bucket_subdir(directory)
   with open(workflows, 'r') as inp:
     for line in inp:
-      (batch, ids) = line.strip().split('\t')
-      ids_list = ids.split(',')
-      batch_dirs[batch] = [bucket + "*/" + workflow_id + "/**" for workflow_id in ids_list]
+      (batch, workflow_id) = line.strip().split('\t')
+      batch_dirs[batch] = subdir + workflow_id + "/"
       batches.append(batch)
-  return batches, batch_dirs
+  return batches, batch_dirs, bucket
 
 
-def find_output_file(batch, paths, filename):
-  for path in paths:
-    path_search = path + filename
-    command = "gsutil ls " + path_search
-    cmd_obj = subprocess.run(command, shell=True, capture_output=True, text=True)
-    # return code is 0 if found, 1 if not
-    rc = cmd_obj.returncode
-    if rc == 0:
-      file = cmd_obj.stdout.strip()  # will not be empty string because return code would be 1
-      return file
-    elif rc == 1:
-      continue  # object not found, try next path
-    else:  # do want to warn of other error besides not found
-      logging.warning("Command gsutil ls " + path_search + " exited with code " + str(cmd_obj.returncode))
-  # if get to this point, have not found file in any of the possible workflow directories for the batch
-  logging.warning(f"{batch} output file {filename} not found in provided directories. Outputting empty string")
-  return ""
+def find_batch_output_files(batch, bucket, prefix, files_dict, output_names, num_outputs):
+  batch_outputs = {file: None for file in output_names}
+  num_found = 0
+  storage_client = storage.Client()
+  blobs = storage_client.list_blobs(bucket, prefix=prefix, delimiter=None)  # only one workflow per batch - assumes caching if multiple
+  names_left = [name for name in output_names]
+  # go through each object in bucket once, checking if it matches any filenames not yet found
+  for blob in blobs:
+    blob_name = blob.name.strip()
+    for name in names_left:
+      if batch_outputs[name] is None and blob_name.endswith(files_dict[name]):
+        num_found += 1
+        batch_outputs[name] = "gs://" + bucket + "/" + blob_name  # reconstruct URI
+        names_left.remove(name)  # does not handle array outputs - don't search for this filename again
+        break
+    if num_found >= num_outputs:  # stop search early if all outputs found
+      break
+  # warn if some outputs not found
+  if num_found < num_outputs:
+    for name in output_names:
+      if batch_outputs[name] is None:
+        logging.warning(f"{batch} output file {name} not found in provided directories. Outputting empty string")
+        batch_outputs[name] = ""
+  return batch_outputs
 
 
-def get_output_files(batches, batch_dirs, files_dict, output_names, num_outputs, output_file):
+def get_output_files(batches, bucket, batch_dirs, files_dict, output_names, num_outputs, output_file):
   logging.info("Writing %s" % output_file)
   with open(output_file, 'w') as out:
     out.write("batch\t" + "\t".join(output_names) + "\n")
     for batch in batches:
       logging.info("Searching for outputs for %s" % batch)
-      paths = batch_dirs[batch]
-      batch_line = [""] * (num_outputs + 1)
-      batch_line[0] = batch
-      for i, output_name in enumerate(output_names):
-        batch_line[i + 1] = find_output_file(batch, paths, files_dict[output_name])
-      out.write("\t".join(batch_line) + "\n")
+      prefix = batch_dirs[batch]
+      batch_outputs = find_batch_output_files(batch, bucket, prefix, files_dict, output_names, num_outputs)
+      out.write(batch + "\t" + "\t".join([batch_outputs[name] for name in output_names]) + "\n")
   logging.info("Done!")
 
 
@@ -88,11 +107,12 @@ def get_output_files(batches, batch_dirs, files_dict, output_names, num_outputs,
 def main():
   parser = argparse.ArgumentParser()
   parser.add_argument("-w", "--workflows", required=True, help="TSV file (no header) with batch (or sample) names and \
-                                                                workflow IDs")
+                                                                workflow IDs (one workflow per batch)")
   parser.add_argument("-f", "--filenames", required=True, help="JSON file with output names and filename suffixes \
                                                                 (assumes ONE file per output, not an array)")  # TODO
   parser.add_argument("-o", "--output_file", required=True, help="Output file path")
-  parser.add_argument("-b", "--bucket", required=True, help="Google bucket path to search for files")
+  parser.add_argument("-b", "--bucket", required=True, help="Google bucket path to search for files - should include \
+                                                            all subdirectories preceding workflow ID")
   parser.add_argument("-l", "--log-level",
                       help="Specify level of logging information, ie. info, warning, error (not case-sensitive)",
                       required=False, default="INFO")
@@ -108,12 +128,10 @@ def main():
   check_file_nonempty(workflows)
   check_file_nonempty(filenames)
 
-  batches, batch_dirs = make_batch_dir_dict(workflows, bucket)
-  files_dict = json.load(open(filenames, 'r'))
-  output_names = sorted(files_dict.keys())
-  num_outputs = len(output_names)
+  batches, batch_dirs, bucket = make_batch_dir_dict(workflows, bucket)
+  files_dict, output_names, num_outputs = load_filenames(filenames)
 
-  get_output_files(batches, batch_dirs, files_dict, output_names, num_outputs, output_file)
+  get_output_files(batches, bucket, batch_dirs, files_dict, output_names, num_outputs, output_file)
 
 
 if __name__ == "__main__":

--- a/scripts/cromwell/get_output_paths.py
+++ b/scripts/cromwell/get_output_paths.py
@@ -11,14 +11,14 @@ from google.cloud import storage
 
 """
 Summary: Find GCS paths for specified workflow file outputs for multiple workflows at once without downloading metadata.
-    
+
 Caveats: Assumes cromwell file structure. Recommended for use with cromwell final_workflow_outputs_dir
     to reduce number of files to search. Requires file suffixes for each output file that are
     unique within the workflow directory.
 
 For usage & parameters: Run python get_output_paths.py --help
 
-Output: TSV file with columns for each output variable and a row for each 
+Output: TSV file with columns for each output variable and a row for each
     batch (or entity, if providing --entities-file), containing GCS output paths
 
 Author: Emma Pierce-Hoffman (epierceh@broadinstitute.org)

--- a/scripts/cromwell/get_output_paths.py
+++ b/scripts/cromwell/get_output_paths.py
@@ -1,12 +1,12 @@
 #!/bin/python
 
 import argparse
-from os.path import isfile, getsize
-import logging
 import json
-from google.cloud import storage
+import logging
 import re
+from os.path import isfile, getsize
 
+from google.cloud import storage
 
 """
 Summary: find GCS paths for specified outputs for multiple batches without downloading metadata
@@ -16,311 +16,276 @@ Usage:
             -b gs://bucket/workflow-name [-l LEVEL] [-s] [-k] [-e entities.txt]
 
 Parameters:
-  -w WORKFLOWS, --workflows WORKFLOWS
+    -w WORKFLOWS, --workflows WORKFLOWS
                         TSV file (no header) with batch (or sample) names and
                         workflow IDs (one workflow per batch). Either -i or -w
                         required. -i takes precedence if both provided.
-  -i ID, --id ID        Workflow ID (alternative to -w if only one workflow).
+    -i ID, --id ID        Workflow ID (alternative to -w if only one workflow).
                         Either -i or -w required. -i takes precedence if both
                         provided.
-  -f FILENAMES, --filenames FILENAMES
+    -f FILENAMES, --filenames FILENAMES
                         JSON file with output names and filename suffixes
                         (assumes ONE file per output, not an array)
-  -o OUTPUT_FILE, --output-file OUTPUT_FILE
+    -o OUTPUT_FILE, --output-file OUTPUT_FILE
                         Output file path
-  -b BUCKET, --bucket BUCKET
+    -b BUCKET, --bucket BUCKET
                         Google bucket path to search for files - should
                         include all subdirectories preceding workflow ID
-  -l LOG_LEVEL, --log-level LOG_LEVEL
+    -l LOG_LEVEL, --log-level LOG_LEVEL
                         Specify level of logging information, ie. info,
                         warning, error (not case-sensitive)
-  -s, --single-file     Assume only one file per output/filename (more
-                        efficient if true)
-  -e ENTITIES_FILE, --entities-file ENTITIES_FILE
+    -e ENTITIES_FILE, --entities-file ENTITIES_FILE
                         Newline-separated text file of entity names. First
                         line is entity type (ie. sample, batch). Expect one
                         output per entity for all outputs, with filename
                         containing entity ID. Output will have one line per
                         entity. If multiple batches, outputs will be concatenated.
-  -k, --keep-all-entities
+    -k, --keep-all-entities
                         With --entities-file, output a line for every entity,
                         even if none of the output files are found
 
 Outputs:
-  - TSV file with columns for each output variable and a row for each 
-    batch (or entity, if providing --entities-file), containing GCS output paths
+    - TSV file with columns for each output variable and a row for each 
+      batch (or entity, if providing --entities-file), containing GCS output paths
 
 Author: Emma Pierce-Hoffman (epierceh@broadinstitute.org)
 """
 
 
 def check_file_nonempty(f):
-  if not isfile(f):
-    raise RuntimeError("Required input file %s does not exist." % f)
-  elif getsize(f) == 0:
-    raise RuntimeError("Required input file %s is empty." % f)
+    if not isfile(f):
+        raise RuntimeError("Required input file %s does not exist." % f)
+    elif getsize(f) == 0:
+        raise RuntimeError("Required input file %s is empty." % f)
 
 
-def read_entities_file(entities_file, single_file):
-  if entities_file is None:
-    return "batch", 0, None
-  elif single_file:
-    logging.warning("--single-file overrides --entities")
-    return "batch", 0, None
-  # proceed with reading file - must not be None at this point
-  check_file_nonempty(entities_file)
-  first = True
-  entity_type = None
-  entities = []
-  num_entities = 0
-  with open(entities_file, 'r') as f:
-    for line in f:
-      item = line.strip()
-      if first:
-        entity_type = item
-        first = False
-      else:
-        entities.append(item)
-        num_entities += 1
-  return entity_type, num_entities, entities
+def read_entities_file(entities_file):
+    entities = []
+    if entities_file is not None:
+        # proceed with reading file - must not be None at this point
+        check_file_nonempty(entities_file)
+        with open(entities_file, 'r') as f:
+            for line in f:
+                entities.append(line.strip())
+    return entities
 
 
 def load_filenames(filenames):
-  files_dict = json.load(open(filenames, 'r'))
-  output_names = sorted(files_dict.keys())
-  num_outputs = len(output_names)
-  return files_dict, output_names, num_outputs
+    files_dict = json.load(open(filenames, 'r'))
+    output_names = sorted(files_dict.keys())
+    return files_dict, output_names
 
 
 def split_bucket_subdir(directory):
-  regex = r'^(gs://)?([^/]+)(/)?(.*)'
-  bucket = re.match(regex, directory).group(2)
-  subdir = re.match(regex, directory).group(4)
-  if subdir[-1] != '/':
-    subdir += "/"
-  return bucket, subdir
+    regex = r'^(gs://)?([^/]+)(/)?(.*)'
+    bucket = re.match(regex, directory).group(2)
+    subdir = re.match(regex, directory).group(4)
+    if subdir[-1] != '/':
+        subdir += "/"
+    return bucket, subdir
 
 
-def make_batch_dir_dict(workflows, workflow_id, directory):
-  single_workflow = True
-  batch_dirs = {}
-  batches = []  # to hold batches in order given in input
-  bucket, subdir = split_bucket_subdir(directory)
-  if workflow_id is not None:
-    return ["placeholder_batch"], {"placeholder_batch": subdir + workflow_id + "/"}, bucket, single_workflow
-  count = 0
-  with open(workflows, 'r') as inp:
-    for line in inp:
-      count += 1
-      (batch, workflow) = line.strip().split('\t')
-      batch_dirs[batch] = subdir + workflow + "/"
-      batches.append(batch)
-  if count > 1:
-    single_workflow = False
-  return batches, batch_dirs, bucket, single_workflow
+def get_batch_dirs(workflows, workflow_id, directory):
+    batches_dirs = []  # to hold tuples of (batch, dir) in order given in input
+    bucket, subdir = split_bucket_subdir(directory)
+    if workflow_id is not None:
+        return [("placeholder_batch", subdir + workflow_id + "/")], bucket
+    with open(workflows, 'r') as inp:
+        for line in inp:
+            if line.strip() == "":
+                continue
+            (batch, workflow) = line.strip().split('\t')
+            batch_dir = subdir + workflow + "/"
+            batches_dirs.append((batch, batch_dir))
+    return batches_dirs, bucket
 
 
-def file_search_single(blobs, names_left, batch_outputs, files_dict, num_found, num_outputs, bucket):
-  # assumes one file per output/filename suffix --> more efficient search if true
-  # go through each object in bucket once, checking if it matches any filenames not yet found
-  for blob in blobs:
-    blob_name = blob.name.strip()
-    for name in names_left:
-      if batch_outputs[name] is None and blob_name.endswith(files_dict[name]):
-        num_found += 1
-        batch_outputs[name] = "gs://" + bucket + "/" + blob_name  # reconstruct URI
-        names_left.remove(name)  # does not handle array outputs - don't search for this filename again
-        break
-    if num_found >= num_outputs:  # stop search early if all outputs found
-      break
-  return batch_outputs, num_found, names_left
+def file_search(blobs, names_left, files_dict, num_found, bucket, output_names):
+    # go through each object in bucket once, checking if it matches any filenames not yet found
+    batch_outputs = {file: None for file in output_names}
+    for blob in blobs:
+        blob_name = blob.name.strip()
+        # in case multiple files, continue matching on suffixes even if already found file match(es)
+        for name in output_names:
+            if blob_name.endswith(files_dict[name]):
+                blob_path = "gs://" + bucket + "/" + blob_name  # reconstruct URI
+                if batch_outputs[name] is None:
+                    num_found += 1
+                    names_left.remove(name)
+                    batch_outputs[name] = [blob_path]
+                else:
+                    batch_outputs[name].append(blob_path)
+                break
+    return batch_outputs, num_found, names_left
 
 
-def file_search_multi(blobs, names_left, batch_outputs, files_dict, num_found, bucket, output_names):
-  # go through each object in bucket once, checking if it matches any filenames not yet found
-  for blob in blobs:
-    blob_name = blob.name.strip()
-    for name in output_names:  # for multi, continue matching on suffixes even if already found file match(es)
-      if blob_name.endswith(files_dict[name]):
-        blob_path = "gs://" + bucket + "/" + blob_name  # reconstruct URI
-        if batch_outputs[name] is None:
-          num_found += 1
-          names_left.remove(name)
-          batch_outputs[name] = [blob_path]
-        else:
-          batch_outputs[name].append(blob_path)
-        break
-  return batch_outputs, num_found, names_left
+def find_batch_output_files(batch, bucket, prefix, files_dict, output_names, num_outputs):
+    num_found = 0
+    storage_client = storage.Client()
+    blobs = storage_client.list_blobs(bucket, prefix=prefix,
+                                      delimiter=None)  # only one workflow per batch - assumes caching if multiple
+    names_left = list(output_names)
 
-
-def find_batch_output_files(batch, bucket, prefix, files_dict, output_names, num_outputs, single_file):
-  batch_outputs = {file: None for file in output_names}
-  num_found = 0
-  storage_client = storage.Client()
-  blobs = storage_client.list_blobs(bucket, prefix=prefix, delimiter=None)  # only one workflow per batch - assumes caching if multiple
-  names_left = [name for name in output_names]
-  
-  if single_file:
-    batch_outputs, num_found, names_left = file_search_single(blobs, names_left, batch_outputs, files_dict, num_found, num_outputs, bucket)
-  else:
-    batch_outputs, num_found, names_left = file_search_multi(blobs, names_left, batch_outputs, files_dict, num_found, bucket, output_names)
-  # warn if some outputs not found
-  if num_found < num_outputs:
-    for name in names_left:
-      logging.warning(f"{batch} output file {name} not found in gs://{bucket}/{prefix}. Outputting empty string")
-      batch_outputs[name] = ""
-  return batch_outputs
+    batch_outputs, num_found, names_left = file_search(blobs, names_left, files_dict,
+                                                       num_found, bucket, output_names)
+    # warn if some outputs not found
+    if num_found < num_outputs:
+        for name in names_left:
+            logging.warning(f"{batch} output file {name} not found in gs://{bucket}/{prefix}. Outputting empty string")
+            batch_outputs[name] = ""
+    return batch_outputs
 
 
 def sort_files_by_shard(file_list):
-  regex = r'^(shard-)([0-9]+)(/.*)'  # extract shard number for sorting - group 2
-  shard_numbers = []
-  check_different_shard = None
-  for file in file_list:
-    index = file.rfind("shard-")  # find index of last occurrence of shard- substring in file path
-    if index == -1:
-      return file_list  # abandon sorting if no shard- substring
-    shard = int(re.match(regex, file[index:]).group(2))
-    # make sure first two shard numbers actually differ
-    if check_different_shard is None:
-      check_different_shard = shard
-    elif check_different_shard != -1:
-      if shard == check_different_shard:
-        return file_list  # if first two shard numbers match, then abandon sorting by shard
-      check_different_shard = -1
-    shard_numbers.append(shard)
-  return [x for _, x in sorted(zip(shard_numbers, file_list), key=lambda pair: pair[0])]
+    regex = r'^(shard-)([0-9]+)(/.*)'  # extract shard number for sorting - group 2
+    shard_numbers = []
+    check_different_shard = None
+    for file in file_list:
+        index = file.rfind("shard-")  # find index of last occurrence of shard- substring in file path
+        if index == -1:
+            return file_list  # abandon sorting if no shard- substring
+        shard = int(re.match(regex, file[index:]).group(2))
+        # make sure first two shard numbers actually differ
+        if check_different_shard is None:
+            check_different_shard = shard
+        elif check_different_shard != -1:
+            if shard == check_different_shard:
+                return file_list  # if first two shard numbers match, then abandon sorting by shard
+            check_different_shard = -1
+        shard_numbers.append(shard)
+    return [x for _, x in sorted(zip(shard_numbers, file_list), key=lambda pair: pair[0])]
 
 
-def format_multifile_line(batch, output_names, batch_outputs):
-  batch_line = batch
-  for name in output_names:
-    file_list = batch_outputs[name]
-    if file_list == "":
-      batch_line += "\t"
-    elif len(file_list) == 1:
-      batch_line += "\t" + file_list[0]
-    else:
-      batch_line += '\t["' + '", "'.join(sort_files_by_shard(file_list)) + '"]'
-  batch_line += "\n"
-  return batch_line
+def format_batch_line(batch, output_names, batch_outputs):
+    batch_line = batch
+    for name in output_names:
+        file_list = batch_outputs[name]
+        if file_list == "":
+            batch_line += "\t"
+        elif len(file_list) == 1:
+            batch_line += "\t" + file_list[0]
+        else:
+            batch_line += '\t["' + '", "'.join(sort_files_by_shard(file_list)) + '"]'
+    batch_line += "\n"
+    return batch_line
 
 
 def get_entity_outputs(output_names, batch_outputs, entities, entity_outputs):
-  # edit entity_outputs dict in place
-  for name in output_names:
-    filepaths = batch_outputs[name]
-    filenames = [path.split("/")[-1] for path in filepaths]
-    for entity in entities:  # not efficient but should be <500 entities and filenames to search
-      found = False
-      for i, filename in enumerate(filenames):
-        if entity in filename:
-          entity_outputs[entity].append(filepaths[i])
-          filenames.remove(filename)
-          filepaths.remove(filepaths[i])
-          found = True
-          break
-      if not found:
-        # logging.warning(f"{entity} output file {name} not found in provided directories. Outputting empty string")
-        entity_outputs[entity].append("")
-  entities_left = []
-  for entity in entities:
-    if all(element == "" for element in entity_outputs[entity]):
-      entity_outputs[entity] = []
-      entities_left.append(entity)
-  return entities_left
+    # edit entity_outputs dict in place
+    for name in output_names:
+        filepaths = batch_outputs[name]
+        filenames = [path.split("/")[-1] for path in filepaths]
+        for entity in entities:  # not efficient but should be <500 entities and filenames to search
+            found = False
+            for i, filename in enumerate(filenames):
+                if entity in filename:
+                    entity_outputs[entity].append(filepaths[i])
+                    filenames.remove(filename)
+                    filepaths.remove(filepaths[i])
+                    found = True
+                    break
+            if not found:
+                # logging.warning(f"{entity} output file {name} not found in provided directories. "
+                #                 f"Outputting empty string")
+                entity_outputs[entity].append("")
+    entities_left = []
+    for entity in entities:
+        if all(element == "" for element in entity_outputs[entity]):
+            entity_outputs[entity] = []
+            entities_left.append(entity)
+    return entities_left
 
 
 def format_entity_outputs(entity_outputs, keep_all_entities, entities):
-  output_string = ""
-  for entity in entities:
-    if not keep_all_entities and all(element == "" for element in entity_outputs[entity]):
-      # logging.info(f"No output files found for {entity} in provided directories. Omitting from output")
-      continue
-    output_string += entity + "\t" + "\t".join(entity_outputs[entity]) + "\n"
-  return output_string
+    output_string = ""
+    for entity in entities:
+        if not keep_all_entities and all(element == "" for element in entity_outputs[entity]):
+            logging.info(f"No output files found for {entity} in provided directories. Omitting from output")
+            continue
+        output_string += entity + "\t" + "\t".join(entity_outputs[entity]) + "\n"
+    return output_string
 
 
-def get_output_files(batches, bucket, batch_dirs, files_dict, output_names, num_outputs, output_file, single_file, num_entities, entities, entity_type, keep_all_entities):
-  entity_outputs = None
-  if num_entities > 0:
-    entities_left = [x for x in entities]
-    entity_outputs = {entity: [] for entity in entities}
-  logging.info("Writing %s" % output_file)
-  with open(output_file, 'w') as out:
-    out.write(entity_type + "\t" + "\t".join(output_names) + "\n")
-    for batch in batches:
-      logging.info("Searching for outputs for %s" % batch)
-      prefix = batch_dirs[batch]
-      batch_outputs = find_batch_output_files(batch, bucket, prefix, files_dict, output_names, num_outputs, single_file)
-      if single_file:
-        out.write(batch + "\t" + "\t".join([batch_outputs[name] for name in output_names]) + "\n")
-      elif num_entities > 0:
-        entities_left = get_entity_outputs(output_names, batch_outputs, entities_left, entity_outputs)
-      else:
-        batch_line = format_multifile_line(batch, output_names, batch_outputs)
-        out.write(batch_line)
+def retrieve_and_write_output_files(batches_dirs, bucket, files_dict, output_names, output_file,
+                                    entities, entity_type, keep_all_entities):
+    num_outputs = len(output_names)
+    num_entities = len(entities)
+    entity_outputs = None
     if num_entities > 0:
-      out.write(format_entity_outputs(entity_outputs, keep_all_entities, entities))
-  logging.info("Done!")
+        entities_left = list(entities)
+        entity_outputs = {entity: [] for entity in entities}
+    logging.info("Writing %s" % output_file)
+    with open(output_file, 'w') as out:
+        out.write(entity_type + "\t" + "\t".join(output_names) + "\n")
+        for batch, batch_dir in batches_dirs:
+            logging.info("Searching for outputs for %s" % batch)
+            batch_outputs = find_batch_output_files(batch, bucket, batch_dir, files_dict, output_names, num_outputs)
+            if num_entities > 0:
+                entities_left = get_entity_outputs(output_names, batch_outputs, entities_left, entity_outputs)
+            else:
+                batch_line = format_batch_line(batch, output_names, batch_outputs)
+                out.write(batch_line)
+        if num_entities > 0:
+            out.write(format_entity_outputs(entity_outputs, keep_all_entities, entities))
+    logging.info("Done!")
 
 
 # Main function
 def main():
-  parser = argparse.ArgumentParser()
-  parser.add_argument("-w", "--workflows", required=False, help="TSV file (no header) with batch (or sample) names and \
-                                                                workflow IDs (one workflow per batch). Either -i or -w \
-                                                                required. -i takes precedence if both provided.",
-                      default=None)
-  parser.add_argument("-i", "--id", required=False, help="Workflow ID (alternative to -w if only one workflow). \
-                                                        Either -i or -w required. -i takes precedence if both given.",
-                      default=None)
-  parser.add_argument("-f", "--filenames", required=True, help="JSON file with output names and filename suffixes \
-                                                                (assumes ONE file per output, not an array)")  # TODO
-  parser.add_argument("-o", "--output-file", required=True, help="Output file path")
-  parser.add_argument("-b", "--bucket", required=True, help="Google bucket path to search for files - should include \
-                                                            all subdirectories preceding workflow ID")
-  parser.add_argument("-l", "--log-level",
-                      help="Specify level of logging information, ie. info, warning, error (not case-sensitive)",
-                      required=False, default="INFO")
-  parser.add_argument("-s", "--single-file", help="Assume only one file per output/filename (more efficient if true)",
-                      required=False, default=False, action='store_true')
-  parser.add_argument("-e", "--entities-file", help="Newline-separated text file of entity names. First line is entity \
-                                              type (ie. sample, batch). Expect one output per entity for all outputs, \
-                                              with filename containing entity ID. Output will have one line per entity.\
-                                               If multiple batches, outputs will be concatenated.",
-                      required=False)
-  parser.add_argument("-k", "--keep-all-entities", help="With --entities-file, output a line for every entity, \
-                                                        even if none of the output files are found",
-                      required=False, default=False, action='store_true')
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("-w", "--workflows-file",
+                       help="TSV file (no header) with batch (or sample) names and workflow IDs (one workflow "
+                            "per batch). Either -i or -w required.")
+    group.add_argument("-i", "--workflow-id",
+                       help="Workflow ID provided directly on the command line; alternative to -w if only "
+                            "one workflow. Either -i or -w required.")
+    parser.add_argument("-f", "--filenames", required=True,
+                        help="JSON file with output names and filename suffixes "
+                             "(assumes ONE file per output, not an array)")
+    parser.add_argument("-o", "--output-file", required=True, help="Output file path")
+    parser.add_argument("-b", "--bucket", required=True,
+                        help="Google bucket path to search for files - should include all subdirectories "
+                             "preceding workflow ID")
+    parser.add_argument("-l", "--log-level", required=False, default="INFO",
+                        help="Specify level of logging information, ie. info, warning, error (not case-sensitive). "
+                             "Default: INFO")
+    parser.add_argument("-t", "--entity-type", required=False, default="batch",
+                        help="Entity type (ie. sample, batch) of each line of output. If using -e, then define "
+                             "what each entity name in the file is (ie. a sample, a batch). Otherwise, define "
+                             "what each workflow corresponds to. This type will be the first column name. "
+                             "Default: batch")
+    parser.add_argument("-e", "--entities-file", required=False,
+                        help="Newline-separated text file of entity names. First line is entity type "
+                             "(ie. sample, batch). Expect one output per entity for all outputs, with filename "
+                             "containing entity ID. Output will have one line per entity. If multiple batches, "
+                             "outputs will be concatenated.")
+    parser.add_argument("-k", "--keep-all-entities", required=False, default=False, action='store_true',
+                        help="With --entities-file, output a line for every entity, even if none of the "
+                             "output files are found.")
+    args = parser.parse_args()
 
-  log_level = args.log_level
-  numeric_level = getattr(logging, log_level.upper(), None)
-  if not isinstance(numeric_level, int):
-    raise ValueError('Invalid log level: %s' % log_level)
-  logging.basicConfig(level=numeric_level, format='%(levelname)s: %(message)s')
+    log_level = args.log_level
+    numeric_level = getattr(logging, log_level.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError('Invalid log level: %s' % log_level)
+    logging.basicConfig(level=numeric_level, format='%(levelname)s: %(message)s')
 
-  filenames, output_file, bucket = args.filenames, args.output_file, args.bucket  # required
-  check_file_nonempty(filenames)
-  files_dict, output_names, num_outputs = load_filenames(filenames)
+    filenames, output_file, bucket = args.filenames, args.output_file, args.bucket  # required
+    check_file_nonempty(filenames)
+    files_dict, output_names = load_filenames(filenames)
 
-  workflows, workflow_id = args.workflows, args.id
-  if workflow_id is None:
-    if workflows is None: 
-      raise ValueError("Must provide either -w or -i input")
-    else:
-      check_file_nonempty(workflows)
-  else:
+    workflows, workflow_id = args.workflows_file, args.workflow_id
     if workflows is not None:
-      logging.warning("Using workflow ID provided by --id and ignoring --workflows input")
-  batches, batch_dirs, bucket, single_workflow = make_batch_dir_dict(workflows, workflow_id, bucket)
-  
-  single_file, entities_file, keep_all_entities = args.single_file, args.entities_file, args.keep_all_entities
-  entity_type, num_entities, entities = read_entities_file(entities_file, single_file)
+        check_file_nonempty(workflows)
+    batches_dirs, bucket = get_batch_dirs(workflows, workflow_id, bucket)
 
-  get_output_files(batches, bucket, batch_dirs, files_dict, output_names, num_outputs, output_file, single_file, num_entities, entities, entity_type, keep_all_entities)
+    entity_type, entities_file, keep_all_entities = args.entity_type, args.entities_file, args.keep_all_entities
+    entities = read_entities_file(entities_file)
+
+    retrieve_and_write_output_files(batches_dirs, bucket, files_dict, output_names, output_file,
+                                    entities, entity_type, keep_all_entities)
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/scripts/cromwell/get_output_paths.py
+++ b/scripts/cromwell/get_output_paths.py
@@ -38,6 +38,7 @@ def check_file_nonempty(f):
 
 def make_batch_dir_dict(workflows, bucket):
   batch_dirs = {}
+  batches = [] # to hold batches in order given in input
   if bucket[-1] != '/':
     bucket += "/"
   with open(workflows, 'r') as inp:
@@ -45,7 +46,8 @@ def make_batch_dir_dict(workflows, bucket):
       (batch, ids) = line.strip().split('\t')
       ids_list = ids.split(',')
       batch_dirs[batch] = [bucket + "*/" + workflow_id + "/**" for workflow_id in ids_list]
-  return batch_dirs
+      batches.append(batch)
+  return batches, batch_dirs
 
 
 def find_output_file(batch, paths, filename):
@@ -67,10 +69,7 @@ def find_output_file(batch, paths, filename):
   return ""
 
 
-def get_output_files(batch_dirs, files_dict, output_file):
-  batches = sorted(batch_dirs.keys())
-  output_names = sorted(files_dict.keys())
-  num_outputs = len(output_names)
+def get_output_files(batches, batch_dirs, files_dict, output_names, num_outputs, output_file):
   logging.info("Writing %s" % output_file)
   with open(output_file, 'w') as out:
     out.write("batch\t" + "\t".join(output_names) + "\n")
@@ -109,10 +108,12 @@ def main():
   check_file_nonempty(workflows)
   check_file_nonempty(filenames)
 
-  batch_dirs = make_batch_dir_dict(workflows, bucket)
+  batches, batch_dirs = make_batch_dir_dict(workflows, bucket)
   files_dict = json.load(open(filenames, 'r'))
-  
-  get_output_files(batch_dirs, files_dict, output_file)
+  output_names = sorted(files_dict.keys())
+  num_outputs = len(output_names)
+
+  get_output_files(batches, batch_dirs, files_dict, output_names, num_outputs, output_file)
 
 
 if __name__ == "__main__":

--- a/scripts/cromwell/get_output_paths.py
+++ b/scripts/cromwell/get_output_paths.py
@@ -12,19 +12,43 @@ import re
 Summary: find GCS paths for specified outputs for multiple batches without downloading metadata
 
 Usage:
-  python get_output_paths.py -w workflows.tsv -f filenames.json -o output.tsv -b gs://bucket/workflow-name [-l LEVEL]
+  python get_output_paths.py [-w workflows.tsv | -i workflow-id] -f filenames.json -o output.tsv 
+            -b gs://bucket/workflow-name [-l LEVEL] [-s] [-k] [-e entities.txt]
 
 Parameters:
-  Required:
-  -w,--workflows: TSV file (no header) with batch (or sample) names and workflow IDs (one per batch)
-  -f,--filenames: JSON file with output names and filename suffixes (assumes ONE file per output, not an array, string, or int)
-  -o,--output_file: Output file path (TSV)
-  -b,--bucket: Google bucket path to search for files (common to all workflows, should include all subdirectories preceding workflow ID)
-  Optional:
-  -l,--log-level LEVEL (specify level of logging information to print, ie. INFO, WARNING, ERROR - not case-sensitive)
+  -w WORKFLOWS, --workflows WORKFLOWS
+                        TSV file (no header) with batch (or sample) names and
+                        workflow IDs (one workflow per batch). Either -i or -w
+                        required. -i takes precedence if both provided.
+  -i ID, --id ID        Workflow ID (alternative to -w if only one workflow).
+                        Either -i or -w required. -i takes precedence if both
+                        provided.
+  -f FILENAMES, --filenames FILENAMES
+                        JSON file with output names and filename suffixes
+                        (assumes ONE file per output, not an array)
+  -o OUTPUT_FILE, --output-file OUTPUT_FILE
+                        Output file path
+  -b BUCKET, --bucket BUCKET
+                        Google bucket path to search for files - should
+                        include all subdirectories preceding workflow ID
+  -l LOG_LEVEL, --log-level LOG_LEVEL
+                        Specify level of logging information, ie. info,
+                        warning, error (not case-sensitive)
+  -s, --single-file     Assume only one file per output/filename (more
+                        efficient if true)
+  -e ENTITIES_FILE, --entities-file ENTITIES_FILE
+                        Newline-separated text file of entity names. First
+                        line is entity type (ie. sample, batch). Expect one
+                        output per entity for all outputs, with filename
+                        containing entity ID. Output will have one line per
+                        entity. If multiple batches, outputs will be concatenated.
+  -k, --keep-all-entities
+                        With --entities-file, output a line for every entity,
+                        even if none of the output files are found
 
 Outputs:
-  - TSV file with columns for batch and each output variable, a row for each batch, containing GCS output paths
+  - TSV file with columns for each output variable and a row for each 
+    batch (or entity, if providing --entities-file), containing GCS output paths
 
 Author: Emma Pierce-Hoffman (epierceh@broadinstitute.org)
 """
@@ -35,6 +59,30 @@ def check_file_nonempty(f):
     raise RuntimeError("Required input file %s does not exist." % f)
   elif getsize(f) == 0:
     raise RuntimeError("Required input file %s is empty." % f)
+
+
+def read_entities_file(entities_file, single_file):
+  if entities_file is None:
+    return "batch", 0, None
+  elif single_file:
+    logging.warning("--single-file overrides --entities")
+    return "batch", 0, None
+  # proceed with reading file - must not be None at this point
+  check_file_nonempty(entities_file)
+  first = True
+  entity_type = None
+  entities = []
+  num_entities = 0
+  with open(entities_file, 'r') as f:
+    for line in f:
+      item = line.strip()
+      if first:
+        entity_type = item
+        first = False
+      else:
+        entities.append(item)
+        num_entities += 1
+  return entity_type, num_entities, entities
 
 
 def load_filenames(filenames):
@@ -53,24 +101,27 @@ def split_bucket_subdir(directory):
   return bucket, subdir
 
 
-def make_batch_dir_dict(workflows, directory):
+def make_batch_dir_dict(workflows, workflow_id, directory):
+  single_workflow = True
   batch_dirs = {}
   batches = []  # to hold batches in order given in input
   bucket, subdir = split_bucket_subdir(directory)
+  if workflow_id is not None:
+    return ["placeholder_batch"], {"placeholder_batch": subdir + workflow_id + "/"}, bucket, single_workflow
+  count = 0
   with open(workflows, 'r') as inp:
     for line in inp:
-      (batch, workflow_id) = line.strip().split('\t')
-      batch_dirs[batch] = subdir + workflow_id + "/"
+      count += 1
+      (batch, workflow) = line.strip().split('\t')
+      batch_dirs[batch] = subdir + workflow + "/"
       batches.append(batch)
-  return batches, batch_dirs, bucket
+  if count > 1:
+    single_workflow = False
+  return batches, batch_dirs, bucket, single_workflow
 
 
-def find_batch_output_files(batch, bucket, prefix, files_dict, output_names, num_outputs):
-  batch_outputs = {file: None for file in output_names}
-  num_found = 0
-  storage_client = storage.Client()
-  blobs = storage_client.list_blobs(bucket, prefix=prefix, delimiter=None)  # only one workflow per batch - assumes caching if multiple
-  names_left = [name for name in output_names]
+def file_search_single(blobs, names_left, batch_outputs, files_dict, num_found, num_outputs, bucket):
+  # assumes one file per output/filename suffix --> more efficient search if true
   # go through each object in bucket once, checking if it matches any filenames not yet found
   for blob in blobs:
     blob_name = blob.name.strip()
@@ -82,40 +133,166 @@ def find_batch_output_files(batch, bucket, prefix, files_dict, output_names, num
         break
     if num_found >= num_outputs:  # stop search early if all outputs found
       break
+  return batch_outputs, num_found, names_left
+
+
+def file_search_multi(blobs, names_left, batch_outputs, files_dict, num_found, bucket, output_names):
+  # go through each object in bucket once, checking if it matches any filenames not yet found
+  for blob in blobs:
+    blob_name = blob.name.strip()
+    for name in output_names:  # for multi, continue matching on suffixes even if already found file match(es)
+      if blob_name.endswith(files_dict[name]):
+        blob_path = "gs://" + bucket + "/" + blob_name  # reconstruct URI
+        if batch_outputs[name] is None:
+          num_found += 1
+          names_left.remove(name)
+          batch_outputs[name] = [blob_path]
+        else:
+          batch_outputs[name].append(blob_path)
+        break
+  return batch_outputs, num_found, names_left
+
+
+def find_batch_output_files(batch, bucket, prefix, files_dict, output_names, num_outputs, single_file):
+  batch_outputs = {file: None for file in output_names}
+  num_found = 0
+  storage_client = storage.Client()
+  blobs = storage_client.list_blobs(bucket, prefix=prefix, delimiter=None)  # only one workflow per batch - assumes caching if multiple
+  names_left = [name for name in output_names]
+  
+  if single_file:
+    batch_outputs, num_found, names_left = file_search_single(blobs, names_left, batch_outputs, files_dict, num_found, num_outputs, bucket)
+  else:
+    batch_outputs, num_found, names_left = file_search_multi(blobs, names_left, batch_outputs, files_dict, num_found, bucket, output_names)
   # warn if some outputs not found
   if num_found < num_outputs:
-    for name in output_names:
-      if batch_outputs[name] is None:
-        logging.warning(f"{batch} output file {name} not found in provided directories. Outputting empty string")
-        batch_outputs[name] = ""
+    for name in names_left:
+      logging.warning(f"{batch} output file {name} not found in gs://{bucket}/{prefix}. Outputting empty string")
+      batch_outputs[name] = ""
   return batch_outputs
 
 
-def get_output_files(batches, bucket, batch_dirs, files_dict, output_names, num_outputs, output_file):
+def sort_files_by_shard(file_list):
+  regex = r'^(shard-)([0-9]+)(/.*)'  # extract shard number for sorting - group 2
+  shard_numbers = []
+  check_different_shard = None
+  for file in file_list:
+    index = file.rfind("shard-")  # find index of last occurrence of shard- substring in file path
+    if index == -1:
+      return file_list  # abandon sorting if no shard- substring
+    shard = int(re.match(regex, file[index:]).group(2))
+    # make sure first two shard numbers actually differ
+    if check_different_shard is None:
+      check_different_shard = shard
+    elif check_different_shard != -1:
+      if shard == check_different_shard:
+        return file_list  # if first two shard numbers match, then abandon sorting by shard
+      check_different_shard = -1
+    shard_numbers.append(shard)
+  return [x for _, x in sorted(zip(shard_numbers, file_list), key=lambda pair: pair[0])]
+
+
+def format_multifile_line(batch, output_names, batch_outputs):
+  batch_line = batch
+  for name in output_names:
+    file_list = batch_outputs[name]
+    if file_list == "":
+      continue
+    elif len(file_list) == 1:
+      batch_line += "\t" + file_list[0]
+    else:
+      batch_line += '\t["' + '", "'.join(sort_files_by_shard(file_list)) + '"]'
+  batch_line += "\n"
+  return batch_line
+
+
+def get_entity_outputs(output_names, batch_outputs, entities, entity_outputs):
+  # edit entity_outputs dict in place
+  for name in output_names:
+    filepaths = batch_outputs[name]
+    filenames = [path.split("/")[-1] for path in filepaths]
+    for entity in entities:  # not efficient but should be <500 entities and filenames to search
+      found = False
+      for i, filename in enumerate(filenames):
+        if entity in filename:
+          entity_outputs[entity].append(filepaths[i])
+          filenames.remove(filename)
+          filepaths.remove(filepaths[i])
+          found = True
+          break
+      if not found:
+        # logging.warning(f"{entity} output file {name} not found in provided directories. Outputting empty string")
+        entity_outputs[entity].append("")
+  entities_left = []
+  for entity in entities:
+    if all(element == "" for element in entity_outputs[entity]):
+      entity_outputs[entity] = []
+      entities_left.append(entity)
+  return entities_left
+
+
+def format_entity_outputs(entity_outputs, keep_all_entities, entities):
+  output_string = ""
+  for entity in entities:
+    if not keep_all_entities and all(element == "" for element in entity_outputs[entity]):
+      # logging.info(f"No output files found for {entity} in provided directories. Omitting from output")
+      continue
+    output_string += entity + "\t" + "\t".join(entity_outputs[entity]) + "\n"
+  return output_string
+
+
+def get_output_files(batches, bucket, batch_dirs, files_dict, output_names, num_outputs, output_file, single_file, num_entities, entities, entity_type, keep_all_entities):
+  entity_outputs = None
+  if num_entities > 0:
+    entities_left = [x for x in entities]
+    entity_outputs = {entity: [] for entity in entities}
   logging.info("Writing %s" % output_file)
   with open(output_file, 'w') as out:
-    out.write("batch\t" + "\t".join(output_names) + "\n")
+    out.write(entity_type + "\t" + "\t".join(output_names) + "\n")
     for batch in batches:
       logging.info("Searching for outputs for %s" % batch)
       prefix = batch_dirs[batch]
-      batch_outputs = find_batch_output_files(batch, bucket, prefix, files_dict, output_names, num_outputs)
-      out.write(batch + "\t" + "\t".join([batch_outputs[name] for name in output_names]) + "\n")
+      batch_outputs = find_batch_output_files(batch, bucket, prefix, files_dict, output_names, num_outputs, single_file)
+      if single_file:
+        out.write(batch + "\t" + "\t".join([batch_outputs[name] for name in output_names]) + "\n")
+      elif num_entities > 0:
+        entities_left = get_entity_outputs(output_names, batch_outputs, entities_left, entity_outputs)
+      else:
+        batch_line = format_multifile_line(batch, output_names, batch_outputs)
+        out.write(batch_line)
+    if num_entities > 0:
+      out.write(format_entity_outputs(entity_outputs, keep_all_entities, entities))
   logging.info("Done!")
 
 
 # Main function
 def main():
   parser = argparse.ArgumentParser()
-  parser.add_argument("-w", "--workflows", required=True, help="TSV file (no header) with batch (or sample) names and \
-                                                                workflow IDs (one workflow per batch)")
+  parser.add_argument("-w", "--workflows", required=False, help="TSV file (no header) with batch (or sample) names and \
+                                                                workflow IDs (one workflow per batch). Either -i or -w \
+                                                                required. -i takes precedence if both provided.",
+                      default=None)
+  parser.add_argument("-i", "--id", required=False, help="Workflow ID (alternative to -w if only one workflow). \
+                                                        Either -i or -w required. -i takes precedence if both given.",
+                      default=None)
   parser.add_argument("-f", "--filenames", required=True, help="JSON file with output names and filename suffixes \
                                                                 (assumes ONE file per output, not an array)")  # TODO
-  parser.add_argument("-o", "--output_file", required=True, help="Output file path")
+  parser.add_argument("-o", "--output-file", required=True, help="Output file path")
   parser.add_argument("-b", "--bucket", required=True, help="Google bucket path to search for files - should include \
                                                             all subdirectories preceding workflow ID")
   parser.add_argument("-l", "--log-level",
                       help="Specify level of logging information, ie. info, warning, error (not case-sensitive)",
                       required=False, default="INFO")
+  parser.add_argument("-s", "--single-file", help="Assume only one file per output/filename (more efficient if true)",
+                      required=False, default=False, action='store_true')
+  parser.add_argument("-e", "--entities-file", help="Newline-separated text file of entity names. First line is entity \
+                                              type (ie. sample, batch). Expect one output per entity for all outputs, \
+                                              with filename containing entity ID. Output will have one line per entity.\
+                                               If multiple batches, outputs will be concatenated.",
+                      required=False)
+  parser.add_argument("-k", "--keep-all-entities", help="With --entities-file, output a line for every entity, \
+                                                        even if none of the output files are found",
+                      required=False, default=False, action='store_true')
   args = parser.parse_args()
 
   log_level = args.log_level
@@ -124,14 +301,25 @@ def main():
     raise ValueError('Invalid log level: %s' % log_level)
   logging.basicConfig(level=numeric_level, format='%(levelname)s: %(message)s')
 
-  workflows, filenames, output_file, bucket = args.workflows, args.filenames, args.output_file, args.bucket
-  check_file_nonempty(workflows)
+  filenames, output_file, bucket = args.filenames, args.output_file, args.bucket  # required
   check_file_nonempty(filenames)
-
-  batches, batch_dirs, bucket = make_batch_dir_dict(workflows, bucket)
   files_dict, output_names, num_outputs = load_filenames(filenames)
 
-  get_output_files(batches, bucket, batch_dirs, files_dict, output_names, num_outputs, output_file)
+  workflows, workflow_id = args.workflows, args.id
+  if workflow_id is None:
+    if workflows is None: 
+      raise ValueError("Must provide either -w or -i input")
+    else:
+      check_file_nonempty(workflows)
+  else:
+    if workflows is not None:
+      logging.warning("Using workflow ID provided by --id and ignoring --workflows input")
+  batches, batch_dirs, bucket, single_workflow = make_batch_dir_dict(workflows, workflow_id, bucket)
+  
+  single_file, entities_file, keep_all_entities = args.single_file, args.entities_file, args.keep_all_entities
+  entity_type, num_entities, entities = read_entities_file(entities_file, single_file)
+
+  get_output_files(batches, bucket, batch_dirs, files_dict, output_names, num_outputs, output_file, single_file, num_entities, entities, entity_type, keep_all_entities)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Script to find GCS paths for specified outputs for multiple batches (multiple workflows per batch ok) without downloading metadata. This is intended for situations with many batches (or samples) in which it would be impractical to download the metadata for each workflow. It is not particularly fast and does incur a small cost because it uses `gsutil ls` with wildcards, but should only have to be run once (or once per batch, if doing groups of batches). Assumes common output bucket for all workflows provided, with subdirectories organized by workflow ID. (Note: definitely only run on outputs bucket rather than execution bucket, to minimize number of objects searched.)

Usage:
```
Summary: find GCS paths for specified outputs for multiple batches without downloading metadata

Usage:
  python get_output_paths.py -w workflows.tsv -f filenames.json -o output.tsv -b gs://bucket/ [-l LEVEL]

Parameters:
  Required:
  -w,--workflows: TSV file (no header) with batch (or sample) names and workflow IDs 
  -f,--filenames: JSON file with output names and filename suffixes (assumes ONE file per output, not an array, string, or int)
  -o,--output_file: Output file path (TSV)
  -b,--bucket: Google bucket path to search for files (common to all workflows)
  Optional:
  -l,--log-level LEVEL (specify level of logging information to print, ie. INFO, WARNING, ERROR - not case-sensitive)

Outputs:
  - TSV file with columns for batch and each output variable, a row for each batch, containing GCS output paths
```

Required input files are:
* TSV in the following format:
```
batch_or_sample_id1	workflow_id1
batch_or_sample_id2	workflow_id2
…
```
* JSON of outputs and the corresponding filenames to search for. Module04 example:
```
{
  "trained_SR_metrics": "sr_metric_file.txt",
  "sr_background_fail": "genotype_SR_part2_background_fail.txt",
  "genotyped_pesr_vcf": "pesr.vcf.gz",
  "trained_genotype_pesr_pesr_sepcutoff": "pesr.pesr_sepcutoff.txt",
  "sr_bothside_pass": "genotype_SR_part2_bothside_pass.txt",
  "trained_genotype_depth_pesr_sepcutoff": "depth.pesr_sepcutoff.txt",
  "genotyped_pesr_vcf_index": "pesr.vcf.gz.tbi",
  "trained_genotype_pesr_depth_sepcutoff": "pesr.depth_sepcutoff.txt",
  "trained_genotype_depth_depth_sepcutoff": "depth.depth_sepcutoff.txt",
  "trained_PE_metrics": "pe_metric_file.txt",
  "genotyped_depth_vcf": "depth.vcf.gz",
  "genotyped_depth_vcf_index": "depth.vcf.gz.tbi",
  "regeno_coverage_medians": "regeno.coverage_medians_merged.bed"
}
```