### PR TITLE
Set default disk to 10GB for SR, PE, BAF, and RD Test for 02

### DIFF
--- a/wdl/BAFTestChromosome.wdl
+++ b/wdl/BAFTestChromosome.wdl
@@ -81,7 +81,6 @@ task BAFTest {
     String prefix
     String batch
     String sv_pipeline_docker
-    Int disk_gb_baseline = 10
     RuntimeAttr? runtime_attr_override
   }
 
@@ -91,14 +90,10 @@ task BAFTest {
     }
   }
 
-  Int disk_gb = disk_gb_baseline + ceil(
-                                      size(bed, "GiB")
-                                      + 2 * size([baf_metrics, baf_metrics_idx], "GiB")
-                                   )
   RuntimeAttr default_attr = object {
     cpu_cores: 1, 
     mem_gb: 3.75,
-    disk_gb: disk_gb,
+    disk_gb: 10,
     boot_disk_gb: 10,
     preemptible_tries: 3,
     max_retries: 1

--- a/wdl/PETestChromosome.wdl
+++ b/wdl/PETestChromosome.wdl
@@ -185,7 +185,6 @@ task PETest {
     File ref_dict
     String prefix
     String sv_pipeline_docker
-    Int disk_gb_baseline = 10
     RuntimeAttr? runtime_attr_override
   }
 
@@ -198,15 +197,10 @@ task PETest {
     }
   }
 
-  Int disk_gb = disk_gb_baseline + ceil(
-                                      size([vcf, medianfile, include_list], "GiB")
-                                      + 2 * size([discfile, discfile_idx], "GiB")
-                                   )
-
   RuntimeAttr default_attr = object {
     cpu_cores: 1,
     mem_gb: 3.75,
-    disk_gb: disk_gb,
+    disk_gb: 10,
     boot_disk_gb: 10,
     preemptible_tries: 3,
     max_retries: 1

--- a/wdl/RDTestChromosome.wdl
+++ b/wdl/RDTestChromosome.wdl
@@ -140,7 +140,6 @@ task RDTest {
     String prefix
     String flags
     String sv_pipeline_rdtest_docker
-    Int disk_gb_baseline = 10
     RuntimeAttr? runtime_attr_override
   }
 
@@ -150,14 +149,10 @@ task RDTest {
     }
   }
 
-  Int disk_gb = disk_gb_baseline + ceil(
-                                    size([bed, medianfile, ped_file, include_list], "GiB")
-                                    + 2 * size([coveragefile, coveragefile_idx], "GiB")
-                                 )
   RuntimeAttr default_attr = object {
     cpu_cores: 1, 
     mem_gb: 3.75,
-    disk_gb: disk_gb,
+    disk_gb: 10,
     boot_disk_gb: 10,
     preemptible_tries: 3,
     max_retries: 1

--- a/wdl/SRTestChromosome.wdl
+++ b/wdl/SRTestChromosome.wdl
@@ -187,7 +187,6 @@ task SRTest {
     String prefix
     File ref_dict
     String sv_pipeline_docker
-    Int disk_gb_baseline = 50
     RuntimeAttr? runtime_attr_override
   }
 
@@ -199,14 +198,10 @@ task SRTest {
     }
   }
 
-  Int disk_gb = disk_gb_baseline + ceil(
-                                      size([vcf, medianfile, include_list], "GiB")
-                                      + 2 * size([splitfile, splitfile_idx], "GiB")
-                                   )
   RuntimeAttr default_attr = object {
     cpu_cores: 1, 
     mem_gb: 3.75,
-    disk_gb: disk_gb,
+    disk_gb: 10,
     boot_disk_gb: 10,
     preemptible_tries: 3,
     max_retries: 1


### PR DESCRIPTION
### Updates
Remove disk scaling and set default disk to 10 GB for SR, PE, BAF, and RD tests in Module02. Disk scaling was determined to be unnecessary, and disk sizes were too large and expensive. Module02 was run with 10 GB for each test for gnomAD, so 10 GB should be an adequate baseline disk size. 

### Testing
WDLs were validated with womtool using the validation script.
Further testing was not performed because of prior resource usage analysis for large batches, and because our test set is quite small and therefore an inadequate stress test. 