### PR TITLE
integrate Xuefang's CramToBam ReviseBase and annotation changes

### DIFF
--- a/input_templates/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json.tmpl
+++ b/input_templates/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.json.tmpl
@@ -98,6 +98,8 @@
   "GATKSVPipelineSingleSample.external_af_population" :      {{ reference_resources.external_af_population | tojson }},
 
   "GATKSVPipelineSingleSample.annotation_sv_per_shard" : "5000",
+  "GATKSVPipelineSingleSample.annotation_max_shards_per_chrom_step1" : 200,
+  "GATKSVPipelineSingleSample.annotation_min_records_per_shard_step1" : 5000,
 
   "GATKSVPipelineSingleSample.cnmops_mem_gb_override_sample3": 24,
 

--- a/input_templates/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json.tmpl
+++ b/input_templates/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json.tmpl
@@ -99,6 +99,8 @@
   "GATKSVPipelineSingleSample.external_af_population" :      {{ reference_resources.external_af_population | tojson }},
 
   "GATKSVPipelineSingleSample.annotation_sv_per_shard" : "5000",
+  "GATKSVPipelineSingleSample.annotation_max_shards_per_chrom_step1" : 200,
+  "GATKSVPipelineSingleSample.annotation_min_records_per_shard_step1" : 5000,
 
   "GATKSVPipelineSingleSample.cnmops_mem_gb_override_sample3": 24,
 

--- a/input_templates/terra_workspaces/single_sample/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json.tmpl
+++ b/input_templates/terra_workspaces/single_sample/GATKSVPipelineSingleSample.ref_panel_1kg.na12878.no_melt.json.tmpl
@@ -98,6 +98,8 @@
   "GATKSVPipelineSingleSample.external_af_population" :      {{ reference_resources.external_af_population | tojson }},
 
   "GATKSVPipelineSingleSample.annotation_sv_per_shard" : "5000",
+  "GATKSVPipelineSingleSample.annotation_max_shards_per_chrom_step1" : 200,
+  "GATKSVPipelineSingleSample.annotation_min_records_per_shard_step1" : 5000,
 
   "GATKSVPipelineSingleSample.cnmops_mem_gb_override_sample3": 24,
 

--- a/test_input_templates/module08/Module08Annotation.test.json.tmpl
+++ b/test_input_templates/module08/Module08Annotation.test.json.tmpl
@@ -14,8 +14,10 @@
   "Module08Annotation.contig_list" :  "gs://fc-fae972fb-9dbf-41c7-926f-f419a767a1ab/chromosomes_nochrY.fai",
   "Module08Annotation.ped_file":      "gs://fc-fae972fb-9dbf-41c7-926f-f419a767a1ab/FINAL_full_prenatal_dosage_sex.ped",
   "Module08Annotation.sv_per_shard" : "5000",
+  "Module08Annotation.max_shards_per_chrom_step1" : 200,
+  "Module08Annotation.min_records_per_shard_step1" :  5000,
 
-  "Module08Annotation.prefix" :       "Talkowski_SV_PCR-free_WGS_144",
+  "Module08Annotation.prefix" : {{ test_batch.batch_name | tojson }},
 
   "Module08Annotation.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
   "Module08Annotation.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }}

--- a/test_input_templates/single-sample/GATKSVPipelineSingleSampleTest.json.tmpl
+++ b/test_input_templates/single-sample/GATKSVPipelineSingleSampleTest.json.tmpl
@@ -109,6 +109,8 @@
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.external_af_population" :      {{ reference_resources.external_af_population | tojson }},
 
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.annotation_sv_per_shard" : "5000",
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.annotation_max_shards_per_chrom_step1" : 200,
+  "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.annotation_min_records_per_shard_step1" : 5000,
 
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.ref_std_manta_vcfs" : {{ ref_panel.std_manta_vcfs | tojson }},
   "GATKSVPipelineSingleSampleTest.GATKSVPipelineSingleSample.ref_std_melt_vcfs" : {{ ref_panel.std_melt_vcfs | tojson }},

--- a/wdl/CramToBam.ReviseBase.wdl
+++ b/wdl/CramToBam.ReviseBase.wdl
@@ -102,7 +102,7 @@ task SplitCramPerContig {
 
   RuntimeAttr default_attr = object {
     cpu_cores: num_cpu,
-    mem_gb: 3.75, 
+    mem_gb: 1.5, 
     disk_gb: vm_disk_size,
     boot_disk_gb: 10,
     preemptible_tries: 3,
@@ -173,7 +173,7 @@ task SplitCramPerContigRequesterPays {
 
   RuntimeAttr default_attr = object {
     cpu_cores: num_cpu,
-    mem_gb: 3.75,
+    mem_gb: 1.5,
     disk_gb: vm_disk_size,
     boot_disk_gb: 10,
     preemptible_tries: 3,
@@ -238,7 +238,7 @@ task ReviseBaseInBam{
 
   RuntimeAttr default_attr = object {
     cpu_cores: num_cpu,
-    mem_gb: 3.75,
+    mem_gb: 1.5,
     disk_gb: vm_disk_size,
     boot_disk_gb: 10,
     preemptible_tries: 3,
@@ -296,7 +296,7 @@ task ConcatBam {
 
   RuntimeAttr default_attr = object {
     cpu_cores: num_cpu,
-    mem_gb: 3.75,
+    mem_gb: 1.5,
     disk_gb: vm_disk_size,
     boot_disk_gb: 10,
     preemptible_tries: 3,

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -374,7 +374,7 @@ workflow GATKSVPipelineSingleSample {
     RuntimeAttr? runtime_override_make_cpx_cnv_input_file
 
     ############################################################
-    ## Module 07
+    ## Module 08
     ############################################################
 
     File protein_coding_gtf
@@ -382,6 +382,8 @@ workflow GATKSVPipelineSingleSample {
     File promoter_bed
     File noncoding_bed
     Int annotation_sv_per_shard
+    Int annotation_max_shards_per_chrom_step1
+    Int annotation_min_records_per_shard_step1
 
     File? external_af_ref_bed             # bed file with population AFs for annotation
     String? external_af_ref_bed_prefix    # name of external AF bed file call set
@@ -1024,6 +1026,8 @@ workflow GATKSVPipelineSingleSample {
         ref_prefix = external_af_ref_bed_prefix,
         population = external_af_population,
         sv_per_shard = annotation_sv_per_shard,
+        max_shards_per_chrom_step1 = annotation_max_shards_per_chrom_step1,
+        min_records_per_shard_step1 = annotation_min_records_per_shard_step1,
         sv_base_mini_docker = sv_base_mini_docker,
         sv_pipeline_docker = sv_pipeline_docker
   }

--- a/wdl/Module00aBatch.wdl
+++ b/wdl/Module00aBatch.wdl
@@ -11,6 +11,11 @@ workflow Module00aBatch {
     # Use only for crams in requester pays buckets
     Boolean requester_pays_crams = false
 
+    # Use to revise Y, R, W, S, K, M, D, H, V, B, X bases in BAM to N. Use only if providing a CRAM file as input 
+    # May be more expensive - use only if necessary
+    Boolean revise_base_cram_to_bam = false
+    File? primary_contigs_fai # required if using revise_base_cram_to_bam
+
     # Caller flags
     Boolean collect_coverage = true
     Boolean collect_pesr = true
@@ -81,6 +86,8 @@ workflow Module00aBatch {
     RuntimeAttr? runtime_attr_pesr
     RuntimeAttr? runtime_attr_wham
     RuntimeAttr? runtime_attr_wham_include_list
+    RuntimeAttr? runtime_attr_ReviseBaseInBam
+    RuntimeAttr? runtime_attr_ConcatBam
 
     File? NONE_FILE_
     String? NONE_STRING_
@@ -93,10 +100,12 @@ workflow Module00aBatch {
         bam_or_cram_index = if defined(bam_or_cram_indexes) then select_first([bam_or_cram_indexes])[i] else NONE_FILE_,
         sample_id = sample_ids[i],
         requester_pays_crams = requester_pays_crams,
+        revise_base_cram_to_bam = revise_base_cram_to_bam,
         collect_coverage = collect_coverage,
         collect_pesr = collect_pesr,
         delete_intermediate_bam = delete_intermediate_bam,
         primary_contigs_list = primary_contigs_list,
+        primary_contigs_fai = primary_contigs_fai,
         reference_fasta = reference_fasta,
         reference_index = reference_index,
         reference_dict = reference_dict,
@@ -141,7 +150,9 @@ workflow Module00aBatch {
         runtime_attr_melt = runtime_attr_melt,
         runtime_attr_pesr = runtime_attr_pesr,
         runtime_attr_wham = runtime_attr_wham,
-        runtime_attr_wham_include_list = runtime_attr_wham_include_list
+        runtime_attr_wham_include_list = runtime_attr_wham_include_list,
+        runtime_attr_ReviseBaseInBam = runtime_attr_ReviseBaseInBam,
+        runtime_attr_ConcatBam = runtime_attr_ConcatBam
     }
   }
 


### PR DESCRIPTION
### Updates
* add option to perform ReviseBase task during CramToBam in Module00a
* optimize default resources for CramToBam ReviseBase version
* fix SplitCramToBamRequesterPays by localizing cram index
* add new required Module08 inputs to Module08 and single-sample JSON templates

### Testing
* Tested `Module00aBatch` workflow with two samples using revise base option, with and without requester pays mode
* Optimized resources after testing
* Validated all JSONs and WDLs