### PR TITLE
Make outlier cutoff table input to 03 optional

### DIFF
--- a/wdl/Module03.wdl
+++ b/wdl/Module03.wdl
@@ -24,7 +24,7 @@ workflow Module03 {
     File evidence_metrics_common
 
     Int outlier_cutoff_nIQR
-    File outlier_cutoff_table
+    File? outlier_cutoff_table
 
     String sv_pipeline_docker
     String sv_base_mini_docker


### PR DESCRIPTION
### Updates
Make outlier cutoff table input to Module03 optional. This is because the cutoff table should really be specific to the cohort, but it currently must be generated outside of the canonical pipeline, and the "default" 1KG table that we use for testing is very permissive so it doesn't impact filtering to use it. Therefore, having an optional input (rather than a no-impact default value for a required input) seems to make it clearer to the user that they have to provide their own table in order for this method of filtering to be useful. With or without a cutoff table, the IQR filtering will still be performed.

### Testing
This branch was tested with and without a cutoff table on `test_large` data and Module03 completed successfully in both cases. The outputs were identical, because the permissive default table was used for testing, but I verified that the cutoff table task did run when the cutoff table was provided (and did not run without it). 