### PR TITLE
Evaluate all batch-origin variants in GetRegenotype

### DIFF
--- a/wdl/Module04b.wdl
+++ b/wdl/Module04b.wdl
@@ -715,7 +715,8 @@ task MergeList {
 
   command {
     set -euo pipefail
-    cat ~{sep=' ' regeno_beds} | sort -k1,1V -k2,2n -k3,3n > ~{prefix}.bed
+    # concatenate, remove duplicate variant IDs (ignore other columns), then sort by position
+    cat ~{sep=' ' regeno_beds} | sort -u -k4,4 | sort -k1,1V -k2,2n -k3,3n > ~{prefix}.bed
     # count non-empty lines in regeno bed file to determine if empty or not --> proceed with regenotyping or stop here?
     # the OR clause is to ignore return code = 1 because that isn't an error, it just means there were 0 matched lines (but don't ignore real error codes > 1)
     NUM_REGENO=$(grep -c '[^[:space:]]' ~{prefix}.bed || [[ $? == 1 ]] ) 


### PR DESCRIPTION
### Updates
Changes to evaluate all variants originally discovered in the batch in GetRegenotype in Module04, rather than just the ones that retained the variant ID containing the batch name after MergeCohortVcfs. A chr_start_end_svtype identifier is created and used to match variants that originated in the batch pre-genotyping with potentially-renamed variants post-genotyping so that they can be checked for sample loss/gain.

Other potential bugs were evaluated (space vs. tab delimiters, checking `$6` instead of `$7`) but the task was determined to be working as expected.

### Testing
Tested with two 1kgp batches and compared to a recent run in Terra. The final outputs were identical. There were 18 additional variants in the `to_regeno.bed` file outputted from GetRegenotype for batch2, and 1 additional variant in the regenotype list outputted from MergeList, which was investigated and appeared to fit the expected pattern. But the added variants were all filtered out during CombineReassess so the final regenotyped VCFs were identical.

Further testing will be performed with gnomAD batches to evaluate scaling performance.
Update: With 30 gnomAD batches, GetRegenotype took on average a few seconds longer than before, and used less memory and disk. The last test had 3407 variants to regenotype before filtering and 51 after filtering; this latest test had 3720 variants to regenotype before filtering and 50 after. The increase pre-filtering is expected because missing variants were added. The decrease in final regenotyped variants is less expected, but may have been caused by shifting outlier boundaries during filtering. Alternatively, it may have been caused by a separate change made in between these two tests; unfortunately, the intermediate files for the first test no longer exist for direct comparison.
