### PR TITLE
Fix RdTest problems related to GATK collect coverage intervals

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -15,7 +15,7 @@
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-base:rlc_posthoc_filtering_cnv_mcnv_compatability_9a8561",
   "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:cw_cleanvcf1_ev_script_7cf6798",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-qc:mw-xz-fixes-7cbffee",
-  "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-rdtest:mw-gnomad-02-6a66c96",
+  "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline-rdtest:cw_bins_not_multiples_of_binsize_ebd0719",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa",
   "igv_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/igv:mw-xz-fixes-2-b1be6a9",
   "duphold_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/duphold:mw-xz-fixes-2-b1be6a9",

--- a/input_values/resources_hg38.json
+++ b/input_values/resources_hg38.json
@@ -8,7 +8,7 @@
     "gs://gatk-sv-resources-secure/resources/hg38_benchmarking/ASC_Werling/ASC_Werling.SV.OTH.bed.gz"
   ],
   "autosome_file" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/autosome.fai",
-  "bin_exclude" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/bin_exclude.hg38.bed.gz",
+  "bin_exclude" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/bin_exclude.hg38.gatkcov.bed.gz",
   "cnmops_exclude_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/GRCh38_Nmask.bed",
   "collins_2017_tarball" : "gs://gatk-sv-resources-secure/resources/Collins_2017_hg38.tar.gz",
   "contig_ploidy_priors" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/hg38.contig_ploidy_priors_homo_sapiens.tsv",

--- a/src/RdTest/RdTest.R
+++ b/src/RdTest/RdTest.R
@@ -212,7 +212,6 @@ loadData <- function(chr, start, end, cnvID, sampleIDs,coveragefile,medianfile,b
     }
     #Find window bin size
     BinSize <- median(cov1$end - cov1$start)
-    
     ##Fill in any gaps between coverage bins with zero-count rows##
     gapLengths <- sapply(2:nrow(cov1), function(i) { cov1$start[i] - cov1$end[i-1]})
     if (any(gapLengths) > 0) {
@@ -220,7 +219,10 @@ loadData <- function(chr, start, end, cnvID, sampleIDs,coveragefile,medianfile,b
       gapEnds <- cov1$start[which(gapLengths > 0)+1]
 
       zeroBinStarts <- unlist(lapply(1:length(gapStarts), function(i) { seq(gapStarts[i], gapEnds[i], by=BinSize) }))
-      zeroBinEnds <- unlist(lapply(1:length(gapEnds), function(i) { c(seq(gapStarts[i] + BinSize, gapEnds[i], by=BinSize), gapEnds[i]) }))
+      zeroBinEnds <- unlist(lapply(1:length(gapEnds),
+                                   function(i) {
+                                      c( if (gapStarts[i] + BinSize < gapEnds[i]) { seq(gapStarts[i] + BinSize, gapEnds[i], by=BinSize) }, gapEnds[i])
+                                   }))
 
       column_start = matrix(zeroBinStarts, ncol = 1)
       column_end = matrix(zeroBinEnds, ncol = 1)
@@ -237,10 +239,7 @@ loadData <- function(chr, start, end, cnvID, sampleIDs,coveragefile,medianfile,b
         cov1 <- data.frame(sapply(cov1, as.numeric), check.names = FALSE)
       } else {cov1<-data.frame(t(sapply(cov1,as.numeric)),check.names=FALSE)}
       cov1 <- cov1[order(cov1[, 2]), ]
-
-
     }
-
     #Round down the number of used bins events for smaller events (e.g at 100 bp bins can't have 10 bins if event is less than 1kb)
     startAdjToInnerBinStart <- cov1$start[which(cov1$start >= start)[1]]
     endAjdToInnerBinEnd <- cov1$end[max(which(cov1$end <= end))]
@@ -354,7 +353,6 @@ loadData <- function(chr, start, end, cnvID, sampleIDs,coveragefile,medianfile,b
       } else if (nrow(cov3) >9) {
         cov1<-cov3
       }
-      
     }
 
     #Rebins values
@@ -377,7 +375,6 @@ loadData <- function(chr, start, end, cnvID, sampleIDs,coveragefile,medianfile,b
                  function(vals){
                    return(as.numeric(vals[1:(nrow(res0)-1)])/as.numeric(vals[nrow(res0)]))
                  })
-
 
     #need to transpose if more than one bin assessed
     if (ncol(as.matrix(res1)) > 1) {

--- a/src/RdTest/RdTest.R
+++ b/src/RdTest/RdTest.R
@@ -229,13 +229,16 @@ loadData <- function(chr, start, end, cnvID, sampleIDs,coveragefile,medianfile,b
         cbind(chr, column_start, column_end, matrix(rep(0, times = nrow(column_start) *
                                                           (ncov_col - 3)), ncol = ncov_col - 3))
       colnames(null_model) <- colnames(cov1)
+
       cov1 <- rbind(cov1, null_model)
 
-      cov1 <- cov1[order(cov1[, 2]), ]
-      ##Use sapply to convert files to numeric only more than one column in cov1 matrix. If not matrix will already be numeric##  
+      ##Use sapply to convert files to numeric only more than one column in cov1 matrix. If not matrix will already be numeric##
       if (nrow(cov1) > 1) {
         cov1 <- data.frame(sapply(cov1, as.numeric), check.names = FALSE)
       } else {cov1<-data.frame(t(sapply(cov1,as.numeric)),check.names=FALSE)}
+      cov1 <- cov1[order(cov1[, 2]), ]
+
+
     }
 
     #Round down the number of used bins events for smaller events (e.g at 100 bp bins can't have 10 bins if event is less than 1kb)
@@ -250,9 +253,8 @@ loadData <- function(chr, start, end, cnvID, sampleIDs,coveragefile,medianfile,b
       {
         # include all bins that overlap the start and end of the interval in Rstart and Rend
         Rstart <- cov1$start[1]
-        Rend <- cov1$end[nrow(conv1)]
+        Rend <- cov1$end[nrow(cov1)]
         compression = 1
-        print(cat("compression is 1, Rstart = ", Rstart, ", Rend = ", Rend))
       }
     }
     
@@ -276,12 +278,9 @@ loadData <- function(chr, start, end, cnvID, sampleIDs,coveragefile,medianfile,b
       Rend <-
         endAjdToInnerBinEnd - RemainderBack
       compression <- (Rend - Rstart) / (BinSize * bins)
-      print(cat("compression is ", compression, ", Rstart = ", Rstart, ", Rend = ", Rend))
     }
     #Cut bins down to those required for compressed clean size based on Rstart and Rend##
     cov1<-cov1[which(cov1[,3]>Rstart & cov1[,2]<Rend ),]
-    print("cov1 after cut down")
-    print(cov1)
 
 
     #Samples Filter
@@ -357,9 +356,6 @@ loadData <- function(chr, start, end, cnvID, sampleIDs,coveragefile,medianfile,b
       }
       
     }
-    print("cov1 after blacklist")
-    print(cov1)
-
 
     #Rebins values
     if (compression > 1) {
@@ -372,9 +368,6 @@ loadData <- function(chr, start, end, cnvID, sampleIDs,coveragefile,medianfile,b
     } else {
       res <- cov1[, 4:ncol(cov1)]
     }
-    print("res")
-    print(res)
-
 
     #Adds sample medians to df
     res0<-rbind((res), allnorm)
@@ -384,9 +377,6 @@ loadData <- function(chr, start, end, cnvID, sampleIDs,coveragefile,medianfile,b
                  function(vals){
                    return(as.numeric(vals[1:(nrow(res0)-1)])/as.numeric(vals[nrow(res0)]))
                  })
-
-    print("res1")
-    print(res1)
 
 
     #need to transpose if more than one bin assessed
@@ -853,8 +843,6 @@ genotype<- function(cnv_matrix,genotype_matrix,refgeno,chr,start,end,cnvID,sampl
 {
  ##get depth intensities##  
  cnv_median <-c(create_groups(genotype_matrix, cnv_matrix)$Control,create_groups(genotype_matrix, cnv_matrix)$Treat)
-  print("cnv_median")
-  print(cnv_median)
  ##order by names so same geno output for each variant##
  cnv_median<-cnv_median[order(names(cnv_median))]
  cutoff_table <-read.table(refgeno, header = TRUE)
@@ -1039,8 +1027,6 @@ runRdTest<-function(bed)
   } else {
     cnv_matrix<-loadData(chr, start, end, cnvID, sampleIDs,coveragefile,medianfile,bins)
   }
-  print("after loadData")
-  print(cnv_matrix)
 
   if (cnv_matrix[1]=="Failure") {
     ##assign genotype if no coverage##
@@ -1099,8 +1085,6 @@ runRdTest<-function(bed)
   }
   ##Assign intial genotypes (del=1,dup=3,diploid=2)##
   genotype_matrix<-specified_cnv(cnv_matrix, sampleIDs, cnvID, chr, start, end, cnvtype)
-  print("genotype_matrix")
-  print(genotype_matrix)
   ##check if no samples are found in genotype matrix##
   if (as.matrix(genotype_matrix)[1,1]=="No_Samples") {
     return(c(chr,start,end,cnvID,sampleOrigIDs,cnvtypeOrigIDs,"No_samples_for_analysis","No_samples_for_analysis","No_samples_for_analysis","No_samples_for_analysis","No_samples_for_analysis","No_samples_for_analysis"))


### PR DESCRIPTION
While investigating a missing large duplication call in the single sample pipeline, I discovered that RdTest was not accurately genotyping intervals which overlapped a gap between the intervals used by the collect coverage tool (ie a gap in `preprocessed_intervals.interval_list`). 

To briefly summarize the problem, RdTest attempts to fill in such gaps in count bin coverage by covering them with new rows of the count matrix that have zero count values. Its strategy for doing this was to tile the entire region with zero-count rows, and then remove any that were duplicates (because there was already a row with real counts with the same coordinates in the matrix). However, the way this was implemented assumed that the start and end coordinates of all bins were multiples of the bin size, ie if the bin size is 100 the count bins should be `chr1:1-100, chr1:100-200, ...`. This is not the case in `preprocessed_intervals.interval_list`, which has odd start coordinates and irregularly sized gaps between intervals, as well as some intervals that are not exactly 100bp in width on the edges of these gaps. This caused RdTest's algorithm to add a complete second set of count bins to the matrix, all with zero counts, which generally caused all samples to genotype as copy number zero in the interval. 

I've fixed this changing the gap-filling strategy so it only tiles the actual gaps between count bins with bins of binsize (apart from the last bin, which may be smaller). 

I also modified some of the code where RdTest trims the interval for compression and testing. This code also was assuming that count bin coordinates were multiples of the bin size. This changes results in small shifts in the bins which are used for testing. Under the new changes, the bins used are all fully contained within the interval to be genotyped (with the exception of intervals that are only covered by one or two bins) and bins which overhang the edges are not used, which is in line with the way the old code would have behaved if given bins that were all based on multiples of the binsize. Prior to this change RdTest was using bins which overlapped the start and end coordinates of the interval. 

This PR also updates the bin_exclude file, which was not actually being used before given that bin coordinates are matched exactly by RdTest and the old file had regularly spaced bin coordinates. A new file matching our `preprocessed_intervals.interval_list` bins was generated and provided by @hab45 .

I've tested this in a full run of the single sample pipeline. The large 11MB duplication call that had been missing is now called successfully. There are many changes in RdTest results for smaller intervals due to the changes described in my last paragraph, but they do not seem to have a large effect on the final call set. There are slightly fewer deletion and duplication calls in the final results -- 13 fewer PASS deletions and and 14 fewer PASS duplications. These may be due to using the bin_exclude file properly.