### PR TITLE
Add option to randomly subsample samples for trainGCNV (for Terra)

### DIFF
--- a/wdl/Utils.wdl
+++ b/wdl/Utils.wdl
@@ -119,3 +119,64 @@ task RunQC {
   }
 
 }
+
+task RandomSubsampleStringArray {
+  input {
+    Array[String] strings
+    Int seed
+    Int quantity
+    String prefix = "prefix"
+    String sv_pipeline_base_docker
+    RuntimeAttr? runtime_attr_override
+  }
+
+  String subsample_indices_filename = "~{prefix}.subsample_indices.list"
+  String subsampled_strings_filename = "~{prefix}.subsampled_strings.list"
+
+  RuntimeAttr default_attr = object {
+    cpu_cores: 1,
+    mem_gb: 3.75,
+    disk_gb: 10,
+    boot_disk_gb: 10,
+    preemptible_tries: 3,
+    max_retries: 1
+  }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+  command <<<
+
+    set -euo pipefail
+    python3 <<CODE
+    import random
+    string_array = ['~{sep="','" strings}']
+    array_len = len(string_array)
+    if ~{quantity} > array_len:
+      raise ValueError("Subsample quantity ~{quantity} cannot > array length %d" % array_len)
+    random.seed(~{seed})
+    numbers = random.sample(range(0, array_len), k=~{quantity})
+    numbers.sort()
+    with open("~{subsample_indices_filename}", 'w') as indices, open("~{subsampled_strings_filename}", 'w') as strings:
+      for num in numbers:
+        indices.write(f"{num}\n")
+        strings.write(string_array[num] + "\n")
+    CODE
+
+  >>>
+
+  output {
+    File subsample_indices_file = subsample_indices_filename
+    Array[Int] subsample_indices_array = read_lines(subsample_indices_filename)
+    File subsampled_strings_file = subsampled_strings_filename
+    Array[String] subsampled_strings_array = read_lines(subsampled_strings_filename)
+  }
+
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: sv_pipeline_base_docker
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
+  }
+}

--- a/wdl/Utils.wdl
+++ b/wdl/Utils.wdl
@@ -124,8 +124,8 @@ task RandomSubsampleStringArray {
   input {
     Array[String] strings
     Int seed
-    Int quantity
-    String prefix = "prefix"
+    Int subset_size
+    String prefix
     String sv_pipeline_base_docker
     RuntimeAttr? runtime_attr_override
   }
@@ -150,10 +150,10 @@ task RandomSubsampleStringArray {
     import random
     string_array = ['~{sep="','" strings}']
     array_len = len(string_array)
-    if ~{quantity} > array_len:
-      raise ValueError("Subsample quantity ~{quantity} cannot > array length %d" % array_len)
+    if ~{subset_size} > array_len:
+      raise ValueError("Subsample quantity ~{subset_size} cannot > array length %d" % array_len)
     random.seed(~{seed})
-    numbers = random.sample(range(0, array_len), k=~{quantity})
+    numbers = random.sample(range(0, array_len), k=~{subset_size})
     numbers.sort()
     with open("~{subsample_indices_filename}", 'w') as indices, open("~{subsampled_strings_filename}", 'w') as strings:
       for num in numbers:

--- a/wdl/trainGCNV.wdl
+++ b/wdl/trainGCNV.wdl
@@ -105,7 +105,7 @@ workflow TrainGCNV {
       input:
         strings = samples,
         seed = subsample_seed,
-        quantity = select_first([n_samples_subsample]),
+        subset_size = select_first([n_samples_subsample]),
         prefix = cohort,
         sv_pipeline_base_docker = select_first([sv_pipeline_base_docker])
     }


### PR DESCRIPTION
### Updates
Add optional parameter to trainGCNV to randomly subsample a subset of samples to use for gCNV training, rather than the full sample list passed in. This feature will be useful for Terra to allow per-batch gCNV training without having to train on every sample in the batch. There is a seed parameter with a default value set in the WDL, and usage of the random subsampling parameter requires passing an additional docker image (for Python). 

### Testing
Tested with and without random subsampling with `test_small` dataset.