### PR TITLE
Add missing optional flag to module07MinGQ.wdl

### DIFF
--- a/src/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py
+++ b/src/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py
@@ -419,8 +419,9 @@ def main():
                     record.info.pop(key)
 
         # Standardize SVTYPE for all INS variants, if optioned
-        if args.simplify_INS_SVTYPEs and 'INS' in record.info['SVTYPE']:
-            record.info['SVTYPE'] = 'INS'
+        if any([keyword in record.info['SVTYPE'].split(':') for keyword in 'INS MEI'.split()]):
+            if args.simplify_INS_SVTYPEs:
+                record.info['SVTYPE'] = 'INS'
 
         if args.dropEmpties:
             samps = svu.get_called_samples(record, include_null=False)

--- a/wdl/Module07MinGQ.wdl
+++ b/wdl/Module07MinGQ.wdl
@@ -847,6 +847,7 @@ task ApplyMinGQFilter {
     /opt/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py \
       --minGQ "~{global_minGQ}" \
       --maxNCR "~{maxNCR}" \
+      --simplify-INS-SVTYPEs \
       --cleanAFinfo \
       --prefix "~{PCR_status}" \
       "~{vcf}" \


### PR DESCRIPTION
This was a simple oversight from [a previous PR](https://github.com/broadinstitute/gatk-sv/commit/aa811c17503e1bf9e80a69c8c2153a956e723a0f) aimed at fixing mobile element `SVTYPE` misspecification during minGQ filtering.

The previous PR added `--simplify-INS-SVTYPEs` to `apply_minGQ_filter.py` in `minGQ.wdl`, but *not* to `Module07MinGQ.wdl`.

I'm less clear on why we need to keep both versions of minGQ and Module07MinGQ, but until we make a decision on that, we need to add the missing `--simplify-INS-SVTYPEs` flag to both versions of the WDL.