### PR TITLE
Support original sample ids in snp vcfs

### DIFF
--- a/wdl/Module00c.wdl
+++ b/wdl/Module00c.wdl
@@ -66,6 +66,8 @@ workflow Module00c {
     # BAF Option #2, position-sharded VCFs
     Array[File]? snp_vcfs
     File? snp_vcf_header  # Only use if snp vcfs are unheadered
+    # Sample ids in vcf, where vcf_samples[i] corresponds to samples[i]. Only use if sample ids are different in vcf
+    Array[String]? vcf_samples
 
     # Condense read counts
     Int? condense_num_bins
@@ -271,7 +273,7 @@ workflow Module00c {
       input:
         vcfs = select_first([snp_vcfs]),
         vcf_header = snp_vcf_header,
-        samples = samples,
+        samples = select_first([vcf_samples, samples]),
         batch = batch,
         sv_base_mini_docker = sv_base_mini_docker,
         sv_pipeline_docker = sv_pipeline_docker,


### PR DESCRIPTION
Adds optional input `vcf_samples` to Module00c so that the user doesn't need to modify snp vcf headers if they've changed sample ids.