### PR TITLE
Update clean_vcf_part1 to fix bugs in setting FORMAT EV tags

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -13,7 +13,7 @@
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:mw-gnomad-02-6a66c96",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:rlc_posthoc_filtering_cnv_mcnv_compatability_9a8561",
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-base:rlc_posthoc_filtering_cnv_mcnv_compatability_9a8561",
-  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:rlc_posthoc_filtering_cnv_mcnv_compatability_9a8561",
+  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:cw_cleanvcf1_bcftools_version_ac0701",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-qc:mw-xz-fixes-7cbffee",
   "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-rdtest:mw-gnomad-02-6a66c96",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa",

--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -13,7 +13,7 @@
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:mw-gnomad-02-6a66c96",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:rlc_posthoc_filtering_cnv_mcnv_compatability_9a8561",
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-base:rlc_posthoc_filtering_cnv_mcnv_compatability_9a8561",
-  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:cw_cleanvcf1_bcftools_version_ac0701",
+  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:cw_cleanvcf1_ev_script_7cf6798",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-qc:mw-xz-fixes-7cbffee",
   "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-rdtest:mw-gnomad-02-6a66c96",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa",

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1.sh
@@ -30,27 +30,8 @@ zcat $vcf \
   > includelist.txt
 
 ##convert EV integer back into string##
-${BCFTOOLS} query -f "%CHROM\t%POS\t%REF\t%ALT\t[%EV\t]\n" $vcf > ev.tab
-cut -f1-4 ev.tab > ev.sites.tab
-cut -f5- ev.tab \
-  | sed -e 's/7/RD,PE,SR/g' -e 's/6/PE,SR/g' -e 's/5/RD,SR/g' -e 's/3/RD,PE/g' -e 's/2/PE/g' -e 's/4/SR/g' -e 's/1/RD/g' \
-  > ev.replaced.list
-paste ev.sites.tab ev.replaced.list | bgzip -c > ev.replaced.tab.gz
-tabix -s1 -b2 -e2 ev.replaced.tab.gz
-
-echo '##FORMAT=<ID=EV,Number=1,Type=String,Description="Classes of evidence supporting final genotype">' > ev_header.txt
-tabix $vcf
-${BCFTOOLS} annotate -x FORMAT/EV $vcf | bgzip -c > no_ev.vcf.gz
-rm $vcf $vcf.tbi
-
-${BCFTOOLS} annotate \
-  -a ev.replaced.tab.gz \
-  -c CHROM,POS,REF,ALT,FORMAT/EV \
-  -h ev_header.txt \
-  no_ev.vcf.gz \
-  | bgzip -c > EV.update.vcf.gz
-
-rm ev.tab no_ev.vcf.gz ev.replaced.tab.gz ev.replaced.tab.gz.tbi ev.replaced.list
+/opt/sv-pipeline/04_variant_resolution/scripts/replace_ev_numeric_code_with_string.py ${vcf} - | bgzip -c > EV.update.vcf.gz
+rm $vcf
 
 ##convert all alt to svtype and alt to N##
 svtk vcf2bed EV.update.vcf.gz stdout -i SVTYPE  \

--- a/src/sv-pipeline/04_variant_resolution/scripts/replace_ev_numeric_code_with_string.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/replace_ev_numeric_code_with_string.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+import argparse
+import gzip
+import sys
+
+ev_numeric_code_to_string_map = {
+    '1' : 'RD',
+    '2' : 'PE',
+    '3' : 'RD,PE',
+    '4' : 'SR',
+    '5' : 'RD,SR',
+    '6' : 'PE,SR',
+    '7' : 'RD,PE,SR'
+}
+
+def replace_ev_numeric_codes(vcf, fout):
+    while True:
+        line = vcf.readline().rstrip()
+        if not line:
+            break
+        line_fields = line.split("\t")
+        format_def = line_fields[8]
+        format_def_fields = format_def.split(":")
+        if 'EV' in format_def_fields:
+            ev_idx = format_def_fields.index('EV')
+            for idx in range(9, len(line_fields)):
+                samp_gt_fields = line_fields[idx].split(":")
+                ev_numeric = samp_gt_fields[ev_idx]
+                ev_string = ev_numeric_code_to_string_map[ev_numeric]
+                samp_gt_fields[ev_idx] = ev_string
+                new_samp_gt = ":".join(samp_gt_fields)
+                line_fields[idx] = new_samp_gt
+        new_line = "\t".join(line_fields)
+        print(new_line, file=fout)
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('vcf')
+    parser.add_argument('fout')
+
+    args = parser.parse_args()
+
+    # we don't use pysam for this due to bugs in our version: https://github.com/pysam-developers/pysam/issues/554
+    # if we ever upgrade pysam to version 0.15.3 or later we should consider replacing this with a pysam implementation
+
+    if args.vcf in '- stdin'.split():
+        vcf = sys.stdin
+    else:
+        if args.vcf.endswith(".gz"):
+            vcf = gzip.open(args.vcf, 'rt')
+        else:
+            vcf = open(args.vcf, 'r')
+
+
+    new_ev_header_line = '##FORMAT=<ID=EV,Number=1,Type=String,Description="Classes of evidence supporting final genotype">'
+
+    if args.fout in '- stdout'.split():
+        fout = sys.stdout
+    else:
+        fout = open(args.fout, 'w')
+
+    while True:
+        line = vcf.readline().rstrip()
+        if not line.startswith("##"):
+            break
+        if line.startswith('##FORMAT=<ID=EV,'):
+            print(new_ev_header_line, file=fout)
+        else:
+            print(line, file=fout)
+
+    # print the #CHROM line
+    print(line, file=fout)
+
+    replace_ev_numeric_codes(vcf, fout)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
A bug in bcftools 1.7 was preventing evidence annotations from being added to some mCNV records in clean_vcf_part1. 

This bug seems to be fixed in bcftools 1.9.

In our sv-pipeline dockers, conda pulls in bcftools 1.7 as a fixed dependency of pysam and puts it on the path, but we have an installation of bcftools 1.9 in /usr/local/bin. This PR changes clean_vcf_part1.sh to use the version 1.9 installation of bcftools.