### PR TITLE
Fix BAFFromGVCFs GenotypeGVCFs

### DIFF
--- a/wdl/GATKSVPipelinePhase1.wdl
+++ b/wdl/GATKSVPipelinePhase1.wdl
@@ -54,6 +54,7 @@ workflow GATKSVPipelinePhase1 {
     Array[File]? gvcfs
     File? unpadded_intervals_file
     File? dbsnp_vcf
+    File? dbsnp_vcf_index
     File? gvcf_gcs_project_for_requester_pays
 
     # BAF Option #2, position-sharded VCFs
@@ -239,6 +240,7 @@ workflow GATKSVPipelinePhase1 {
       gvcfs = gvcfs,
       unpadded_intervals_file = unpadded_intervals_file,
       dbsnp_vcf = dbsnp_vcf,
+      dbsnp_vcf_index = dbsnp_vcf_index,
       gvcf_gcs_project_for_requester_pays = gvcf_gcs_project_for_requester_pays,
       ref_fasta = reference_fasta,
       ref_fasta_index = reference_index,

--- a/wdl/Module00c.wdl
+++ b/wdl/Module00c.wdl
@@ -65,6 +65,7 @@ workflow Module00c {
     Array[File]? gvcfs
     File? unpadded_intervals_file
     File? dbsnp_vcf
+    File? dbsnp_vcf_index
     String? gvcf_gcs_project_for_requester_pays  # Required only if GVCFs are in a requester pays bucket
 
     # BAF Option #2, position-sharded VCFs
@@ -243,6 +244,7 @@ workflow Module00c {
         samples = samples,
         unpadded_intervals_file = select_first([unpadded_intervals_file]),
         dbsnp_vcf = select_first([dbsnp_vcf]),
+        dbsnp_vcf_index = dbsnp_vcf_index,
         ref_fasta = ref_fasta,
         ref_fasta_index = ref_fasta_index,
         ref_dict = ref_dict,


### PR DESCRIPTION
- Fix Module00c/BAFFromGVCFs/GenotypeGVCFs by localizing dbsnp_vcf_index to the container. GenotypeGVCFs is expecting to have the index file next to the vcf file (https://github.com/broadinstitute/gatk-sv/issues/138).
- Dynamically allocate size of the disk based on the input files