### PR TITLE
Fix annotation external AF error by sorting vcf2bed output

### DIFF
--- a/wdl/AnnotateExternalAF.wdl
+++ b/wdl/AnnotateExternalAF.wdl
@@ -223,7 +223,9 @@ task SplitVcf{
     
     command <<<
         svtk vcf2bed -i SVTYPE -i SVLEN ~{vcf} tmp.bed
-        cut -f1-4,7-8 tmp.bed > ~{prefix}.bed
+        head -1 tmp.bed > tmp.sorted.bed
+        awk 'NR > 1' < tmp.bed | sort -k1,1V -k2,2n -k3,3n >> tmp.sorted.bed
+        cut -f1-4,7-8 tmp.sorted.bed > ~{prefix}.bed
         head -1 ~{prefix}.bed > header
         cat header <(awk '{if ($5=="DEL") print}' ~{prefix}.bed )> ~{prefix}.DEL.bed
         cat header <(awk '{if ($5=="DUP") print}' ~{prefix}.bed )> ~{prefix}.DUP.bed

--- a/wdl/AnnotateExternalAF.wdl
+++ b/wdl/AnnotateExternalAF.wdl
@@ -222,10 +222,12 @@ task SplitVcf{
     String prefix = basename(vcf, ".vcf.gz")
     
     command <<<
-        svtk vcf2bed -i SVTYPE -i SVLEN ~{vcf} tmp.bed
-        head -1 tmp.bed > tmp.sorted.bed
-        awk 'NR > 1' < tmp.bed | sort -k1,1V -k2,2n -k3,3n >> tmp.sorted.bed
-        cut -f1-4,7-8 tmp.sorted.bed > ~{prefix}.bed
+        svtk vcf2bed -i SVTYPE -i SVLEN ~{vcf} - |
+            cut -f1-4,7-8 > tmp.bed
+        head -1 tmp.bed > ~{prefix}.bed
+        awk 'NR > 1' < tmp.bed \
+            | sort -k1,1V -k2,2n -k3,3n >> ~{prefix}.bed
+        rm tmp.bed
         head -1 ~{prefix}.bed > header
         cat header <(awk '{if ($5=="DEL") print}' ~{prefix}.bed )> ~{prefix}.DEL.bed
         cat header <(awk '{if ($5=="DUP") print}' ~{prefix}.bed )> ~{prefix}.DUP.bed


### PR DESCRIPTION
A recent single sample pipeline run encountered an "unsorted BED file" error in Module08.AnnotateExternalAF as described here: https://github.com/broadinstitute/gatk-sv/issues/135

This fixes that error by re-sorting the results of `svtk vcf2bed`. 