### PR TITLE
Option to rename VCF samples in BAFFromShardedVCF

### DIFF
--- a/test_input_templates/module00c/Module00cTest.test_baf_from_vcf.json.tmpl
+++ b/test_input_templates/module00c/Module00cTest.test_baf_from_vcf.json.tmpl
@@ -66,7 +66,6 @@
 
   "Module00cTest.Module00c.batch": {{ test_batch.batch_name | tojson }},
   "Module00cTest.Module00c.gcnv_model_tars" : {{ test_batch.gcnv_model_tars | tojson }},
-  "Module00cTest.Module00c.BAF_files": {{ test_batch.BAF_files | tojson }},
   "Module00cTest.Module00c.PE_files": {{ test_batch.PE_files | tojson }},
   "Module00cTest.Module00c.SR_files": {{ test_batch.SR_files | tojson }},
   "Module00cTest.Module00c.counts": {{ test_batch.counts | tojson }},

--- a/wdl/Module00c.wdl
+++ b/wdl/Module00c.wdl
@@ -65,6 +65,7 @@ workflow Module00c {
 
     # BAF Option #2, position-sharded VCFs
     Array[File]? snp_vcfs
+    Array[String]? replacement_snp_vcf_sample_ids  # Reheaders vcf with ids, if provided
     File? snp_vcf_header  # Only use if snp vcfs are unheadered
 
     # Condense read counts
@@ -271,10 +272,12 @@ workflow Module00c {
       input:
         vcfs = select_first([snp_vcfs]),
         vcf_header = snp_vcf_header,
+        replacement_snp_vcf_sample_ids = replacement_snp_vcf_sample_ids,
         samples = samples,
         batch = batch,
         sv_base_mini_docker = sv_base_mini_docker,
         sv_pipeline_docker = sv_pipeline_docker,
+        linux_docker = linux_docker,
         runtime_attr_baf_gen = runtime_attr_baf_gen
     }
   }


### PR DESCRIPTION
Adds `Array[String]? replacement_snp_vcf_sample_ids` input to Module00c. When specified and using the `snp_vcfs` input to generate BAF, each vcf will be reheadered with the given sample IDs. This is useful when sample IDs have been reformatted for gatk-sv but the the vcfs have been already been generated with original IDs. 

Note that the length and order of `replacement_snp_vcf_sample_ids` must exactly match that in the vcfs (or header file if provided), and also that they may be different from the `samples` input (e.g. when the batch samples are a subset of those in the vcf, or the vcf samples are in a different order). 