### PR TITLE
Module04b: parametrize sample overlap and minimum var count outlier threshold for regeno filtering

### DIFF
--- a/wdl/Module04b.wdl
+++ b/wdl/Module04b.wdl
@@ -26,6 +26,8 @@ workflow Module04b {
     Array[File] regeno_coverage_medians # one file per batch
     Float regeno_max_allele_freq = 0.01 
     Int regeno_allele_count_threshold = 3 
+    Int min_var_per_sample_outlier_threshold = 3
+    Float regeno_sample_overlap = 0.7
 
     RuntimeAttr? runtime_attr_cluster_merged_depth_beds
     RuntimeAttr? runtime_attr_regeno_raw_combined_depth
@@ -188,6 +190,8 @@ workflow Module04b {
         regeno_file = MergeList.master_regeno,
         regeno_sample_ids_lookup = ConcatSampleIdLookupBed.concat_bed,
         vcfs = Genotype_2.genotyped_vcf,
+        min_var_per_sample_outlier_threshold = min_var_per_sample_outlier_threshold,
+        regeno_sample_overlap = regeno_sample_overlap,
         sv_pipeline_docker = sv_pipeline_docker,
         sv_pipeline_base_docker = sv_pipeline_base_docker,
         runtime_attr_merge_list_creassess = runtime_attr_merge_list_creassess,

--- a/wdl/Module04b.wdl
+++ b/wdl/Module04b.wdl
@@ -24,10 +24,10 @@ workflow Module04b {
     String cohort             # Cohort name or project prefix for all cohort-level outputs
     File contig_list
     Array[File] regeno_coverage_medians # one file per batch
-    Float regeno_max_allele_freq = 0.01 
-    Int regeno_allele_count_threshold = 3 
-    Int min_var_per_sample_outlier_threshold = 3
-    Float regeno_sample_overlap = 0.7
+    Float regeno_max_allele_freq = 0.01 # Rare variant filter for regenotyping candidates: must be < AF threshold (this parameter) or <= AC threshold (below)
+    Int regeno_allele_count_threshold = 3 # Rare variant filter for regenotyping candidates: must be < AF threshold (above) or <= AC threshold (this parameter)
+    Int min_var_per_sample_outlier_threshold = 3 # Threshold below which regeno SV count per sample should not be considered an outlier (need when counts are sparse)
+    Float regeno_sample_overlap = 0.7 # Minimum sample overlap required between raw and regenotyped calls
 
     RuntimeAttr? runtime_attr_cluster_merged_depth_beds
     RuntimeAttr? runtime_attr_regeno_raw_combined_depth


### PR DESCRIPTION
### Updates
* In Module04b.CombineReassess.MergeList, do not count sample as outlier for regenotyped variant count unless it has >3 such variants (and add optional parameter to change that threshold)
* In the same task, add a parameter for the sample overlap threshold (between samples with raw calls & samples with regenotyped calls), which is set to 0.7 by default

### Testing
Tested on test_large, 1 gnomAD batch, and 30 gnomAD batches with default parameters. The number of regenotyped variants was unchanged in each case.