### PR TITLE
Add missing option to minGQ filtering in module 07

### DIFF
--- a/wdl/Module07MinGQ.wdl
+++ b/wdl/Module07MinGQ.wdl
@@ -847,6 +847,7 @@ task ApplyMinGQFilter {
     /opt/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py \
       --minGQ "~{global_minGQ}" \
       --maxNCR "~{maxNCR}" \
+      --simplify-INS-SVTYPEs \
       --cleanAFinfo \
       --prefix "~{PCR_status}" \
       "~{vcf}" \


### PR DESCRIPTION
This was a simple oversight from [a previous PR](https://github.com/broadinstitute/gatk-sv/pull/109) aimed at fixing mobile element `SVTYPE` misspecification during minGQ filtering.

The previous PR added `--simplify-INS-SVTYPEs` to `apply_minGQ_filter.py` in `minGQ.wdl`, but *not* to `Module07MinGQ.wdl`.

I'm less clear on why we need to keep both versions of minGQ and Module07MinGQ, but until we make a decision on that, we need to add the missing `--simplify-INS-SVTYPEs` flag to both versions of the WDL.