### PR TITLE
Add ExpansionHunter Denovo WDL 

### DIFF
--- a/dockerfiles/expansion-hunter-denovo/Dockerfile
+++ b/dockerfiles/expansion-hunter-denovo/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:3-alpine
-RUN apk update && \
-    apk add --no-cache \
-                       # bash is required by container_linux.go
-                       bash \
-                       curl && \
+FROM python:3.7-slim
+RUN apt-get update && apt-get install -y \
+    # bash is required by container_linux.go
+    wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* && \
+
     wget https://github.com/Illumina/ExpansionHunterDenovo/releases/download/v0.9.0/ExpansionHunterDenovo-v0.9.0-linux_x86_64.tar.gz && \
     mkdir ehdn_extract && \
     tar -xf *.tar.gz --strip-components=1 -C ehdn_extract && \
@@ -11,5 +12,7 @@ RUN apk update && \
     mkdir ehdn && \
     mv ehdn_extract/bin/* ehdn/ && \
     mv ehdn_extract/scripts ehdn/ && \
-    rm -rf ehdn_extract
+    rm -rf ehdn_extract && \
+    pip install -r /ehdn/scripts/requirements.txt
 ENV PATH="/ehdn/:$PATH"
+ENV SCRIPTS_DIR /ehdn/scripts

--- a/dockerfiles/expansion-hunter-denovo/Dockerfile
+++ b/dockerfiles/expansion-hunter-denovo/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.7-slim
 RUN apt-get update && apt-get install -y \
-    # bash is required by container_linux.go
     wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* && \

--- a/dockerfiles/expansion-hunter-denovo/Dockerfile
+++ b/dockerfiles/expansion-hunter-denovo/Dockerfile
@@ -1,5 +1,9 @@
 FROM alpine:latest
-RUN apk --no-cache add curl && \
+RUN apk update && \
+    apk add --no-cache \
+                       # bash is required by container_linux.go
+                       bash \
+                       curl && \
     wget https://github.com/Illumina/ExpansionHunterDenovo/releases/download/v0.9.0/ExpansionHunterDenovo-v0.9.0-linux_x86_64.tar.gz && \
     mkdir ehdn_extract && \
     tar -xf *.tar.gz --strip-components=1 -C ehdn_extract && \

--- a/dockerfiles/expansion-hunter-denovo/Dockerfile
+++ b/dockerfiles/expansion-hunter-denovo/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM python:3-alpine
 RUN apk update && \
     apk add --no-cache \
                        # bash is required by container_linux.go
@@ -10,5 +10,6 @@ RUN apk update && \
     rm -rf *.tar.gz && \
     mkdir ehdn && \
     mv ehdn_extract/bin/* ehdn/ && \
+    mv ehdn_extract/scripts ehdn/ && \
     rm -rf ehdn_extract
 ENV PATH="/ehdn/:$PATH"

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -1,21 +1,30 @@
-## Runs ExpansionHunter denovo
+## Runs ExpansionHunter denovo (ehdn)
 
 version 1.0
 
 import "Structs.wdl"
 
+struct FilenamePostfixes {
+  String locus
+  String motif
+  String profile
+  String merged_profile
+  Int profile_len
+}
+
 workflow ComputeSTRProfiles {
 
   input {
     Array[File] case_reads_filenames
+    Array[File] case_indexes_filenames
     Array[File] control_reads_filenames
-    File manifest_filename
+    Array[File] control_indexes_filenames
     File reference_filename
-    String output_prefix
     Int min_anchor_mapq
     Int max_irr_mapq
     String ehdn_docker
-    RuntimeAttr? runtime_attr
+    RuntimeAttr? runtime_attr_str_profile
+    RuntimeAttr? runtime_attr_merge
   }
 
   parameter_meta {
@@ -23,54 +32,34 @@ workflow ComputeSTRProfiles {
     control_reads_filenames: ""
     manifest_filename: ""
     reference_filename: ""
-    output_prefix: ""
     min_anchor_mapq: ""
     max_irr_mapq: ""
     ehdn_docker: ""
-    runtime_attr: ""
   }
 
-  scatter(reads_filename in case_reads_filenames) {
-    call ComputeSTRProfile {
-      input:
-        reads_filename = reads_filename,
-        reference_filename = reference_filename,
-        output_prefix = output_prefix,
-        min_anchor_mapq = min_anchor_mapq,
-        max_irr_mapq = max_irr_mapq,
-        ehdn_docker = ehdn_docker,
-        runtime_attr_override = runtime_attr
-    }
+  # The values of the variables are based on
+  # ehdn's current latest hard-coded postfixes.
+  # Do not change them unless they are changed
+  # in ehdn.
+  FilenamePostfixes postfixes = object {
+    locus: ".locus.tsv",
+    motif: ".motif.tsv",
+    profile: ".str_profile.json",
+    merged_profile: ".multisample_profile.json",
+
+    # This the length of `profile` postfix without
+    # the filename extension. It is used to remove
+    # postfix in order to extract sample name from
+    # ehdn generated output.
+    # e.g., extract `sample1` from `sample1.str_profile.json`.
+    profile_len: 12
   }
 
-  call Merge {
-    input:
-      reference_filename = reference_filename,
-      manifest_filename = manifest_filename,
-      output_prefix = output_prefix,
-      ehdn_docker = ehdn_docker
-  }
+  String locus_filename_postfix = ".locus.tsv"
+  String motif_filename_postfix = ".motif.tsv"
+  String profile_filename_postfix = ".str_profile.json"
 
-  output {
-    Array[File] locus = ComputeSTRProfile.locus
-    Array[File] motif = ComputeSTRProfile.motif
-    Array[File] profile = ComputeSTRProfile.profile
-    File multisample_profile = Merge.multisample_profile
-  }
-}
-
-task ComputeSTRProfile {
-  input {
-    File reads_filename
-    File reference_filename
-    String output_prefix
-    Int min_anchor_mapq
-    Int max_irr_mapq
-    String ehdn_docker
-    RuntimeAttr? runtime_attr_override
-  }
-
-  RuntimeAttr default_attr = object {
+  RuntimeAttr runtime_attr_str_profile_default = object {
     cpu_cores: 1,
     mem_gb: 4,
     disk_gb: 10,
@@ -78,54 +67,184 @@ task ComputeSTRProfile {
     preemptible_tries: 0,
     max_retries: 1
   }
-  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+  RuntimeAttr runtime_attr_str_profile = select_first([
+    runtime_attr_str_profile,
+    runtime_attr_str_profile_default])
+
+  RuntimeAttr runtime_attr_merge_default = object {
+    cpu_cores: 1,
+    mem_gb: 4,
+    disk_gb: 10,
+    boot_disk_gb: 10,
+    preemptible_tries: 0,
+    max_retries: 1
+  }
+  RuntimeAttr runtime_attr_merge = select_first([
+    runtime_attr_merge,
+    runtime_attr_merge_default])
+
+  scatter(pair in zip(case_reads_filenames, case_indexes_filenames)) {
+    String case_sample_filename = basename(pair.left, ".bam")
+    call ComputeSTRProfile as CasesProfiles {
+      input:
+        filename = case_sample_filename,
+        reads_filename = pair.left,
+        index_filename = pair.right,
+        reference_filename = reference_filename,
+        min_anchor_mapq = min_anchor_mapq,
+        max_irr_mapq = max_irr_mapq,
+        ehdn_docker = ehdn_docker,
+        runtime_attr = runtime_attr_str_profile,
+        postfixes = postfixes
+    }
+  }
+
+  scatter(pair in zip(control_reads_filenames, control_indexes_filenames)) {
+    String control_sample_filename = basename(pair.left, ".bam")
+    call ComputeSTRProfile as ControlsProfiles {
+      input:
+        filename = control_sample_filename,
+        reads_filename = pair.left,
+        index_filename = pair.right,
+        reference_filename = reference_filename,
+        min_anchor_mapq = min_anchor_mapq,
+        max_irr_mapq = max_irr_mapq,
+        ehdn_docker = ehdn_docker,
+        runtime_attr = runtime_attr_str_profile,
+        postfixes = postfixes
+    }
+  }
+
+  call Merge {
+    input:
+      cases = CasesProfiles.str_profile,
+      controls = ControlsProfiles.str_profile,
+      reference_filename = reference_filename,
+      ehdn_docker = ehdn_docker,
+      runtime_attr = runtime_attr_merge,
+      postfixes = postfixes
+  }
 
   output {
-    File locus = "${output_prefix}.locus.tsv"
-    File motif = "${output_prefix}.motif.tsv"
-    File profile = "${output_prefix}.str_profile.json"
+    Array[File] cases_locus = CasesProfiles.locus
+    Array[File] cases_motif = CasesProfiles.motif
+    Array[File] cases_str_profile = CasesProfiles.str_profile
+    Array[File] controls_locus = ControlsProfiles.locus
+    Array[File] controls_motif = ControlsProfiles.motif
+    Array[File] controls_str_profile = ControlsProfiles.str_profile
+    File multisample_profile = Merge.multisample_profile
   }
+}
+
+task ComputeSTRProfile {
+  input {
+    String filename
+    File reads_filename
+    File index_filename
+    File reference_filename
+    Int min_anchor_mapq
+    Int max_irr_mapq
+    String ehdn_docker
+    RuntimeAttr runtime_attr
+    FilenamePostfixes postfixes
+  }
+
+  output {
+    File locus = "${filename}${postfixes.locus}"
+    File motif = "${filename}${postfixes.motif}"
+    File str_profile = "${filename}${postfixes.profile}"
+  }
+
   command <<<
 
     ExpansionHunterDenovo profile \
-      --reads ~{reads_filename} \
-      -reference ~{reference_filename} \
-      --output-prefix ~{output_prefix} \
-      --min-anchor-mapq ~{min_anchor_mapq} \
-      --max-irr-mapq ~{max_irr_mapq}
+    --reads ~{reads_filename} \
+    --reference ~{reference_filename} \
+    --output-prefix ~{filename} \
+    --min-anchor-mapq ~{min_anchor_mapq} \
+    --max-irr-mapq ~{max_irr_mapq}
+
   >>>
 
   runtime {
+    docker: ehdn_docker
     cpu: runtime_attr.cpu_cores
     memory: runtime_attr.mem_gb + " GiB"
     disks: "local-disk " + runtime_attr.disk_gb + " HDD"
     bootDiskSizeGb: runtime_attr.boot_disk_gb
     preemptible: runtime_attr.preemptible_tries
     maxRetries: runtime_attr.max_retries
-    docker: ehdn_docker
   }
 }
 
 task Merge {
   input {
+    Array[File] cases
+    Array[File] controls
     File reference_filename
-    File manifest_filename
-    String output_prefix
     String ehdn_docker
+    RuntimeAttr runtime_attr
+    FilenamePostfixes postfixes
   }
 
   output {
-    File multisample_profile = "${output_prefix.multisample_profile.json}"
+    File multisample_profile = "${output_prefix}${postfixes.merged_profile}"
   }
 
+  Int cases_length = length(cases)
+  Int controls_length = length(controls)
+  String output_prefix = "merged"
+
+  # This shell script uses ehdn's `merge` command
+  # to merge STR profiles on all the individual samples
+  # into a single JSON file.
+  #
+  # The script is composed of two parts:
+  # - Create a "manifest" file based on the given inputs.
+  #   The manifest file is composed of three columns:
+  #   (1) Sample name (infered from the filename);
+  #   (2) case/control (infered from files in the inputs
+  #       `cases` and `controls`);
+  #   (3) file path.
+  #
+  # - Call ehdn's `merge` method using the input and
+  #   the generaged manifest file.
   command <<<
+    get_sample_name()
+    {
+      filename=$(basename -- "$1")
+      filename="${filename%.*}"
+      echo "${filename::-~{postfixes.profile_len}}"
+    }
+    manifest_filename="manifest.tsv"
+
+    echo ~{cases_length}
+    echo ~{controls_length}
+    if [ ~{cases_length} -ne 0 ]; then
+      for i in "~{sep=" " cases}"; do
+        echo -e "$( get_sample_name "$i" )\tcase\t$i" >> $manifest_filename
+      done
+    fi
+    if [ ~{controls_length} -ne 0 ]; then
+      for i in "~{sep=" " controls}"; do
+        echo -e "$( get_sample_name "$i" )\tcontrol\t$i" >> $manifest_filename
+      done
+    fi
+    cat $manifest_filename
+
     ExpansionHunterDenovo merge \
       --reference ~{reference_filename} \
-      --manifest ~{manifest_filename} \
+      --manifest $manifest_filename \
       --output-prefix ~{output_prefix}
   >>>
 
   runtime {
     docker: ehdn_docker
+    cpu: runtime_attr.cpu_cores
+    memory: runtime_attr.mem_gb + " GiB"
+    disks: "local-disk " + runtime_attr.disk_gb + " HDD"
+    bootDiskSizeGb: runtime_attr.boot_disk_gb
+    preemptible: runtime_attr.preemptible_tries
+    maxRetries: runtime_attr.max_retries
   }
 }

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -2,6 +2,8 @@
 
 version 1.0
 
+import "Structs.wdl"
+
 workflow ComputeSTRProfiles {
 
   input {
@@ -28,7 +30,7 @@ workflow ComputeSTRProfiles {
     runtime_attr: ""
   }
 
-  scatter(reads_filename in [case_reads_filenames, control_reads_filenames]) {
+  scatter(reads_filename in case_reads_filenames) {
     call ComputeSTRProfile {
       input:
         reads_filename = reads_filename,

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -1,0 +1,129 @@
+## Runs ExpansionHunter denovo
+
+version 1.0
+
+workflow ComputeSTRProfiles {
+
+  input {
+    Array[File] case_reads_filenames
+    Array[File] control_reads_filenames
+    File manifest_filename
+    File reference_filename
+    String output_prefix
+    Int min_anchor_mapq
+    Int max_irr_mapq
+    String ehdn_docker
+    RuntimeAttr? runtime_attr
+  }
+
+  parameter_meta {
+    case_reads_filenames: ""
+    control_reads_filenames: ""
+    manifest_filename: ""
+    reference_filename: ""
+    output_prefix: ""
+    min_anchor_mapq: ""
+    max_irr_mapq: ""
+    ehdn_docker: ""
+    runtime_attr: ""
+  }
+
+  scatter(reads_filename in [case_reads_filenames, control_reads_filenames]) {
+    call ComputeSTRProfile {
+      input:
+        reads_filename = reads_filename,
+        reference_filename = reference_filename,
+        output_prefix = output_prefix,
+        min_anchor_mapq = min_anchor_mapq,
+        max_irr_mapq = max_irr_mapq,
+        ehdn_docker = ehdn_docker,
+        runtime_attr_override = runtime_attr
+    }
+  }
+
+  call Merge {
+    input:
+      reference_filename = reference_filename,
+      manifest_filename = manifest_filename,
+      output_prefix = output_prefix,
+      ehdn_docker = ehdn_docker
+  }
+
+  output {
+    Array[File] locus = ComputeSTRProfile.locus
+    Array[File] motif = ComputeSTRProfile.motif
+    Array[File] profile = ComputeSTRProfile.profile
+    File multisample_profile = Merge.multisample_profile
+  }
+}
+
+task ComputeSTRProfile {
+  input {
+    File reads_filename
+    File reference_filename
+    String output_prefix
+    Int min_anchor_mapq
+    Int max_irr_mapq
+    String ehdn_docker
+    RuntimeAttr? runtime_attr_override
+  }
+
+  RuntimeAttr default_attr = object {
+    cpu_cores: 1,
+    mem_gb: 4,
+    disk_gb: 10,
+    boot_disk_gb: 10,
+    preemptible_tries: 0,
+    max_retries: 1
+  }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+  output {
+    File locus = "${output_prefix}.locus.tsv"
+    File motif = "${output_prefix}.motif.tsv"
+    File profile = "${output_prefix}.str_profile.json"
+  }
+  command <<<
+
+    ExpansionHunterDenovo profile \
+      --reads ~{reads_filename} \
+      -reference ~{reference_filename} \
+      --output-prefix ~{output_prefix} \
+      --min-anchor-mapq ~{min_anchor_mapq} \
+      --max-irr-mapq ~{max_irr_mapq}
+  >>>
+
+  runtime {
+    cpu: runtime_attr.cpu_cores
+    memory: runtime_attr.mem_gb + " GiB"
+    disks: "local-disk " + runtime_attr.disk_gb + " HDD"
+    bootDiskSizeGb: runtime_attr.boot_disk_gb
+    preemptible: runtime_attr.preemptible_tries
+    maxRetries: runtime_attr.max_retries
+    docker: ehdn_docker
+  }
+}
+
+task Merge {
+  input {
+    File reference_filename
+    File manifest_filename
+    String output_prefix
+    String ehdn_docker
+  }
+
+  output {
+    File multisample_profile = "${output_prefix.multisample_profile.json}"
+  }
+
+  command <<<
+    ExpansionHunterDenovo merge \
+      --reference ~{reference_filename} \
+      --manifest ~{manifest_filename} \
+      --output-prefix ~{output_prefix}
+  >>>
+
+  runtime {
+    docker: ehdn_docker
+  }
+}

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -1,9 +1,10 @@
-## ExpansionHunter denovo (EHdn)
+##  ExpansionHunter denovo (EHdn)
 ##
-## This WDL implements workflows for
-## EHdn's two execution modes:
-## (i) case-control analysis;
-## (ii) outliner analysis.
+##  This WDL implements workflows for EHdn's two execution modes:
+##  - case-control analysis (read EHdn docs on this:
+##    https://github.com/Illumina/ExpansionHunterDenovo/blob/master/documentation/03_Case_control_quickstart.md);
+##  - outliner analysis (read EHdn docs on this:
+##    https://github.com/Illumina/ExpansionHunterDenovo/blob/master/documentation/04_Outlier_quickstart.md).
 
 version 1.0
 
@@ -36,10 +37,12 @@ workflow EHdnSTRAnalysis {
   }
 
   parameter_meta {
-    analysis_type: "possible values: {casecontrol, outlier, both}"
-    str_comparison_type: "possible values: {locus, motif, both}"
-    case_reads_filenames: ""
-    control_reads_filenames: ""
+    analysis_type: "Sets the analysis type; accepted values are: `casecontrol`, `outlier`, and `both`."
+    str_comparison_type: "Set the STR comparison type; accepted values are: `locus`, `motif`, and `both`."
+    case_reads_filenames: "A list of BAM files to be used as `case` samples."
+    case_indexes_filenames: "A list of index files (.bam.bai) for the `case` samples. Files should be in the same order as the case samples"
+    control_reads_filenames: "A list of BAM files to be used as `control` samples."
+    control_indexes_filenames: "A list of index files (.bam.bai) for `control` samples. Files should be in the same order as the control samples (i.e., the `control_reads_filenames` list)."
     manifest_filename: ""
     reference_filename: ""
     min_anchor_mapq: ""

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -67,20 +67,18 @@ workflow EHdnSTRAnalysis {
 
   scatter (i in range(length(sample_bams_or_crams))) {
     File sample_bam_or_cram_ = sample_bams_or_crams[i]
+    Boolean is_bam =
+      basename(sample_bam_or_cram_, ".bam") + ".bam" ==
+      basename(sample_bam_or_cram_)
+
     File bam_or_cram_index_ =
       if defined(sample_bams_or_crams_indexes) then
         select_first([sample_bams_or_crams_indexes])[i]
       else
-        sample_bam_or_cram_ +
-        if  basename(sample_bam_or_cram_, ".bam") + ".bam" ==
-            basename(sample_bam_or_cram_) then
-          ".bai"
-        else
-          ".crai"
+        sample_bam_or_cram_ + if is_bam then ".bai" else ".crai"
 
     String filename =
-      if  basename(sample_bam_or_cram_, ".bam") + ".bam" ==
-          basename(sample_bam_or_cram_) then
+      if is_bam then
         basename(sample_bam_or_cram_, ".bam")
       else
         basename(sample_bam_or_cram_, ".cram")

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -197,6 +197,7 @@ task ComputeSTRProfile {
   }
 
   command <<<
+    set -euxo pipefail
 
     ExpansionHunterDenovo profile \
     --reads ~{reads_filename} \
@@ -252,6 +253,8 @@ task Merge {
   # - Call EHdn's `merge` method using the input and
   #   the generaged manifest file.
   command <<<
+    set -euxo pipefail
+
     get_sample_name()
     {
       filename=$(basename -- "$1")
@@ -306,6 +309,8 @@ task STRAnalyze {
   }
 
   command <<<
+    set -euxo pipefail
+
     analysis_types=()
     comparison_types=()
     if [ ~{analysis_type} == "both" ]; then

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -1,4 +1,9 @@
-## Runs ExpansionHunter denovo (ehdn)
+## ExpansionHunter denovo (ehdn)
+##
+## This WDL implements workflows for
+## ehdn's two execution modes:
+## (i) case-control analysis;
+## (ii) outliner analysis.
 
 version 1.0
 

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -256,12 +256,14 @@ task Merge {
     echo ~{cases_length}
     echo ~{controls_length}
     if [ ~{cases_length} -ne 0 ]; then
-      for i in "~{sep=" " cases}"; do
+      cases_arr=(~{sep=" " cases})
+      for i in "${cases_arr[@]}"; do
         echo -e "$( get_sample_name "$i" )\tcase\t$i" >> $manifest_filename
       done
     fi
     if [ ~{controls_length} -ne 0 ]; then
-      for i in "~{sep=" " controls}"; do
+      controls_arr=(~{sep=" " controls})
+      for i in "${controls_arr[@]}"; do
         echo -e "$( get_sample_name "$i" )\tcontrol\t$i" >> $manifest_filename
       done
     fi
@@ -322,11 +324,11 @@ task STRAnalyze {
       analysis_types+=("~{analysis_type}")
     fi
 
-    if [ ~{analysis_type} == "both" ]; then
+    if [ ~{str_comparison_type} == "both" ]; then
       comparison_types+=("locus")
       comparison_types+=("motif")
     else
-      comparison_types+=("~{analysis_type}")
+      comparison_types+=("~{str_comparison_type}")
     fi
 
     for analysis_type in "${analysis_types[@]}"; do

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -78,11 +78,16 @@ workflow EHdnSTRAnalysis {
         else
           ".crai"
 
-    # TODO: change this to work for both BAM and CRAM.
-    String case_sample_filename = basename(sample_bam_or_cram_, ".bam")
+    String filename =
+      if  basename(sample_bam_or_cram_, ".bam") + ".bam" ==
+          basename(sample_bam_or_cram_) then
+        basename(sample_bam_or_cram_, ".bam")
+      else
+        basename(sample_bam_or_cram_, ".cram")
+
     call ComputeSTRProfile {
       input:
-        filename = case_sample_filename,
+        filename = filename,
         bam_or_cram = sample_bam_or_cram_,
         bam_or_cram_index = bam_or_cram_index_,
         reference_fasta = reference_fasta,

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -112,8 +112,8 @@ workflow EHdnSTRAnalysis {
 
   call STRAnalyze {
     input:
-      cases = cases_str_profile_json,
-      controls = controls_str_profile_json,
+      case_jsons = cases_str_profile_json,
+      control_jsons = controls_str_profile_json,
       reference_fasta = reference_fasta,
       reference_fasta_index = reference_fasta_index,
       postfixes = postfixes,
@@ -203,8 +203,8 @@ task STRAnalyze {
   input {
     String analysis_type
     String str_comparison_type
-    Array[File] cases
-    Array[File] controls
+    Array[File] case_jsons
+    Array[File] control_jsons
     File reference_fasta
     File? reference_fasta_index
     FilenamePostfixes postfixes
@@ -218,8 +218,8 @@ task STRAnalyze {
     Array[File] results = glob("result_*.tsv")
   }
 
-  Int cases_length = length(cases)
-  Int controls_length = length(controls)
+  Int cases_length = length(case_jsons)
+  Int controls_length = length(control_jsons)
   String output_prefix = "merged"
   String multisample_profile = output_prefix + postfixes.merged_profile
 
@@ -263,13 +263,13 @@ task STRAnalyze {
     manifest_filename="manifest.tsv"
 
     if [ ~{cases_length} -ne 0 ]; then
-      cases_arr=(~{sep=" " cases})
+      cases_arr=(~{sep=" " case_jsons})
       for i in "${cases_arr[@]}"; do
         echo -e "$( get_sample_name "$i" )\tcase\t$i" >> $manifest_filename
       done
     fi
     if [ ~{controls_length} -ne 0 ]; then
-      controls_arr=(~{sep=" " controls})
+      controls_arr=(~{sep=" " control_jsons})
       for i in "${controls_arr[@]}"; do
         echo -e "$( get_sample_name "$i" )\tcontrol\t$i" >> $manifest_filename
       done

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -175,10 +175,14 @@ task ComputeSTRProfile {
   RuntimeAttr runtime_attr_str_profile_default = object {
     cpu_cores: 1,
     mem_gb: 4,
-    disk_gb: 10,
     boot_disk_gb: 10,
-    preemptible_tries: 0,
-    max_retries: 1
+    preemptible_tries: 3,
+    max_retries: 1,
+    disk_gb: 10 + ceil(size([
+      bam_or_cram,
+      bam_or_cram_index,
+      reference_fasta,
+      reference_fasta_index_], "GiB"))
   }
   RuntimeAttr runtime_attr = select_first([
     runtime_attr_override,
@@ -309,12 +313,14 @@ task STRAnalyze {
   >>>
 
   RuntimeAttr runtime_attr_analysis_default = object {
-    cpu_cores: 1,
-    mem_gb: 4,
-    disk_gb: 10,
-    boot_disk_gb: 10,
-    preemptible_tries: 0,
-    max_retries: 1
+  cpu_cores: 1,
+  mem_gb: 4,
+  boot_disk_gb: 10,
+  preemptible_tries: 3,
+  max_retries: 1,
+  disk_gb: 10 + ceil(size([
+    reference_fasta,
+    reference_fasta_index_], "GiB"))
   }
   RuntimeAttr runtime_attr = select_first([
     runtime_attr_override,

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -32,19 +32,22 @@ workflow EHdnSTRAnalysis {
     Int max_irr_mapq
     String ehdn_docker
     RuntimeAttr? runtime_attr_str_profile
-    RuntimeAttr? runtime_attr_merge
     RuntimeAttr? runtime_attr_analysis
   }
 
   parameter_meta {
     analysis_type: "Sets the analysis type; accepted values are: `casecontrol`, `outlier`, and `both`."
-    str_comparison_type: "Set the STR comparison type; accepted values are: `locus`, `motif`, and `both`."
-    case_indexes_filenames: "A list of index files (.bam.bai) for the `case` samples. Files should be in the same order as the case samples"
-    manifest_filename: ""
-    reference_filename: ""
-    min_anchor_mapq: ""
-    max_irr_mapq: ""
-    ehdn_docker: ""
+    str_comparison_type: "Sets the STR comparison type; accepted values are: `locus`, `motif`, and `both`."
+    sample_bams_or_crams: "A list of bam or cram files to be used as input to EHdn."
+    sample_bams_or_crams_indexes: "[Optional] A list of index files (.bam.bai) for the samples. Files should be in the same order as the samples. If not provided, it will be inferred from sample filenames."
+    samples_status: "A list of `case` or `control` that specify which samples should be considered `case` or `control`. For instance `['case', 'case', 'control']` sets the first two samples in the `sample_bams_or_crams` array to be `case` and the third sample to be `control`."
+    reference_fasta: "Sets the path to the reference."
+    reference_fasta_index: "[Optional] Sets the path to the index of reference. If not provided, it will be inferred from the reference filename."
+    min_anchor_mapq: "Sets anchor mapping quality (mapq) threshold."
+    max_irr_mapq: "Set the mapping quality (mapq) threshold on reads to be considered when searching for in-repeat reads (IRR)."
+    ehdn_docker: "Sets the docker image of EHdn."
+    runtime_attr_str_profile: "[Optional] Override the default runtime attributes for STR profiling task."
+    runtime_attr_analysis: "[Optional] Override the default runtime attributes for the STR analysis task."
   }
 
   # The values of the variables are based on

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -73,15 +73,6 @@ workflow EHdnSTRAnalysis {
   String index_ext_ = if is_bam_ then ".bai" else ".crai"
   File reference_bam_or_cram_index = if defined(reference_bam_or_cram_index) then select_first([reference_bam_or_cram_index]) else reference_bam_or_cram + index_ext_
 
-  if (analysis_type != "casecontrol" && analysis_type != "outlier" && analysis_type != "both")
-  {
-    # TODO: Throw an exception.
-  }
-
-  String locus_filename_postfix = ".locus.tsv"
-  String motif_filename_postfix = ".motif.tsv"
-  String profile_filename_postfix = ".str_profile.json"
-
   scatter(pair in zip(case_reads_filenames, case_indexes_filenames)) {
     String case_sample_filename = basename(pair.left, ".bam")
     call ComputeSTRProfile as CasesProfiles {

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -227,21 +227,26 @@ task STRAnalyze {
     reference_fasta_index,
     reference_fasta + ".fai"])
 
-  # This shell script uses EHdn's `merge` command
-  # to merge STR profiles on all the individual samples
-  # into a single JSON file.
+  # This script is composed of two stesp:
   #
-  # The script is composed of two parts:
-  # - Create a "manifest" file based on the given inputs.
-  #   The manifest file is composed of three columns:
-  #   (1) Sample name (infered from the filename);
-  #   (2) case/control (infered from files in the inputs
-  #       `cases` and `controls`);
-  #   (3) file path.
+  # - Merge STR profiles determined for each
+  #   sample separately into a single TSV file.
+  #   This step uses the `merge` script of EHdn
+  #   and is composes of the following steps:
+  #   - Create a manifest file, a TSV with three
+  #     columns: (i) Sample name (infered from
+  #     the filename); (2) case/control (infered
+  #     from files in the inputs `cases` and
+  #     `controls`); and  (3) file path.
+  #   - Call EHdn's `merge` method on the manifest
+  #     file. This script outputs a single JSON
+  #     file which contains STR profiles of
+  #     all individual samples.
   #
-  # - Call EHdn's `merge` method using the input and
-  #   the generaged manifest file.
-
+  # - Using the STR profiles in the JSON file and
+  #   the manifest, perform case-control or outlier
+  #   analysis at motif or locus level.
+  #
   command <<<
     set -euxo pipefail
 

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -1,7 +1,7 @@
-## ExpansionHunter denovo (ehdn)
+## ExpansionHunter denovo (EHdn)
 ##
 ## This WDL implements workflows for
-## ehdn's two execution modes:
+## EHdn's two execution modes:
 ## (i) case-control analysis;
 ## (ii) outliner analysis.
 
@@ -43,9 +43,9 @@ workflow ComputeSTRProfiles {
   }
 
   # The values of the variables are based on
-  # ehdn's current latest hard-coded postfixes.
+  # EHdn's current latest hard-coded postfixes.
   # Do not change them unless they are changed
-  # in ehdn.
+  # in EHdn.
   FilenamePostfixes postfixes = object {
     locus: ".locus.tsv",
     motif: ".motif.tsv",
@@ -55,7 +55,7 @@ workflow ComputeSTRProfiles {
     # This the length of `profile` postfix without
     # the filename extension. It is used to remove
     # postfix in order to extract sample name from
-    # ehdn generated output.
+    # EHdn generated output.
     # e.g., extract `sample1` from `sample1.str_profile.json`.
     profile_len: 12
   }
@@ -200,7 +200,7 @@ task Merge {
   Int controls_length = length(controls)
   String output_prefix = "merged"
 
-  # This shell script uses ehdn's `merge` command
+  # This shell script uses EHdn's `merge` command
   # to merge STR profiles on all the individual samples
   # into a single JSON file.
   #
@@ -212,7 +212,7 @@ task Merge {
   #       `cases` and `controls`);
   #   (3) file path.
   #
-  # - Call ehdn's `merge` method using the input and
+  # - Call EHdn's `merge` method using the input and
   #   the generaged manifest file.
   command <<<
     get_sample_name()

--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -3,7 +3,7 @@
 ##  This WDL implements workflows for EHdn's two execution modes:
 ##  - case-control analysis (read EHdn docs on this:
 ##    https://github.com/Illumina/ExpansionHunterDenovo/blob/master/documentation/03_Case_control_quickstart.md);
-##  - outliner analysis (read EHdn docs on this:
+##  - outlier analysis (read EHdn docs on this:
 ##    https://github.com/Illumina/ExpansionHunterDenovo/blob/master/documentation/04_Outlier_quickstart.md).
 
 version 1.0


### PR DESCRIPTION
This PR implements a WDL to use ExpansionHunter Denovo's (EHdn) [case-control analysis](https://github.com/Illumina/ExpansionHunterDenovo/blob/master/documentation/03_Case_control_quickstart.md#quickstart-case-control-analysis). 

- [x] Implement WDL;
- [x] Update `ehdn` docker image. The image is based on `python:3.7-slim`. The version `3.7` of python is chosen because of EHdn's script's pinned requirements (`numpy==1.17.1` and `scipy==1.3.1`). `slim` is chosen instead of `alpine` because of dependency issues at the time of dev/debugging. Hopefully, the image size is no big deal, if so, we can revert to `alpine` and try to resolve the dependency issues. 
- [ ] ~~Implement Carrot unit test.~~ (postponed to a separate PR: https://github.com/broadinstitute/gatk-sv/pull/209)

