### PR TITLE
Small bug and aesthetic fixes for quota script

### DIFF
--- a/scripts/cromwell/analyze_resource_acquisition.py
+++ b/scripts/cromwell/analyze_resource_acquisition.py
@@ -98,6 +98,8 @@ def calculate_start_end(call_info, override_warning=False, alias=None):
       alias = job_id
     else:
       alias += "." + job_id
+  elif alias is None or alias == "":
+    alias = "NA"
 
   # get start (start time of VM start) & end time (end time of 'ok') according to metadata
   start = None


### PR DESCRIPTION
### Updates
* Previously, if the job ID was missing for a task, the script broke. Modified to just continue processing regardless
* Previously, cached tasks may have been counted as non-preemptible in rare cases when information about the number of attempts was missing. Modified to automatically mark cached tasks as preemptible in order to avoid inflating the non-preemptible VMs count
* Various aesthetic fixes

### Testing
Tested with an array of small, large, successful, failed, clean, cached, and broken metadata files