### PR TITLE
Add Dockerfile for ExpansionHunter Denovo.

### DIFF
--- a/dockerfiles/expansion-hunter-denovo/Dockerfile
+++ b/dockerfiles/expansion-hunter-denovo/Dockerfile
@@ -1,10 +1,6 @@
 FROM alpine:latest
 RUN apk --no-cache add curl && \
-    curl -s https://api.github.com/repos/Illumina/ExpansionHunterDenovo/releases/latest \
-    | grep "browser_download_url.*.tar.gz" \
-    | cut -d : -f 2,3 \
-    | tr -d \" \
-    | xargs wget && \
+    wget https://github.com/Illumina/ExpansionHunterDenovo/releases/download/v0.9.0/ExpansionHunterDenovo-v0.9.0-linux_x86_64.tar.gz && \
     mkdir ehdn_extract && \
     tar -xf *.tar.gz --strip-components=1 -C ehdn_extract && \
     rm -rf *.tar.gz && \

--- a/dockerfiles/expansion-hunter-denovo/Dockerfile
+++ b/dockerfiles/expansion-hunter-denovo/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:latest
+RUN apk --no-cache add curl && \
+    curl -s https://api.github.com/repos/Illumina/ExpansionHunterDenovo/releases/latest \
+    | grep "browser_download_url.*.tar.gz" \
+    | cut -d : -f 2,3 \
+    | tr -d \" \
+    | xargs wget && \
+    mkdir ehdn_extract && \
+    tar -xf *.tar.gz --strip-components=1 -C ehdn_extract && \
+    rm -rf *.tar.gz && \
+    mkdir ehdn && \
+    mv ehdn_extract/bin/* ehdn/ && \
+    rm -rf ehdn_extract
+ENV PATH="/ehdn/:$PATH"


### PR DESCRIPTION
This PR adds a Dockerfile for [ExpansionHunter Denovo](https://github.com/Illumina/ExpansionHunterDenovo). The resulting image is of size `13.9MB` and you may test it as it follows. 

```
$ docker build --no-cache -t ehdn .
$ docker run -it ehdn ExpansionHunterDenovo profile --help
Usage: ExpansionHunterDenovo profile [options]

Available options:
  --help                      Print help message
  --reads arg                 BAM or CRAM file with aligned reads
  --reference arg             FASTA file with reference assembly
  --output-prefix arg         Prefix for the output files
  --min-unit-len arg (=2)     Shortest repeat unit to consider
  --max-unit-len arg (=20)    Longest repeat unit to consider
  --min-anchor-mapq arg (=50) Minimum MAPQ of an anchor read
  --max-irr-mapq arg (=40)    Maximum MAPQ of an in-repeat read
  --log-reads                 Log informative reads
```

Note that at the build time, the latest version of `ExpansionHunter Devono` is pulled from its Github release, and successful builds using future releases depend on if the maintainers are persistent with their currently used norms: (1) a release is distributed in `.tar.gz`; and (2) binaries are stored under `bin` directory. We can define both the archive type and binary directory as arguments, however, for the archive type, in particular, we may need to alternate between different archive extraction programs depending on the archive type. 