### PR TITLE
Remove greps in clean_vcf_part1 which could match sample IDs to variant IDs

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -13,7 +13,7 @@
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:mw-gnomad-02-6a66c96",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:rlc_posthoc_filtering_cnv_mcnv_compatability_9a8561",
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-base:rlc_posthoc_filtering_cnv_mcnv_compatability_9a8561",
-  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:cw_cleanvcf1_ev_script_7cf6798",
+  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_clean_vcf_part1_rm_allosome_greps_8348649",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-qc:mw-xz-fixes-7cbffee",
   "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-rdtest:mw-gnomad-02-6a66c96",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa",

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1.sh
@@ -59,6 +59,7 @@ zcat convertsvtype.vcf.gz \
   |awk 'NR==FNR{inFileA[$1]=$2; next} {if ($3 in inFileA && $1!~"#") $6=inFileA[$3]; print }' OFS='\t' vargq.persample - \
   |bgzip \
    >cleaninfo.vcf.gz
+   tabix -p vcf cleaninfo.vcf.gz
 
    
 ##fix sex chr if necessary##
@@ -242,7 +243,6 @@ fi
 
 
   tabix -p vcf combinedsex.vcf.gz
-  tabix -p vcf cleaninfo.vcf.gz
 
 zcat combinedsex.vcf.gz|awk '{if ($1!~"#") print $3}'>modified.ids.txt
 

--- a/test_input_templates/module0506/Module0506.json.tmpl
+++ b/test_input_templates/module0506/Module0506.json.tmpl
@@ -1,6 +1,7 @@
 {
   "Module0506.bin_exclude": {{ reference_resources.bin_exclude | tojson }},
   "Module0506.contig_list": {{ reference_resources.primary_contigs_fai | tojson }},
+  "Module0506.allosome_fai": {{ reference_resources.allosome_file | tojson }},
   "Module0506.cytobands": {{ reference_resources.cytobands | tojson }},
   "Module0506.mei_bed": {{ reference_resources.mei_bed | tojson }},
   "Module0506.pe_exclude_list": {{ reference_resources.pesr_exclude_list | tojson }},

--- a/test_input_templates/module0506/Module0506Test.json.tmpl
+++ b/test_input_templates/module0506/Module0506Test.json.tmpl
@@ -120,6 +120,7 @@
 
   "Module0506Test.Module0506.bin_exclude": {{ reference_resources.bin_exclude | tojson }},
   "Module0506Test.Module0506.contig_list": {{ reference_resources.primary_contigs_fai | tojson }},
+  "Module0506Test.Module0506.allosome_fai": {{ reference_resources.allosome_file | tojson }},
   "Module0506Test.Module0506.cytobands": {{ reference_resources.cytobands | tojson }},
   "Module0506Test.Module0506.mei_bed": {{ reference_resources.mei_bed | tojson }},
   "Module0506Test.Module0506.pe_exclude_list": {{ reference_resources.pesr_exclude_list | tojson }},

--- a/wdl/CleanVcf.wdl
+++ b/wdl/CleanVcf.wdl
@@ -15,6 +15,7 @@ workflow CleanVcf {
     String contig
     File background_list
     File ped_file
+    File allosome_fai
     String prefix
     Int max_shards_per_chrom_step1
     File bothsides_pass_list
@@ -66,6 +67,7 @@ workflow CleanVcf {
         ped_file=ped_file,
         sv_pipeline_docker=sv_pipeline_docker,
         bothsides_pass_list=bothsides_pass_list,
+        allosome_fai=allosome_fai,
         runtime_attr_override=runtime_override_clean_vcf_1a
     }
   }
@@ -209,6 +211,7 @@ task CleanVcf1a {
     File ped_file
     String sv_pipeline_docker
     File bothsides_pass_list
+    File allosome_fai
     RuntimeAttr? runtime_attr_override
   }
 
@@ -241,7 +244,7 @@ task CleanVcf1a {
   command <<<
     set -eu -o pipefail
     
-    /opt/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1.sh ~{vcf} ~{background_list} ~{ped_file}
+    /opt/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1.sh ~{vcf} ~{background_list} ~{ped_file} ~{allosome_fai}
     /opt/sv-pipeline/04_variant_resolution/scripts/add_bothsides_support_filter.py \
       --bgzip \
       --outfile int.w_bothsides.vcf.gz \

--- a/wdl/GATKSVPipelineBatch.wdl
+++ b/wdl/GATKSVPipelineBatch.wdl
@@ -251,6 +251,7 @@ workflow GATKSVPipelineBatch {
       pesr_vcfs=[Module04.genotyped_pesr_vcf],
       depth_vcfs=Module04b.regenotyped_depth_vcfs,
       contig_list=primary_contigs_fai,
+      allosome_fai=allosome_file,
       ref_dict=reference_dict,
       disc_files=[GATKSVPipelinePhase1.merged_PE],
       disc_files_index=[GATKSVPipelinePhase1.merged_PE_index],

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -871,6 +871,7 @@ workflow GATKSVPipelineSingleSample {
       pesr_vcfs=[ConvertCNVsWithoutDepthSupportToBNDs.out_vcf],
       depth_vcfs=[Module04.genotyped_depth_vcf],
       contig_list=primary_contigs_fai,
+      allosome_fai=allosome_file,
       ref_dict=reference_dict,
 
       merge_complex_genotype_vcfs = true,

--- a/wdl/Module0506.wdl
+++ b/wdl/Module0506.wdl
@@ -31,6 +31,7 @@ workflow Module0506 {
 
     File bin_exclude
     File contig_list
+    File allosome_fai
     Int max_shards_per_chrom
     Int min_variants_per_shard
     File cytobands
@@ -270,6 +271,7 @@ workflow Module0506 {
       complex_resolve_background_fail_lists=Module0506ComplexResolve.complex_resolve_background_fail_lists,
       merged_ped_file=ped_file,
       contig_list=contig_list,
+      allosome_fai=allosome_fai,
       max_shards_per_chrom=max_shards_per_chrom,
       max_shards_per_chrom_clean_vcf_step1=max_shards_per_chrom_clean_vcf_step1,
       min_records_per_shard_clean_vcf_step1=min_records_per_shard_clean_vcf_step1,

--- a/wdl/Module0506Clean.wdl
+++ b/wdl/Module0506Clean.wdl
@@ -13,6 +13,7 @@ workflow Module0506Clean {
     File merged_ped_file
 
     File contig_list
+    File allosome_fai
     Int max_shards_per_chrom
     Int max_shards_per_chrom_clean_vcf_step1
     Int min_records_per_shard_clean_vcf_step1
@@ -57,6 +58,7 @@ workflow Module0506Clean {
         background_list=complex_resolve_background_fail_lists[i],
         ped_file=merged_ped_file,
         bothsides_pass_list=complex_resolve_bothside_pass_lists[i],
+        allosome_fai=allosome_fai,
         prefix=cohort_name,
         max_shards_per_chrom_step1=max_shards_per_chrom_clean_vcf_step1,
         min_records_per_shard_step1=min_records_per_shard_clean_vcf_step1,


### PR DESCRIPTION
This fixes a problem in `clean_vcf_part1.sh` which could cause problems in the calculation of median with-sex depth for allosome CNVs if a sample ID was present in the batch name. The root cause was a grep statement based on sample IDs which could match variant IDs. I've rewritten the bash pipe in question to use bcftools instead of grep/awk/vcftools. Also passed the allosome fai down into this task so that we are less dependent on hard coded searches for X and Y chromosome names, although there are still multiple places in this script where that is the case. Tested this out in a full single sample pipeline run and confirmed that a missing, clinically important chr X duplication in a male sample is now correctly called with this change.