### PR TITLE
hotfix for Tasks0506 cromwell compliance

### DIFF
--- a/wdl/Tasks0506.wdl
+++ b/wdl/Tasks0506.wdl
@@ -12,7 +12,7 @@ import "Structs.wdl"
 task ZcatCompressedFiles {
   input {
     Array[File] shards
-    String outfile_name
+    String? outfile_name
     String? filter_command
     String sv_base_mini_docker
     RuntimeAttr? runtime_attr_override
@@ -60,7 +60,7 @@ task ZcatCompressedFiles {
   }
 
   output {
-    File outfile=outfile_name
+    File outfile=output_file_name
   }
 }
 


### PR DESCRIPTION
### Updates
Very minor changes to allow cromwell/womtool to handle Tasks0506.wdl

### Testing
Just validated with womtool as ZcatCompressedFiles now matches CatUncompressedFiles in this respect, so I don't feel that further testing is necessary