### PR TITLE
add -w flag to grep for varID searches in 04b

### DIFF
--- a/wdl/CombineReassess.wdl
+++ b/wdl/CombineReassess.wdl
@@ -64,7 +64,7 @@ task Vcf2Bed {
     svtk vcf2bed ~{vcf} ~{vcf}.bed
     awk '{if($6!="")print $0}' ~{vcf}.bed >~{vcf}.nonempty.bed
     cut -f 4 ~{regeno_file} >regeno_variants.txt
-    fgrep -f regeno_variants.txt ~{vcf}.nonempty.bed> nonempty.txt
+    fgrep -wf regeno_variants.txt ~{vcf}.nonempty.bed> nonempty.txt
   >>>
   output {
     File nonempty="nonempty.txt"
@@ -103,7 +103,7 @@ task MergeList {
   command <<<
     set -euo pipefail
     cut -f 4 ~{regeno_file} >regeno_variants.txt
-    fgrep -f regeno_variants.txt ~{regeno_sample_ids_lookup} > cohort.regeno_var.combined.bed
+    fgrep -wf regeno_variants.txt ~{regeno_sample_ids_lookup} > cohort.regeno_var.combined.bed
     cat ~{sep=' ' nonempty_txt}|sort -k1,1V -k2,2n -k3,3n |bgzip -c > nonempty.bed.gz
     tabix nonempty.bed.gz
     # For each variant in regeno_file, take variants across all batches
@@ -113,7 +113,7 @@ task MergeList {
     done<~{regeno_file} >regeno_variant_sample.txt
     # Use cohort cluster file, add samples that are clustered with the variant in question across whole cohort
     while read chr start end var sample;do
-        expected_samples=$(fgrep $var: cohort.regeno_var.combined.bed |cut -f8)
+        expected_samples=$(fgrep -w $var: cohort.regeno_var.combined.bed |cut -f8)
         printf "$var\t$sample\t$expected_samples\n"
     done<regeno_variant_sample.txt > reassesss_by_var.txt
     python3 <<CODE

--- a/wdl/CombineReassess.wdl
+++ b/wdl/CombineReassess.wdl
@@ -103,7 +103,7 @@ task MergeList {
   command <<<
     set -euo pipefail
     cut -f 4 ~{regeno_file} >regeno_variants.txt
-    fgrep -wf regeno_variants.txt ~{regeno_sample_ids_lookup} > cohort.regeno_var.combined.bed
+    fgrep -f regeno_variants.txt ~{regeno_sample_ids_lookup} > cohort.regeno_var.combined.bed
     cat ~{sep=' ' nonempty_txt}|sort -k1,1V -k2,2n -k3,3n |bgzip -c > nonempty.bed.gz
     tabix nonempty.bed.gz
     # For each variant in regeno_file, take variants across all batches
@@ -113,7 +113,7 @@ task MergeList {
     done<~{regeno_file} >regeno_variant_sample.txt
     # Use cohort cluster file, add samples that are clustered with the variant in question across whole cohort
     while read chr start end var sample;do
-        expected_samples=$(fgrep -w $var: cohort.regeno_var.combined.bed |cut -f8)
+        expected_samples=$(fgrep $var: cohort.regeno_var.combined.bed |cut -f8)
         printf "$var\t$sample\t$expected_samples\n"
     done<regeno_variant_sample.txt > reassesss_by_var.txt
     python3 <<CODE

--- a/wdl/Genotype_2.wdl
+++ b/wdl/Genotype_2.wdl
@@ -290,7 +290,7 @@ task ConcatReGenotypedVcfs {
       | vcf-sort -c \
       | bgzip -c > ~{batch}.regeno.vcf.gz
     cut -f 4 ~{bed} |awk '{print $0"\t"}'> varlist.txt
-    zcat ~{depth_vcf} |fgrep -f varlist.txt -v |bgzip -c > no_variant.vcf.gz
+    zcat ~{depth_vcf} |fgrep -wf varlist.txt -v |bgzip -c > no_variant.vcf.gz
     vcf-concat ~{batch}.regeno.vcf.gz no_variant.vcf.gz \
       | vcf-sort -c \
       | bgzip -c > ~{batch}.depth.regeno.vcf.gz

--- a/wdl/Genotype_2.wdl
+++ b/wdl/Genotype_2.wdl
@@ -290,7 +290,7 @@ task ConcatReGenotypedVcfs {
       | vcf-sort -c \
       | bgzip -c > ~{batch}.regeno.vcf.gz
     cut -f 4 ~{bed} |awk '{print $0"\t"}'> varlist.txt
-    zcat ~{depth_vcf} |fgrep -wf varlist.txt -v |bgzip -c > no_variant.vcf.gz
+    zcat ~{depth_vcf} |fgrep -f varlist.txt -v |bgzip -c > no_variant.vcf.gz
     vcf-concat ~{batch}.regeno.vcf.gz no_variant.vcf.gz \
       | vcf-sort -c \
       | bgzip -c > ~{batch}.depth.regeno.vcf.gz

--- a/wdl/Module04b.wdl
+++ b/wdl/Module04b.wdl
@@ -722,9 +722,9 @@ task ConcatRegenotypedVcfs {
   command <<<
     set -euo pipefail
     zcat ~{regeno_vcf} |fgrep "#" > head.txt
-    zcat ~{regeno_vcf} |fgrep -f ~{regeno_variants} >body.txt
+    zcat ~{regeno_vcf} |fgrep -wf ~{regeno_variants} >body.txt
     cat head.txt body.txt|bgzip -c > regeno.vcf.gz
-    zcat ~{depth_vcf} |fgrep -f ~{regeno_variants} -v |bgzip -c > no_variant.vcf.gz
+    zcat ~{depth_vcf} |fgrep -wf ~{regeno_variants} -v |bgzip -c > no_variant.vcf.gz
     vcf-concat regeno.vcf.gz no_variant.vcf.gz \
       | vcf-sort -c \
       | bgzip -c > ~{batch}.depth.regeno_final.vcf.gz


### PR DESCRIPTION
### Updates
Add -w flag to grep in several places in Module04b when extracting variants by variant ID, to avoid matching variant IDs on a substring and getting more variants than expected. 

### Testing
Tested successfully on `test_large` data. This resulted in a change from 85 to 46 filtered regenotyped variants at the end (despite starting with the same number of original regenotyping candidates, 408).