### PR TITLE
Separate build logic for PR & push in diff. steps.

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -1,6 +1,6 @@
 name: Build Docker Images
 
-on: 
+on:
   push:
     branches:
       - master
@@ -8,6 +8,7 @@ on:
       - 'src/**'
       - 'dockerfiles/**'
       - 'scripts/**'
+      - '.github/workflows/sv_pipeline_docker.yml'
   pull_request:
     branches:
       - master
@@ -15,6 +16,7 @@ on:
       - 'src/**'
       - 'dockerfiles/**'
       - 'scripts/**'
+      - '.github/workflows/sv_pipeline_docker.yml'
 
 jobs:
   test_build:
@@ -28,12 +30,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      
+
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -7,7 +7,8 @@ on:
     paths:
       - 'src/**'
       - 'dockerfiles/**'
-      - 'scripts/**'
+      - 'scripts/docker/build_docker.py'
+      - 'scripts/docker/resources.Dockerfile'
       - '.github/workflows/sv_pipeline_docker.yml'
   pull_request:
     branches:
@@ -15,7 +16,8 @@ on:
     paths:
       - 'src/**'
       - 'dockerfiles/**'
-      - 'scripts/**'
+      - 'scripts/docker/build_docker.py'
+      - 'scripts/docker/resources.Dockerfile'
       - '.github/workflows/sv_pipeline_docker.yml'
 
 jobs:

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -7,20 +7,21 @@ on:
     paths:
       - 'src/**'
       - 'dockerfiles/**'
+      - 'scripts/**'
   pull_request:
     branches:
       - master
     paths:
       - 'src/**'
       - 'dockerfiles/**'
+      - 'scripts/**'
 
 jobs:
   test_build:
     runs-on: ubuntu-20.04
     name: Build GATK-SV Pipeline Docker Images
     env:
-      PR_NUM: ${{ github.event.number }}
-      COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+      GITHUB_CONTEXT: ${{ toJson(github) }}
     strategy:
       matrix:
         python-version: ['3.8']
@@ -38,7 +39,31 @@ jobs:
           python -m pip install --upgrade pip
           pip install termcolor
 
-      - name: Run build_docker.py
+      - name: Run build_docker.py [Pull Request]
+        if: github.event_name == 'pull_request'
         run: |
+          PR_NUM=${{ github.event.number }}
+          COMMIT_SHA=${{ github.event.pull_request.head.sha }}
+          IMAGE_TAG=${PR_NUM}-${COMMIT_SHA::8}
+          echo "::debug::Image tag: $IMAGE_TAG"
           cd ./scripts/docker/
-          python build_docker.py --targets all --image-tag ${PR_NUM}-${COMMIT_SHA::8}
+          python build_docker.py --targets all --image-tag $IMAGE_TAG
+
+      - name: Run build_docker.py [Push]
+        if: github.event_name == 'push'
+        run: |
+          # Get push/merge commit SHA and its time stamp
+          # from Github's context json.
+          MERGE_COMMIT_SHA=$(echo "$GITHUB_CONTEXT"| jq '.event.commits[].id' | tail -2 | head -1 |sed 's/\"//g')
+          TIME_STAMP=$(echo "$GITHUB_CONTEXT"| jq '.event.commits[].timestamp' | tail -2 | head -1 |sed 's/\"//g')
+
+          # Extract date, without dash, from time stamp; e.g.,
+          # from: 2021-07-09T20:43:27-07:00
+          # to:   20210709
+          DATE="$(cut -d'T' -f1 <<<${TIME_STAMP//-})"
+
+          IMAGE_TAG=$DATE-${MERGE_COMMIT_SHA::8}
+          echo "::debug::Image tag: $IMAGE_TAG"
+
+          cd ./scripts/docker/
+          python build_docker.py --targets all --image-tag $IMAGE_TAG


### PR DESCRIPTION
Concerning building docker images, we'd like to take different steps for PRs and pushes (e.g., PR merge commits). For instance, while we might only be interested in testing if images are successfully built for PRs, we'd like to build and push the images to GCR and update `input_values/dockers.json` accordingly. Therefore, defining separate tasks for each can simplify tailoring specific steps for PRs and pushes. This PR takes the first step in that direction and solves the issue of setting incorrect tags for images on merge commits. 


### Images tag
We're currently using the `{PR number}-{SHA8}` pattern to tag docker images. While this pattern works for images built within the context of a PR, it does not work for pushes (e.g., merge commits) since they happen outside the PR context. This PR implements the `{Date}-{SHA8}` pattern (e.g., `20210709-12345678`) for images built for merge commits.