### PR TITLE
Make GATKSVPipelineSingleSample validate it in MiniWDL

### DIFF
--- a/wdl/DepthPreprocessing.wdl
+++ b/wdl/DepthPreprocessing.wdl
@@ -23,7 +23,7 @@ workflow MergeDepth {
     String sv_base_mini_docker
     String sv_pipeline_docker
     Int gcnv_qs_cutoff
-    Float defragment_max_dist
+    Float? defragment_max_dist
     RuntimeAttr? runtime_attr_merge_sample
     RuntimeAttr? runtime_attr_merge_set
     RuntimeAttr? runtime_attr_convert_gcnv
@@ -141,11 +141,13 @@ task MergeSample {
   input {
     File gcnv
     Array[File] cnmops
-    Float max_dist = 0.25
+    Float? max_dist = 0.25
     String sample_id
     String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
+
+  Float _max_dist = select_first([max_dist, 0.25])
 
   RuntimeAttr default_attr = object {
     cpu_cores: 1, 
@@ -167,7 +169,7 @@ task MergeSample {
     cat ~{gcnv} cnmops.cnv | sort -k1,1V -k2,2n > ~{sample_id}.bed
     bedtools merge -i ~{sample_id}.bed -d 0 -c 4,5,6,7 -o distinct > ~{sample_id}.merged.bed
     /opt/sv-pipeline/00_preprocessing/scripts/defragment_cnvs.py \
-      --max-dist ~{max_dist} ~{sample_id}.merged.bed ~{sample_id}.merged.defrag.bed
+      --max-dist ~{_max_dist} ~{sample_id}.merged.bed ~{sample_id}.merged.defrag.bed
     sort -k1,1V -k2,2n ~{sample_id}.merged.defrag.bed > ~{sample_id}.merged.defrag.sorted.bed
     
   >>>

--- a/wdl/DepthPreprocessing.wdl
+++ b/wdl/DepthPreprocessing.wdl
@@ -160,6 +160,7 @@ task MergeSample {
   output {
     File sample_bed = "~{sample_id}.merged.defrag.sorted.bed"
   }
+  Float max_dist_ = select_first([max_dist, 0.25])
   command <<<
 
     set -euo pipefail
@@ -167,7 +168,7 @@ task MergeSample {
     cat ~{gcnv} cnmops.cnv | sort -k1,1V -k2,2n > ~{sample_id}.bed
     bedtools merge -i ~{sample_id}.bed -d 0 -c 4,5,6,7 -o distinct > ~{sample_id}.merged.bed
     /opt/sv-pipeline/00_preprocessing/scripts/defragment_cnvs.py \
-      --max-dist ~{select_first([max_dist, 0.25])}} ~{sample_id}.merged.bed ~{sample_id}.merged.defrag.bed
+      --max-dist ~{max_dist_}} ~{sample_id}.merged.bed ~{sample_id}.merged.defrag.bed
     sort -k1,1V -k2,2n ~{sample_id}.merged.defrag.bed > ~{sample_id}.merged.defrag.sorted.bed
     
   >>>

--- a/wdl/DepthPreprocessing.wdl
+++ b/wdl/DepthPreprocessing.wdl
@@ -147,8 +147,6 @@ task MergeSample {
     RuntimeAttr? runtime_attr_override
   }
 
-  Float max_dist_ = select_first([max_dist, 0.25])
-
   RuntimeAttr default_attr = object {
     cpu_cores: 1, 
     mem_gb: 3.75,
@@ -169,7 +167,7 @@ task MergeSample {
     cat ~{gcnv} cnmops.cnv | sort -k1,1V -k2,2n > ~{sample_id}.bed
     bedtools merge -i ~{sample_id}.bed -d 0 -c 4,5,6,7 -o distinct > ~{sample_id}.merged.bed
     /opt/sv-pipeline/00_preprocessing/scripts/defragment_cnvs.py \
-      --max-dist ~{max_dist_}} ~{sample_id}.merged.bed ~{sample_id}.merged.defrag.bed
+      --max-dist ~{select_first([max_dist, 0.25])}} ~{sample_id}.merged.bed ~{sample_id}.merged.defrag.bed
     sort -k1,1V -k2,2n ~{sample_id}.merged.defrag.bed > ~{sample_id}.merged.defrag.sorted.bed
     
   >>>

--- a/wdl/DepthPreprocessing.wdl
+++ b/wdl/DepthPreprocessing.wdl
@@ -23,7 +23,7 @@ workflow MergeDepth {
     String sv_base_mini_docker
     String sv_pipeline_docker
     Int gcnv_qs_cutoff
-    Float? defragment_max_dist
+    Float defragment_max_dist
     RuntimeAttr? runtime_attr_merge_sample
     RuntimeAttr? runtime_attr_merge_set
     RuntimeAttr? runtime_attr_convert_gcnv

--- a/wdl/DepthPreprocessing.wdl
+++ b/wdl/DepthPreprocessing.wdl
@@ -141,7 +141,7 @@ task MergeSample {
   input {
     File gcnv
     Array[File] cnmops
-    Float? max_dist = 0.25
+    Float? max_dist
     String sample_id
     String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
@@ -160,7 +160,7 @@ task MergeSample {
   output {
     File sample_bed = "~{sample_id}.merged.defrag.sorted.bed"
   }
-  Float max_dist_ = select_first([max_dist, 0.25])
+
   command <<<
 
     set -euo pipefail
@@ -168,7 +168,7 @@ task MergeSample {
     cat ~{gcnv} cnmops.cnv | sort -k1,1V -k2,2n > ~{sample_id}.bed
     bedtools merge -i ~{sample_id}.bed -d 0 -c 4,5,6,7 -o distinct > ~{sample_id}.merged.bed
     /opt/sv-pipeline/00_preprocessing/scripts/defragment_cnvs.py \
-      --max-dist ~{max_dist_}} ~{sample_id}.merged.bed ~{sample_id}.merged.defrag.bed
+      --max-dist ~{if defined(max_dist) then max_dist else "0.25"} ~{sample_id}.merged.bed ~{sample_id}.merged.defrag.bed
     sort -k1,1V -k2,2n ~{sample_id}.merged.defrag.bed > ~{sample_id}.merged.defrag.sorted.bed
     
   >>>

--- a/wdl/DepthPreprocessing.wdl
+++ b/wdl/DepthPreprocessing.wdl
@@ -147,7 +147,7 @@ task MergeSample {
     RuntimeAttr? runtime_attr_override
   }
 
-  Float _max_dist = select_first([max_dist, 0.25])
+  Float max_dist_ = select_first([max_dist, 0.25])
 
   RuntimeAttr default_attr = object {
     cpu_cores: 1, 
@@ -169,7 +169,7 @@ task MergeSample {
     cat ~{gcnv} cnmops.cnv | sort -k1,1V -k2,2n > ~{sample_id}.bed
     bedtools merge -i ~{sample_id}.bed -d 0 -c 4,5,6,7 -o distinct > ~{sample_id}.merged.bed
     /opt/sv-pipeline/00_preprocessing/scripts/defragment_cnvs.py \
-      --max-dist ~{_max_dist} ~{sample_id}.merged.bed ~{sample_id}.merged.defrag.bed
+      --max-dist ~{max_dist_}} ~{sample_id}.merged.bed ~{sample_id}.merged.defrag.bed
     sort -k1,1V -k2,2n ~{sample_id}.merged.defrag.bed > ~{sample_id}.merged.defrag.sorted.bed
     
   >>>

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -289,7 +289,7 @@ workflow GATKSVPipelineSingleSample {
 
     RuntimeAttr? runtime_attr_filter_large_pesr
     RuntimeAttr? runtime_attr_srtest
-    RuntimeAttr? runtime_attr_split_vcf
+    RuntimeAttr? runtime_attr_split_vcf_srtest
     RuntimeAttr? runtime_attr_merge_allo
     RuntimeAttr? runtime_attr_merge_stats
     RuntimeAttr? runtime_attr_rewritesrcoords
@@ -322,6 +322,8 @@ workflow GATKSVPipelineSingleSample {
     RuntimeAttr? runtime_attr_rdtest_genotype
     RuntimeAttr? runtime_attr_add_genotypes
     RuntimeAttr? runtime_attr_concat_vcfs
+    RuntimeAttr? runtime_attr_split_vcf_module04
+
 
     # Master
     RuntimeAttr? runtime_attr_add_batch
@@ -448,13 +450,13 @@ workflow GATKSVPipelineSingleSample {
         manta_mem_gb_per_job=manta_mem_gb_per_job,
         melt_standard_vcf_header=melt_standard_vcf_header,
         melt_metrics_intervals=melt_metrics_intervals,
-        insert_size=insert_size_input,
-        read_length=read_length_input,
-        coverage=coverage_input,
+        insert_size=insert_size,
+        read_length=read_length,
+        coverage=coverage,
         metrics_intervals=metrics_intervals,
-        pf_reads_improper_pairs=pf_reads_improper_pairs_input,
-        pct_chimeras=pct_chimeras_input,
-        total_reads=total_reads_input,
+        pf_reads_improper_pairs=pf_reads_improper_pairs,
+        pct_chimeras=pct_chimeras,
+        total_reads=total_reads,
         wham_include_list_bed_file=wham_include_list_bed_file,
         sv_pipeline_docker=sv_pipeline_docker,
         sv_base_mini_docker=sv_base_mini_docker,
@@ -775,7 +777,7 @@ workflow GATKSVPipelineSingleSample {
       linux_docker = linux_docker,
       sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_srtest = runtime_attr_srtest,
-      runtime_attr_split_vcf = runtime_attr_split_vcf,
+      runtime_attr_split_vcf = runtime_attr_split_vcf_srtest,
       runtime_attr_merge_allo = runtime_attr_merge_allo,
       runtime_attr_merge_stats = runtime_attr_merge_stats
   }
@@ -828,7 +830,7 @@ workflow GATKSVPipelineSingleSample {
       sv_pipeline_docker=sv_pipeline_docker,
       sv_pipeline_rdtest_docker=sv_pipeline_rdtest_docker,
       linux_docker=linux_docker,
-      runtime_attr_split_vcf=runtime_attr_split_vcf,
+      runtime_attr_split_vcf=runtime_attr_split_vcf_module04,
       runtime_attr_merge_counts=runtime_attr_merge_counts,
       runtime_attr_split_variants=runtime_attr_split_variants,
       runtime_attr_make_subset_vcf=runtime_attr_make_subset_vcf,

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -284,8 +284,8 @@ workflow GATKSVPipelineSingleSample {
     File rmsk
     File segdups
 
-    Int min_large_pesr_call_size_for_filtering
-    Float min_large_pesr_depth_overlap_fraction
+    Int? min_large_pesr_call_size_for_filtering
+    Float? min_large_pesr_depth_overlap_fraction
 
     RuntimeAttr? runtime_attr_filter_large_pesr
     RuntimeAttr? runtime_attr_srtest

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -284,8 +284,8 @@ workflow GATKSVPipelineSingleSample {
     File rmsk
     File segdups
 
-    Int? min_large_pesr_call_size_for_filtering
-    Float? min_large_pesr_depth_overlap_fraction
+    Int min_large_pesr_call_size_for_filtering
+    Float min_large_pesr_depth_overlap_fraction
 
     RuntimeAttr? runtime_attr_filter_large_pesr
     RuntimeAttr? runtime_attr_srtest
@@ -316,7 +316,6 @@ workflow GATKSVPipelineSingleSample {
     File bin_exclude
 
     # Common
-    RuntimeAttr? runtime_attr_split_vcf
     RuntimeAttr? runtime_attr_merge_counts
     RuntimeAttr? runtime_attr_split_variants
     RuntimeAttr? runtime_attr_make_subset_vcf
@@ -339,7 +338,6 @@ workflow GATKSVPipelineSingleSample {
 
     # Depth part 2
     RuntimeAttr? runtime_attr_integrate_depth_gq
-    RuntimeAttr? runtime_attr_concat_vcfs
 
     ############################################################
     ## Module 0506
@@ -363,7 +361,6 @@ workflow GATKSVPipelineSingleSample {
     Int? clean_vcf_random_seed
 
     RuntimeAttr? runtime_override_update_sr_list
-    RuntimeAttr? runtime_override_merge_pesr_depth
     RuntimeAttr? runtime_override_merge_pesr_depth
     RuntimeAttr? runtime_override_integrate_resolved_vcfs
     RuntimeAttr? runtime_override_rename_variants
@@ -847,8 +844,7 @@ workflow GATKSVPipelineSingleSample {
       runtime_attr_integrate_gq=runtime_attr_integrate_gq,
       runtime_attr_integrate_pesr_gq=runtime_attr_integrate_pesr_gq,
       runtime_attr_triple_stream_cat=runtime_attr_triple_stream_cat,
-      runtime_attr_integrate_depth_gq=runtime_attr_integrate_depth_gq,
-      runtime_attr_concat_vcfs=runtime_attr_concat_vcfs
+      runtime_attr_integrate_depth_gq=runtime_attr_integrate_depth_gq
   }
 
   call SingleSampleFiltering.ConvertCNVsWithoutDepthSupportToBNDs as ConvertCNVsWithoutDepthSupportToBNDs {

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -321,7 +321,8 @@ workflow GATKSVPipelineSingleSample {
     RuntimeAttr? runtime_attr_make_subset_vcf
     RuntimeAttr? runtime_attr_rdtest_genotype
     RuntimeAttr? runtime_attr_add_genotypes
-    RuntimeAttr? runtime_attr_concat_vcfs
+    RuntimeAttr? runtime_attr_genotype_depths_concat_vcfs
+    RuntimeAttr? runtime_attr_genotype_pesr_concat_vcfs
     RuntimeAttr? runtime_attr_split_vcf_module04
 
 
@@ -364,6 +365,7 @@ workflow GATKSVPipelineSingleSample {
 
     RuntimeAttr? runtime_override_update_sr_list
     RuntimeAttr? runtime_override_merge_pesr_depth
+    RuntimeAttr? runtime_override_breakpoint_overlap_filter
     RuntimeAttr? runtime_override_integrate_resolved_vcfs
     RuntimeAttr? runtime_override_rename_variants
 
@@ -829,7 +831,8 @@ workflow GATKSVPipelineSingleSample {
       runtime_attr_make_subset_vcf=runtime_attr_make_subset_vcf,
       runtime_attr_rdtest_genotype=runtime_attr_rdtest_genotype,
       runtime_attr_add_genotypes=runtime_attr_add_genotypes,
-      runtime_attr_concat_vcfs=runtime_attr_concat_vcfs,
+      runtime_attr_genotype_depths_concat_vcfs=runtime_attr_genotype_depths_concat_vcfs,
+      runtime_attr_genotype_pesr_concat_vcfs=runtime_attr_genotype_pesr_concat_vcfs,
       runtime_attr_add_batch=runtime_attr_add_batch,
       runtime_attr_index_vcf=runtime_attr_index_vcf,
       runtime_attr_count_pe=runtime_attr_count_pe,
@@ -902,7 +905,7 @@ workflow GATKSVPipelineSingleSample {
 
       runtime_override_update_sr_list=runtime_override_update_sr_list,
       runtime_override_merge_pesr_depth=runtime_override_merge_pesr_depth,
-      runtime_override_breakpoint_overlap_filter=runtime_override_merge_pesr_depth,
+      runtime_override_breakpoint_overlap_filter=runtime_override_breakpoint_overlap_filter,
       runtime_override_integrate_resolved_vcfs=runtime_override_integrate_resolved_vcfs,
       runtime_override_rename_variants=runtime_override_rename_variants,
 

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -412,13 +412,6 @@ workflow GATKSVPipelineSingleSample {
 
   }
 
-  if (defined(insert_size)) { Array[Float]? insert_size_input = [select_first([insert_size])]}
-  if (defined(read_length)) { Array[Int]? read_length_input = [select_first([read_length])]}
-  if (defined(coverage)) { Array[Float]? coverage_input = [select_first([coverage])]}
-  if (defined(pf_reads_improper_pairs)) { Array[Int]? pf_reads_improper_pairs_input = [select_first([pf_reads_improper_pairs])]}
-  if (defined(total_reads)) { Array[Float]? total_reads_input = [select_first([total_reads])]}
-  if (defined(pct_chimeras)) { Array[Float]? pct_chimeras_input = [select_first([pct_chimeras])]}
-
   String? delly_docker_ = if (!defined(case_delly_vcf) && use_delly) then delly_docker else NONE_STRING_
   String? manta_docker_ = if (!defined(case_manta_vcf) && use_manta) then manta_docker else NONE_STRING_
   String? melt_docker_ = if (!defined(case_melt_vcf) && use_melt) then melt_docker else NONE_STRING_

--- a/wdl/MakeBincovMatrix.wdl
+++ b/wdl/MakeBincovMatrix.wdl
@@ -30,7 +30,7 @@ workflow MakeBincovMatrix {
       binsize = binsize,
       bincov_matrix_samples = bincov_matrix_samples,
       sv_base_mini_docker = sv_base_mini_docker,
-      disk_overhead_gb = disk_overhead_gb,
+      disk_overhead_gb = select_first([disk_overhead_gb, 0]),
       runtime_attr_override = runtime_attr_override
   }
   if(defined(bincov_matrix_samples)) {
@@ -45,9 +45,9 @@ workflow MakeBincovMatrix {
       input:
         count_file = all_count_files[i],
         sample = all_samples[i],
-        binsize = SetBins.binsize,
+        binsize = SetBins.out_binsize,
         bin_locs = SetBins.bin_locs,
-        disk_overhead_gb = disk_overhead_gb,
+        disk_overhead_gb = select_first([disk_overhead_gb, 0]),
         sv_base_mini_docker = sv_base_mini_docker,
         runtime_attr_override = runtime_attr_override
     }
@@ -57,7 +57,7 @@ workflow MakeBincovMatrix {
     input:
       column_files = flatten([[SetBins.bin_locs], MakeBincovMatrixColumns.bincov_bed]),
       matrix_file_name = "~{batch}.RD.txt.gz",
-      disk_overhead_gb = disk_overhead_gb,
+      disk_overhead_gb = select_first([disk_overhead_gb, 0]),
       sv_base_docker = sv_base_docker,
       runtime_attr_override = runtime_attr_override
   }
@@ -97,7 +97,7 @@ task SetBins {
 
   output {
     File bin_locs = bin_file_name
-    Int binsize = read_int(binsize_output_file_name)
+    Int out_binsize = read_int(binsize_output_file_name)
     File bincov_matrix_header_file = bincov_header_file_name
   }
 

--- a/wdl/MakeBincovMatrix.wdl
+++ b/wdl/MakeBincovMatrix.wdl
@@ -78,14 +78,13 @@ task SetBins {
     RuntimeAttr? runtime_attr_override
   }
 
-  Int disk_overhead_gb_ = select_first([disk_overhead_gb, 10])
   String bincov_header_file_name = "bincov_header_file.tsv"
 
   String bin_file_name = "locs.bed.gz"
   String binsize_output_file_name = "binsize.txt"
 
   Float disk_scale_factor = 10.0
-  Int disk_gb = disk_overhead_gb_ + ceil(disk_scale_factor * size(count_file, "GiB"))
+  Int disk_gb = select_first([disk_overhead_gb, 10]) + ceil(disk_scale_factor * size(count_file, "GiB"))
   RuntimeAttr default_attr = object {
     cpu_cores: 1,
     mem_gb: 2.0,
@@ -171,9 +170,8 @@ task MakeBincovMatrixColumns {
     String sv_base_mini_docker
     RuntimeAttr? runtime_attr_override
   }
-  Int disk_overhead_ = select_first([disk_overhead_gb, 10])
   Float disk_scale_factor = 10.0
-  Int disk_gb = disk_overhead_ + ceil(disk_scale_factor * (size(count_file, "GiB") + size(bin_locs, "GiB")))
+  Int disk_gb = select_first([disk_overhead_gb, 10])+ ceil(disk_scale_factor * (size(count_file, "GiB") + size(bin_locs, "GiB")))
   RuntimeAttr default_attr = object {
     cpu_cores: 1,
     mem_gb: 2.0,
@@ -239,12 +237,9 @@ task ZPaste {
     RuntimeAttr? runtime_attr_override
   }
 
-  Int disk_overhead_gb_ = select_first([disk_overhead_gb, 10])
-
-
   # Only compressed files are stored (if localization_optional, then only output file is stored),
   # so this is a reasonably conservative estimate for disk:
-  Int disk_gb = disk_overhead_gb_ + ceil(3.0 * size(column_files, "GiB"))
+  Int disk_gb = select_first([disk_overhead_gb, 10]) + ceil(3.0 * size(column_files, "GiB"))
   # Some memory is used up by the named pipes. Not a lot, but allocate in case the batch is huge:
   Float mem_gb = mem_overhead_gb + 0.003 * length(column_files)
   RuntimeAttr default_attr = object {

--- a/wdl/MakeBincovMatrix.wdl
+++ b/wdl/MakeBincovMatrix.wdl
@@ -78,14 +78,14 @@ task SetBins {
     RuntimeAttr? runtime_attr_override
   }
 
-  Int _disk_overhead_gb = select_first([disk_overhead_gb, 10])
+  Int disk_overhead_gb_ = select_first([disk_overhead_gb, 10])
   String bincov_header_file_name = "bincov_header_file.tsv"
 
   String bin_file_name = "locs.bed.gz"
   String binsize_output_file_name = "binsize.txt"
 
   Float disk_scale_factor = 10.0
-  Int disk_gb = _disk_overhead_gb + ceil(disk_scale_factor * size(count_file, "GiB"))
+  Int disk_gb = disk_overhead_gb_ + ceil(disk_scale_factor * size(count_file, "GiB"))
   RuntimeAttr default_attr = object {
     cpu_cores: 1,
     mem_gb: 2.0,
@@ -171,9 +171,9 @@ task MakeBincovMatrixColumns {
     String sv_base_mini_docker
     RuntimeAttr? runtime_attr_override
   }
-  Int _disk_overhead = select_first([disk_overhead_gb, 10])
+  Int disk_overhead_ = select_first([disk_overhead_gb, 10])
   Float disk_scale_factor = 10.0
-  Int disk_gb = _disk_overhead + ceil(disk_scale_factor * (size(count_file, "GiB") + size(bin_locs, "GiB")))
+  Int disk_gb = disk_overhead_ + ceil(disk_scale_factor * (size(count_file, "GiB") + size(bin_locs, "GiB")))
   RuntimeAttr default_attr = object {
     cpu_cores: 1,
     mem_gb: 2.0,
@@ -239,12 +239,12 @@ task ZPaste {
     RuntimeAttr? runtime_attr_override
   }
 
-  Int _disk_overhead_gb = select_first([disk_overhead_gb, 10])
+  Int disk_overhead_gb_ = select_first([disk_overhead_gb, 10])
 
 
   # Only compressed files are stored (if localization_optional, then only output file is stored),
   # so this is a reasonably conservative estimate for disk:
-  Int disk_gb = _disk_overhead_gb + ceil(3.0 * size(column_files, "GiB"))
+  Int disk_gb = disk_overhead_gb_ + ceil(3.0 * size(column_files, "GiB"))
   # Some memory is used up by the named pipes. Not a lot, but allocate in case the batch is huge:
   Float mem_gb = mem_overhead_gb + 0.003 * length(column_files)
   RuntimeAttr default_attr = object {

--- a/wdl/MasterVcfQc.wdl
+++ b/wdl/MasterVcfQc.wdl
@@ -137,8 +137,6 @@ workflow MasterVcfQc {
       runtime_override_collect_vids_per_sample=runtime_override_collect_vids_per_sample,
       runtime_override_split_samples_list=runtime_override_split_samples_list,
       runtime_override_tar_shard_vid_lists=runtime_override_tar_shard_vid_lists,
-      sv_base_mini_docker=sv_base_mini_docker,
-      sv_pipeline_docker=sv_pipeline_docker
   }
 
   # Plot per-sample stats

--- a/wdl/Module00a.wdl
+++ b/wdl/Module00a.wdl
@@ -61,13 +61,13 @@ workflow Module00a {
     # Melt inputs
     File? melt_standard_vcf_header # required if run_melt True
     File? melt_metrics_intervals
-    Array[Float]? insert_size
-    Array[Int]? read_length
-    Array[Float]? coverage
+    Float? insert_size
+    Int? read_length
+    Float? coverage
     File? metrics_intervals
-    Array[Float]? pct_chimeras
-    Array[Float]? total_reads
-    Array[Int]? pf_reads_improper_pairs
+    Float? pct_chimeras
+    Float? total_reads
+    Int? pf_reads_improper_pairs
 
     # Wham inputs
     File wham_include_list_bed_file
@@ -196,12 +196,6 @@ workflow Module00a {
   }
 
   if (run_melt) {
-    Float? insert_size_i = if defined(insert_size) then select_first([insert_size])[0] else NONE_FLOAT_
-    Int? read_length_i = if defined(read_length) then select_first([read_length])[0] else NONE_INT_
-    Float? coverage_i = if defined(coverage) then select_first([coverage])[0] else NONE_FLOAT_
-    Float? pct_chimeras_i = if defined(pct_chimeras) then select_first([pct_chimeras])[0] else NONE_FLOAT_
-    Float? total_reads_i = if defined(total_reads) then select_first([total_reads])[0] else NONE_INT_
-    Int? pf_reads_improper_pairs_i = if defined(pf_reads_improper_pairs) then select_first([pf_reads_improper_pairs])[0] else NONE_INT_
     call melt.MELT {
       input:
         bam_or_cram_file = bam_file_,
@@ -212,13 +206,13 @@ workflow Module00a {
         reference_index = reference_index,
         reference_version = reference_version,
         melt_standard_vcf_header = select_first([melt_standard_vcf_header]),
-        insert_size = insert_size_i,
-        read_length = read_length_i,
-        coverage = coverage_i,
+        insert_size = insert_size,
+        read_length = read_length,
+        coverage = coverage,
         wgs_metrics_intervals = melt_metrics_intervals,
-        pct_chimeras = pct_chimeras_i,
-        total_reads = total_reads_i,
-        pf_reads_improper_pairs = pf_reads_improper_pairs_i,
+        pct_chimeras = pct_chimeras,
+        total_reads = total_reads,
+        pf_reads_improper_pairs = pf_reads_improper_pairs,
         runtime_attr_coverage = runtime_attr_melt_coverage,
         runtime_attr_metrics = runtime_attr_melt_metrics,
         samtools_cloud_docker = samtools_cloud_docker,

--- a/wdl/Module00a.wdl
+++ b/wdl/Module00a.wdl
@@ -196,12 +196,12 @@ workflow Module00a {
   }
 
   if (run_melt) {
-    Float? insert_size_i = if defined(insert_size) then select_first([insert_size]) else NONE_FLOAT_
-    Int? read_length_i = if defined(read_length) then select_first([read_length]) else NONE_INT_
-    Float? coverage_i = if defined(coverage) then select_first([coverage]) else NONE_FLOAT_
-    Float? pct_chimeras_i = if defined(pct_chimeras) then select_first([pct_chimeras]) else NONE_FLOAT_
-    Float? total_reads_i = if defined(total_reads) then select_first([total_reads]) else NONE_INT_
-    Int? pf_reads_improper_pairs_i = if defined(pf_reads_improper_pairs) then select_first([pf_reads_improper_pairs]) else NONE_INT_
+    Float? insert_size_i = if defined(insert_size) then select_first([insert_size])[0] else NONE_FLOAT_
+    Int? read_length_i = if defined(read_length) then select_first([read_length])[0] else NONE_INT_
+    Float? coverage_i = if defined(coverage) then select_first([coverage])[0] else NONE_FLOAT_
+    Float? pct_chimeras_i = if defined(pct_chimeras) then select_first([pct_chimeras])[0] else NONE_FLOAT_
+    Float? total_reads_i = if defined(total_reads) then select_first([total_reads])[0] else NONE_INT_
+    Int? pf_reads_improper_pairs_i = if defined(pf_reads_improper_pairs) then select_first([pf_reads_improper_pairs])[0] else NONE_INT_
     call melt.MELT {
       input:
         bam_or_cram_file = bam_file_,

--- a/wdl/Module00aBatch.wdl
+++ b/wdl/Module00aBatch.wdl
@@ -84,6 +84,8 @@ workflow Module00aBatch {
 
     File? NONE_FILE_
     String? NONE_STRING_
+    Float? NONE_FLOAT_
+    Int? NONE_INT_
   }
 
   scatter (i in range(length(bam_or_cram_files))) {
@@ -112,13 +114,13 @@ workflow Module00aBatch {
         manta_mem_gb_per_job = manta_mem_gb_per_job,
         melt_standard_vcf_header = melt_standard_vcf_header,
         melt_metrics_intervals = melt_metrics_intervals,
-        insert_size = insert_size,
-        read_length = read_length,
-        coverage = coverage,
+        insert_size = if defined(insert_size) then select_first([insert_size])[i] else NONE_FLOAT_,
+        read_length = if defined(read_length) then select_first([read_length])[i] else NONE_INT_,
+        coverage = if defined(coverage) then select_first([coverage])[i] else NONE_FLOAT_,
         metrics_intervals = metrics_intervals,
-        pct_chimeras = pct_chimeras,
-        total_reads = total_reads,
-        pf_reads_improper_pairs = pf_reads_improper_pairs,
+        pct_chimeras = if defined(pct_chimeras) then select_first([pct_chimeras])[i] else NONE_FLOAT_,
+        total_reads = if defined(total_reads) then select_first([total_reads])[i] else NONE_FLOAT_,
+        pf_reads_improper_pairs = if defined(pf_reads_improper_pairs) then select_first([pf_reads_improper_pairs])[i] else NONE_INT_,
         wham_include_list_bed_file = wham_include_list_bed_file,
         sv_pipeline_docker = sv_pipeline_docker,
         sv_base_mini_docker = sv_base_mini_docker,

--- a/wdl/Module00c.wdl
+++ b/wdl/Module00c.wdl
@@ -193,7 +193,7 @@ workflow Module00c {
     RuntimeAttr? runtime_attr_postprocess
     RuntimeAttr? runtime_attr_explode
 
-    Array[File]? _NONE_ARRAY_FILE_
+    Array[File]? NONE_ARRAY_FILE_
   }
 
   Array[String] all_samples = flatten(select_all([samples, ref_panel_samples]))
@@ -289,7 +289,7 @@ workflow Module00c {
   call bem.EvidenceMerging as EvidenceMerging {
     input:
       samples = all_samples,
-      BAF_files = if defined(BAFFromShardedVCF.baf_files) then BAFFromShardedVCF.baf_files else (if defined(BAF_files) then select_all(select_first([BAF_files])) else _NONE_ARRAY_FILE_),
+      BAF_files = if defined(BAFFromShardedVCF.baf_files) then BAFFromShardedVCF.baf_files else (if defined(BAF_files) then select_all(select_first([BAF_files])) else NONE_ARRAY_FILE_),
       PE_files = all_PE_files,
       SR_files = all_SR_files,
       inclusion_bed = inclusion_bed,

--- a/wdl/Module00c.wdl
+++ b/wdl/Module00c.wdl
@@ -192,8 +192,6 @@ workflow Module00c {
     RuntimeAttr? runtime_attr_bundle
     RuntimeAttr? runtime_attr_postprocess
     RuntimeAttr? runtime_attr_explode
-
-    Array[File]? _NONE_ARRAY_FILE_
   }
 
   Array[String] all_samples = flatten(select_all([samples, ref_panel_samples]))
@@ -289,7 +287,7 @@ workflow Module00c {
   call bem.EvidenceMerging as EvidenceMerging {
     input:
       samples = all_samples,
-      BAF_files = if defined(BAFFromShardedVCF.baf_files) then BAFFromShardedVCF.baf_files else (if defined(BAF_files) then select_all(select_first([BAF_files])) else _NONE_ARRAY_FILE_),
+      BAF_files = if defined(BAFFromShardedVCF.baf_files) then BAFFromShardedVCF.baf_files else BAF_files,
       PE_files = all_PE_files,
       SR_files = all_SR_files,
       inclusion_bed = inclusion_bed,

--- a/wdl/Module00c.wdl
+++ b/wdl/Module00c.wdl
@@ -193,7 +193,7 @@ workflow Module00c {
     RuntimeAttr? runtime_attr_postprocess
     RuntimeAttr? runtime_attr_explode
 
-    Array[File]? NONE_ARRAY_FILE_
+    Array[File]? _NONE_ARRAY_FILE_
   }
 
   Array[String] all_samples = flatten(select_all([samples, ref_panel_samples]))
@@ -289,7 +289,7 @@ workflow Module00c {
   call bem.EvidenceMerging as EvidenceMerging {
     input:
       samples = all_samples,
-      BAF_files = if defined(BAFFromShardedVCF.baf_files) then BAFFromShardedVCF.baf_files else (if defined(BAF_files) then select_all(select_first([BAF_files])) else NONE_ARRAY_FILE_),
+      BAF_files = if defined(BAFFromShardedVCF.baf_files) then BAFFromShardedVCF.baf_files else (if defined(BAF_files) then select_all(select_first([BAF_files])) else _NONE_ARRAY_FILE_),
       PE_files = all_PE_files,
       SR_files = all_SR_files,
       inclusion_bed = inclusion_bed,

--- a/wdl/Module00c.wdl
+++ b/wdl/Module00c.wdl
@@ -123,7 +123,7 @@ workflow Module00c {
     Boolean append_first_sample_to_ped = false
 
     Int gcnv_qs_cutoff              # QS filtering cutoff
-    Float defragment_max_dist
+    Float? defragment_max_dist
 
     # SV tool calls
     Array[File]? manta_vcfs        # Manta VCF

--- a/wdl/Module00c.wdl
+++ b/wdl/Module00c.wdl
@@ -123,7 +123,7 @@ workflow Module00c {
     Boolean append_first_sample_to_ped = false
 
     Int gcnv_qs_cutoff              # QS filtering cutoff
-    Float? defragment_max_dist
+    Float defragment_max_dist
 
     # SV tool calls
     Array[File]? manta_vcfs        # Manta VCF
@@ -174,7 +174,6 @@ workflow Module00c {
 
     RuntimeAttr? runtime_attr_merge_vcfs
     RuntimeAttr? runtime_attr_baf_gen
-    RuntimeAttr? runtime_attr_merge_baf
     RuntimeAttr? ploidy_score_runtime_attr
     RuntimeAttr? ploidy_build_runtime_attr
     RuntimeAttr? runtime_attr_subset_ped
@@ -193,6 +192,8 @@ workflow Module00c {
     RuntimeAttr? runtime_attr_bundle
     RuntimeAttr? runtime_attr_postprocess
     RuntimeAttr? runtime_attr_explode
+
+    Array[File]? _NONE_ARRAY_FILE_
   }
 
   Array[String] all_samples = flatten(select_all([samples, ref_panel_samples]))
@@ -288,7 +289,7 @@ workflow Module00c {
   call bem.EvidenceMerging as EvidenceMerging {
     input:
       samples = all_samples,
-      BAF_files = if defined(BAFFromShardedVCF.baf_files) then BAFFromShardedVCF.baf_files else BAF_files,
+      BAF_files = if defined(BAFFromShardedVCF.baf_files) then BAFFromShardedVCF.baf_files else (if defined(BAF_files) then select_all(select_first([BAF_files])) else _NONE_ARRAY_FILE_),
       PE_files = all_PE_files,
       SR_files = all_SR_files,
       inclusion_bed = inclusion_bed,

--- a/wdl/Module04.wdl
+++ b/wdl/Module04.wdl
@@ -59,7 +59,8 @@ workflow Module04 {
     RuntimeAttr? runtime_attr_make_subset_vcf
     RuntimeAttr? runtime_attr_rdtest_genotype
     RuntimeAttr? runtime_attr_add_genotypes
-    RuntimeAttr? runtime_attr_concat_vcfs
+    RuntimeAttr? runtime_attr_genotype_depths_concat_vcfs
+    RuntimeAttr? runtime_attr_genotype_pesr_concat_vcfs
 
     # Master
     RuntimeAttr? runtime_attr_add_batch
@@ -211,7 +212,7 @@ workflow Module04 {
       runtime_attr_integrate_pesr_gq = runtime_attr_integrate_pesr_gq,
       runtime_attr_add_genotypes = runtime_attr_add_genotypes,
       runtime_attr_triple_stream_cat = runtime_attr_triple_stream_cat,
-      runtime_attr_concat_vcfs = runtime_attr_concat_vcfs
+      runtime_attr_concat_vcfs = runtime_attr_genotype_pesr_concat_vcfs
   }
 
   if (!single_sample_mode) {
@@ -266,7 +267,7 @@ workflow Module04 {
       runtime_attr_make_subset_vcf = runtime_attr_make_subset_vcf,
       runtime_attr_integrate_depth_gq = runtime_attr_integrate_depth_gq,
       runtime_attr_add_genotypes = runtime_attr_add_genotypes,
-      runtime_attr_concat_vcfs = runtime_attr_concat_vcfs,
+      runtime_attr_concat_vcfs = runtime_attr_genotype_depths_concat_vcfs,
       runtime_attr_merge_regeno_cov_med = runtime_attr_merge_regeno_cov_med
   }
   output {

--- a/wdl/Module04.wdl
+++ b/wdl/Module04.wdl
@@ -81,13 +81,10 @@ workflow Module04 {
     RuntimeAttr? runtime_attr_genotype_train
     RuntimeAttr? runtime_attr_generate_cutoff
     RuntimeAttr? runtime_attr_update_cutoff
-    RuntimeAttr? runtime_attr_split_variants
     RuntimeAttr? runtime_attr_merge_genotypes
 
     # PESR part 2
-    RuntimeAttr? runtime_attr_count_pe
     RuntimeAttr? runtime_attr_genotype_pe
-    RuntimeAttr? runtime_attr_count_sr
     RuntimeAttr? runtime_attr_genotype_sr
     RuntimeAttr? runtime_attr_integrate_gq
     RuntimeAttr? runtime_attr_integrate_pesr_gq
@@ -95,7 +92,6 @@ workflow Module04 {
 
     # Depth part 2
     RuntimeAttr? runtime_attr_integrate_depth_gq
-    RuntimeAttr? runtime_attr_concat_vcfs
     RuntimeAttr? runtime_attr_merge_regeno_cov_med
 
   }

--- a/wdl/RDTest.wdl
+++ b/wdl/RDTest.wdl
@@ -96,7 +96,7 @@ workflow RDTest {
 
   call tasks02.MergeStats as MergeStats {
     input:
-      stats = flatten([RDTestAutosome.stats, RDTestAllosome.stats]),
+      stats = flatten([RDTestAutosome.out_stats, RDTestAllosome.out_stats]),
       prefix = "${batch}.${algorithm}",
       linux_docker = linux_docker,
       runtime_attr_override = runtime_attr_merge_stats

--- a/wdl/RDTestChromosome.wdl
+++ b/wdl/RDTestChromosome.wdl
@@ -124,7 +124,7 @@ workflow RDTestChromosome {
   }
 
   output {
-    File stats = MergeStats.merged_stats
+    File out_stats = MergeStats.merged_stats
   }
 }
 

--- a/wdl/SingleSampleFiltering.wdl
+++ b/wdl/SingleSampleFiltering.wdl
@@ -216,8 +216,8 @@ task FilterLargePESRCallsWithoutRawDepthSupport {
     File raw_dels
     File raw_dups
 
-    Int? min_large_pesr_call_size_for_filtering = 1000000
-    Float? min_large_pesr_depth_overlap_fraction = 0.3
+    Int? min_large_pesr_call_size_for_filtering
+    Float? min_large_pesr_depth_overlap_fraction
 
     String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
@@ -236,9 +236,6 @@ task FilterLargePESRCallsWithoutRawDepthSupport {
   String filebase = basename(pesr_vcf, ".vcf.gz")
   String outfile = "~{filebase}.filter_large_pesr_by_depth.vcf.gz"
 
-  Int min_large_pesr_call_size_for_filtering_ = select_first([min_large_pesr_call_size_for_filtering, 1000000])
-  Float min_large_pesr_depth_overlap_fraction_ = select_first([min_large_pesr_depth_overlap_fraction, 0.3])
-
   output {
     File out = "~{outfile}"
     File out_idx = "~{outfile}.tbi"
@@ -247,11 +244,11 @@ task FilterLargePESRCallsWithoutRawDepthSupport {
   command <<<
     set -euo pipefail
 
-    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{min_large_pesr_call_size_for_filtering_} && ($5 == "DEL")' \
-        | coverageBed -a stdin -b ~{raw_dels} | awk '$NF < ~{min_large_pesr_depth_overlap_fraction_} {print $4}' > large_dels_without_raw_depth_support.list
+    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{if defined(min_large_pesr_call_size_for_filtering) then min_large_pesr_call_size_for_filtering else 1000000} && ($5 == "DEL")' \
+        | coverageBed -a stdin -b ~{raw_dels} | awk '$NF < ~{if defined(min_large_pesr_depth_overlap_fraction) then min_large_pesr_depth_overlap_fraction else "0.3"} {print $4}' > large_dels_without_raw_depth_support.list
 
-    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{min_large_pesr_call_size_for_filtering_} && ($5 == "DUP")' \
-        | coverageBed -a stdin -b ~{raw_dups} | awk '$NF < ~{min_large_pesr_depth_overlap_fraction_} {print $4}' > large_dups_without_raw_depth_support.list
+    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{if defined(min_large_pesr_call_size_for_filtering) then min_large_pesr_call_size_for_filtering else 1000000} && ($5 == "DUP")' \
+        | coverageBed -a stdin -b ~{raw_dups} | awk '$NF < ~{if defined(min_large_pesr_depth_overlap_fraction) then min_large_pesr_depth_overlap_fraction else "0.3"} {print $4}' > large_dups_without_raw_depth_support.list
 
     cat large_dels_without_raw_depth_support.list large_dups_without_raw_depth_support.list > large_pesr_without_raw_depth_support.list
 

--- a/wdl/SingleSampleFiltering.wdl
+++ b/wdl/SingleSampleFiltering.wdl
@@ -236,18 +236,22 @@ task FilterLargePESRCallsWithoutRawDepthSupport {
   String filebase = basename(pesr_vcf, ".vcf.gz")
   String outfile = "~{filebase}.filter_large_pesr_by_depth.vcf.gz"
 
+  Int min_large_pesr_call_size_for_filtering_ = select_first([min_large_pesr_call_size_for_filtering, 1000000])
+  Float min_large_pesr_depth_overlap_fraction_ = select_first([min_large_pesr_depth_overlap_fraction, 0.3])
+
   output {
     File out = "~{outfile}"
     File out_idx = "~{outfile}.tbi"
   }
+  
   command <<<
     set -euo pipefail
 
-    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{select_first([min_large_pesr_call_size_for_filtering, 1000000])} && ($5 == "DEL")' \
-        | coverageBed -a stdin -b ~{raw_dels} | awk '$NF < ~{select_first([min_large_pesr_depth_overlap_fraction, 0.3])} {print $4}' > large_dels_without_raw_depth_support.list
+    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{min_large_pesr_call_size_for_filtering_} && ($5 == "DEL")' \
+        | coverageBed -a stdin -b ~{raw_dels} | awk '$NF < ~{min_large_pesr_depth_overlap_fraction_} {print $4}' > large_dels_without_raw_depth_support.list
 
-    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{select_first([min_large_pesr_call_size_for_filtering, 1000000])} && ($5 == "DUP")' \
-        | coverageBed -a stdin -b ~{raw_dups} | awk '$NF < ~{select_first([min_large_pesr_depth_overlap_fraction, 0.3])} {print $4}' > large_dups_without_raw_depth_support.list
+    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{min_large_pesr_call_size_for_filtering_} && ($5 == "DUP")' \
+        | coverageBed -a stdin -b ~{raw_dups} | awk '$NF < ~{min_large_pesr_depth_overlap_fraction_} {print $4}' > large_dups_without_raw_depth_support.list
 
     cat large_dels_without_raw_depth_support.list large_dups_without_raw_depth_support.list > large_pesr_without_raw_depth_support.list
 

--- a/wdl/SingleSampleFiltering.wdl
+++ b/wdl/SingleSampleFiltering.wdl
@@ -223,8 +223,8 @@ task FilterLargePESRCallsWithoutRawDepthSupport {
     RuntimeAttr? runtime_attr_override
   }
 
-  Int _min_large_pesr_call_size_for_filtering = select_first([min_large_pesr_call_size_for_filtering, 1000000])
-  Float _min_large_pesr_depth_overlap_fraction = select_first([min_large_pesr_depth_overlap_fraction, 0.3])
+  Int min_large_pesr_call_size_for_filtering_ = select_first([min_large_pesr_call_size_for_filtering, 1000000])
+  Float min_large_pesr_depth_overlap_fraction_ = select_first([min_large_pesr_depth_overlap_fraction, 0.3])
 
   RuntimeAttr default_attr = object {
     cpu_cores: 1,
@@ -246,11 +246,11 @@ task FilterLargePESRCallsWithoutRawDepthSupport {
   command <<<
     set -euo pipefail
 
-    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{_min_large_pesr_call_size_for_filtering} && ($5 == "DEL")' \
-        | coverageBed -a stdin -b ~{raw_dels} | awk '$NF < ~{_min_large_pesr_depth_overlap_fraction} {print $4}' > large_dels_without_raw_depth_support.list
+    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{min_large_pesr_call_size_for_filtering_} && ($5 == "DEL")' \
+        | coverageBed -a stdin -b ~{raw_dels} | awk '$NF < ~{min_large_pesr_depth_overlap_fraction_} {print $4}' > large_dels_without_raw_depth_support.list
 
-    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{_min_large_pesr_call_size_for_filtering} && ($5 == "DUP")' \
-        | coverageBed -a stdin -b ~{raw_dups} | awk '$NF < ~{_min_large_pesr_depth_overlap_fraction} {print $4}' > large_dups_without_raw_depth_support.list
+    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{min_large_pesr_call_size_for_filtering_} && ($5 == "DUP")' \
+        | coverageBed -a stdin -b ~{raw_dups} | awk '$NF < ~{min_large_pesr_depth_overlap_fraction_} {print $4}' > large_dups_without_raw_depth_support.list
 
     cat large_dels_without_raw_depth_support.list large_dups_without_raw_depth_support.list > large_pesr_without_raw_depth_support.list
 

--- a/wdl/SingleSampleFiltering.wdl
+++ b/wdl/SingleSampleFiltering.wdl
@@ -223,9 +223,6 @@ task FilterLargePESRCallsWithoutRawDepthSupport {
     RuntimeAttr? runtime_attr_override
   }
 
-  Int min_large_pesr_call_size_for_filtering_ = select_first([min_large_pesr_call_size_for_filtering, 1000000])
-  Float min_large_pesr_depth_overlap_fraction_ = select_first([min_large_pesr_depth_overlap_fraction, 0.3])
-
   RuntimeAttr default_attr = object {
     cpu_cores: 1,
     mem_gb: 3.75,
@@ -246,11 +243,11 @@ task FilterLargePESRCallsWithoutRawDepthSupport {
   command <<<
     set -euo pipefail
 
-    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{min_large_pesr_call_size_for_filtering_} && ($5 == "DEL")' \
-        | coverageBed -a stdin -b ~{raw_dels} | awk '$NF < ~{min_large_pesr_depth_overlap_fraction_} {print $4}' > large_dels_without_raw_depth_support.list
+    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{select_first([min_large_pesr_call_size_for_filtering, 1000000])} && ($5 == "DEL")' \
+        | coverageBed -a stdin -b ~{raw_dels} | awk '$NF < ~{select_first([min_large_pesr_depth_overlap_fraction, 0.3])} {print $4}' > large_dels_without_raw_depth_support.list
 
-    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{min_large_pesr_call_size_for_filtering_} && ($5 == "DUP")' \
-        | coverageBed -a stdin -b ~{raw_dups} | awk '$NF < ~{min_large_pesr_depth_overlap_fraction_} {print $4}' > large_dups_without_raw_depth_support.list
+    svtk vcf2bed ~{pesr_vcf} stdout | cut -f1-5 | awk '$3 - $2 > ~{select_first([min_large_pesr_call_size_for_filtering, 1000000])} && ($5 == "DUP")' \
+        | coverageBed -a stdin -b ~{raw_dups} | awk '$NF < ~{select_first([min_large_pesr_depth_overlap_fraction, 0.3])} {print $4}' > large_dups_without_raw_depth_support.list
 
     cat large_dels_without_raw_depth_support.list large_dups_without_raw_depth_support.list > large_pesr_without_raw_depth_support.list
 

--- a/wdl/Tasks0506.wdl
+++ b/wdl/Tasks0506.wdl
@@ -12,14 +12,14 @@ import "Structs.wdl"
 task ZcatCompressedFiles {
   input {
     Array[File] shards
-    String? outfile_name
+    String outfile_name
     String? filter_command
     String sv_base_mini_docker
     RuntimeAttr? runtime_attr_override
   }
 
   String output_file_name = select_first([outfile_name, "output.txt.gz"])
-  Boolean do_filter = defined(filter_command) && filter_command != ""
+  Boolean do_filter = defined(filter_command) && select_first([filter_command]) != ""
 
   # when filtering/sorting/etc, memory usage will likely go up (much of the data will have to
   # be held in memory or disk while working, potentially in a form that takes up more space)
@@ -81,7 +81,7 @@ task CatUncompressedFiles {
   }
 
   String output_file_name = select_first([outfile_name, "output.txt"])
-  Boolean do_filter = defined(filter_command) && filter_command != ""
+  Boolean do_filter = defined(filter_command) && select_first([filter_command]) != ""
 
   # when filtering/sorting/etc, memory usage will likely go up (much of the data will have to
   # be held in memory or disk while working, potentially in a form that takes up more space)


### PR DESCRIPTION
Fixes #153.

Make the GATKSVPipelineSingleSample pipeline validate in MiniWDL through a combination of:

- Optional to non-optional
  - Eg: Output was required, but input `outfile-name` was optional.
  - Add `select_first` to coerce `X? -> X`
- Remove duplicate inputs
- Default disk_overhead_gb to 0: `disk_overhead_gb = select_first([disk_overhead_gb, 0])`, because if it's not supplied I guess it could be 0.