### PR TITLE
fix two issues in new RdTest

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -15,7 +15,7 @@
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline-base:rlc_posthoc_filtering_cnv_mcnv_compatability_9a8561",
   "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline:cw_clean_vcf_part1_rm_allosome_greps_8348649",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-qc:mw-xz-fixes-7cbffee",
-  "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline-rdtest:cw_bins_not_multiples_of_binsize_ebd0719",
+  "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/cwhelan/sv-pipeline-rdtest:cw_rdtest_bin_fix_update_5f2c8f",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa",
   "igv_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/igv:mw-xz-fixes-2-b1be6a9",
   "duphold_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/duphold:mw-xz-fixes-2-b1be6a9",


### PR DESCRIPTION
Further testing of the new RdTest changes exposed two bugs that caused crashes.

One was a simple off-by-one error when filling in gaps in the coverage intervals.

The other was an issue with how bins at the start and end of the interval are trimmed. Solving this required me to redo quite a bit of the logic of this section, which I hadn't completely changed to get away from the assumption of 100% fixed size bins with start coordinates that were multiples of the bin size.