### PR TITLE
relax single-sample QC thresholds to allow values seen in additional good pcr-free samples

### DIFF
--- a/input_values/ref_panel_1kg_v2.json
+++ b/input_values/ref_panel_1kg_v2.json
@@ -1090,7 +1090,7 @@
     "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/NA21122.split.txt.gz",
     "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/NA21133.split.txt.gz"
   ],
-  "qc_definitions" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/single_sample.qc_definitions.tsv",
+  "qc_definitions" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/single_sample.qc_definitions.v2.tsv",
   "requester_pays_crams" : "true",
   "samples":  [
     "HG00096",


### PR DESCRIPTION
Recent real-life runs of the single sample pipeline have highlighted that some of the QC definitions for the current reference panel are too strict. In particular, the WGD score thresholds, while covering the entire range of reference panel samples, would exclude many non-outlier PCR-free samples based on the distribution of scores seen in gnomAD samples. Some of this is likely due to the fact that the old thresholds were set based on values calculated with prior versions of the WGD scoring mask. This PR switches runs that use the current 1kg_v2 reference panel to a new version of the QC definitions file. WGD scores in the new file are based on the distribution of non-outlier-sample WGD scores in gnomAD. I've also updated some variant count thresholds that many samples were failing in recent runs on SFARI data.

Since we don't currently check in these definitions files (should we?), I'll document the changes here:

WGD_score_sample min: change from -0.1053 to -0.307
WGD_score_sample max: change from 0.1208 to 0.068
final_vcf_BND_count max: change from 1300 to 1800
final_vcf_INS_pass_size_5000_100000 max: change from 34.6 to 50.0

Here's the complete new version of the file:

```
METRIC	MIN	MAX
rd_mean_sample	15	200
wgd_score_sample	-0.307	0.068
sr_left_sample	4166678.0	75457545.8
sr_right_sample	4169899.2	75377368.3
pe_LL_sample	539588.1	6337340.5
pe_RR_sample	396180.7	6876821.2
pe_LR_sample	1379831.1	13423140.6
pe_RL_sample	592065.5	7370520.4
rd_q25_sample	10.0	49.2
rd_q50_sample	12.8	54.8
rd_q75_sample	15.8	60.6
final_vcf_BND_count	522	1800
final_vcf_CPX_pass_count	1.0	80.2
final_vcf_CPX_pass_size_0_500	0.0	25.9
final_vcf_CPX_pass_size_5000_100000	0.0	10.0
final_vcf_CPX_pass_size_500_5000	0.0	35.3
final_vcf_CPX_pass_size_gte_100000	0.0	10.0
final_vcf_DEL_pass_count	2250	3534
final_vcf_DEL_pass_size_0_500	1750	3009
final_vcf_DEL_pass_size_5000_100000	140	261
final_vcf_DEL_pass_size_500_5000	375	917
final_vcf_DEL_pass_size_gte_100000	0.0	28.1
final_vcf_DUP_pass_count	387.6	1246
final_vcf_DUP_pass_size_0_500	279.5	1073
final_vcf_DUP_pass_size_5000_100000	36.3	195.6
final_vcf_DUP_pass_size_500_5000	1.0	1291.5
final_vcf_DUP_pass_size_gte_100000	0.0	17.5
final_vcf_INS_pass_count	606.6	2856
final_vcf_INS_pass_size_0_500	570.2	2676
final_vcf_INS_pass_size_5000_100000	0.0	50.0
final_vcf_INS_pass_size_500_5000	15	142
final_vcf_INS_pass_size_gte_100000	0.0	10.0
final_vcf_INV_pass_count	0.0	18.8
final_vcf_INV_pass_size_0_500	0.0	10.0
final_vcf_INV_pass_size_5000_100000	0.0	10.0
final_vcf_INV_pass_size_500_5000	0.0	14.9
final_vcf_INV_pass_size_gte_100000	0.0	10.0
final_vcf_MCNV_count	161.5	167.4
```