### PR TITLE
Add a script to compare files in two metadata files.

### DIFF
--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -1,0 +1,207 @@
+import argparse
+import json
+import os
+from itertools import chain
+from subprocess import DEVNULL, STDOUT, check_call
+
+
+class BaseCompareAgent:
+    def __init__(self, working_dir=None):
+        self.working_dir = working_dir
+
+    def get_filename(self, obj):
+        return obj.replace("gs://", self.working_dir)
+
+    def get_obj(self, obj):
+        """
+        Ensures the given Google Cloud Storage
+        object (obj) is available in the working
+        directory, and returns its filename in
+        the working directory.
+        """
+        raise NotImplementedError
+
+
+class VCFCompareAgent(BaseCompareAgent):
+    def __init__(self, working_dir=None):
+        super(VCFCompareAgent, self).__init__(working_dir)
+
+        # Delimiter
+        self.d = "\t"
+        self.id_col = 2
+
+    def get_obj(self, obj):
+        """
+        Ensures the given VCF object is
+        available in working directory,
+        uncompressed, and returns its filename.
+        If not, downloads the VCF object and
+        extracts it.
+        """
+        filename = self.get_filename(obj)
+        extracted_filename = filename[:-len(".gz")]
+        if not os.path.isfile(extracted_filename):
+            if not os.path.isfile(filename):
+                check_call(["gsutil", "cp", obj, filename], stdout=DEVNULL, stderr=STDOUT)
+            check_call(["gunzip", filename], stdout=DEVNULL, stderr=STDOUT)
+        return extracted_filename
+
+    def equals(self, x, y):
+        """
+        Gets two VCF objects (Google Cloud Storage URI),
+        x and y, and returns true if files are identical,
+        and false if otherwise. Additionally, it returns the
+        compared files.
+        """
+        x = self.get_obj(x)
+        y = self.get_obj(y)
+
+        with open(x, "r") as X, open(y, "r") as Y:
+            # Not an optimal search, but it works
+            # if the files are not sorted, which
+            # is expected for some files in the
+            # pipeline.
+            for x_line in X:
+                if x_line.startswith("chr"):
+                    x_columns = x_line.split(self.d)
+                    for y_line in Y:
+                        if y_line.startswith("chr"):
+                            y_columns = y_line.split(self.d)
+                            if len(x_columns) == len(y_columns):
+                                for c in chain(range(0, self.id_col), range(self.id_col + 1, len(x_columns))):
+                                    if x_columns[c] != y_columns[c]:
+                                        break
+                                else:
+                                    break
+                    else:
+                        return False, x, y
+        return True, x, y
+
+
+class CompareWorkflowOutputs:
+    def __init__(self, working_dir):
+        self.working_dir = working_dir
+        self.filetypes_to_compare = {
+            "vcf.gz": VCFCompareAgent(self.working_dir)
+        }
+
+    def _get_filtered_outputs(self, task_outputs):
+        """
+        Iterates through the outputs of a task and
+        filters the outputs whose file type match
+        the types subject to comparison (i.e.,
+        types defined in filetypes_to_compare).
+        """
+        filtered_outputs = {}
+        if isinstance(task_outputs, list):
+            for task_output in task_outputs:
+                for ext in self.filetypes_to_compare:
+                    if task_output.endswith(ext):
+                        filtered_outputs[ext] = task_output
+        elif isinstance(task_outputs, str):
+            for ext in self.filetypes_to_compare:
+                if task_outputs.endswith(ext):
+                    filtered_outputs[ext] = task_outputs
+        return filtered_outputs
+
+    def _get_output_files(self, filename):
+        """
+        Iterates through a given cromwell metadata file
+        and filters the output files to be compared.
+        """
+        output_files = {}
+        with open(filename, "r") as f:
+            metadata = json.load(f)
+            for label, runs in metadata["calls"].items():
+                for run in runs:
+                    if run["executionStatus"] != "Done":
+                        continue
+                    for out_label, out_files in run["outputs"].items():
+                        if not out_files:
+                            continue
+                        outputs = self._get_filtered_outputs(out_files)
+                        if len(outputs) > 0:
+                            output_files[f"{label}.{out_label}"] = outputs
+        return output_files
+
+    def get_mismatches(self, reference_metadata, target_metadata):
+        """
+        Takes two metadata files (both belonging to a common
+        workflow execution), iterates through the outputs of
+        their task, downloads the objects if not already exist
+        in the working directory, compares the corresponding
+        files, and returns the files that do not match.
+        """
+        ref_output_files = self._get_output_files(reference_metadata)
+        test_output_files = self._get_output_files(target_metadata)
+
+        # For coloring the prints; see the following SO
+        # answer for details: https://stackoverflow.com/a/287944/947889
+        color_green = '\033[92m'
+        color_red = '\033[91m'
+        color_endc = '\033[0m'
+
+        mismatches = {}
+        i = 0
+        for call, ref_outputs in ref_output_files.items():
+            i += 1
+            print(f"Comparing\t{i}/{len(ref_output_files)}\t{call} ... ", end="")
+            if len(ref_outputs) > 1:
+                raise NotImplementedError
+            for extension, obj in ref_outputs.items():
+                equals, x, y = \
+                    self.filetypes_to_compare[extension].equals(
+                        obj, test_output_files[call][extension])
+                if not equals:
+                    if not call in mismatches:
+                        mismatches[call] = []
+                    mismatches[call].append([x, y])
+                    print(f"{color_red}mismatch{color_endc}")
+                else:
+                    print(f"{color_green}match{color_endc}")
+        return mismatches
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Takes two cromwell metadata files as input, "
+                    "reference and target, compares their corresponding "
+                    "output files, and reports the files that do not match. "
+                    "The two metadata files should belong to the execution "
+                    "of a common workflow (e.g., one workflow with different "
+                    "inputs). The script requires `gsutil` and `gzip` to be "
+                    "installed and configured.")
+
+    parser.add_argument(
+        "reference_metadata",
+        help="Reference cromwell metadata file.")
+    parser.add_argument(
+        "target_metadata",
+        help="Target cromwell metadata file.")
+    parser.add_argument(
+        "-w", "--working_dir",
+        help="The directory where the files will "
+             "be downloaded; default is the "
+             "invocation directory.")
+    parser.add_argument(
+        "-o", "--output",
+        help="Output file to store mismatches "
+             "(in JSON format); defaults to `output.json`.")
+
+    args = parser.parse_args()
+
+    wd = args.working_dir if args.working_dir else "."
+    comparer = CompareWorkflowOutputs(wd)
+    mismatches = comparer.get_mismatches(
+        args.reference_metadata,
+        args.target_metadata)
+
+    print(f"{len(mismatches)} files did not match.")
+
+    output_file = \
+        args.output if args.output else \
+        os.path.join(wd, "output.json")
+    with open(output_file, "w") as f:
+        json.dump(mismatches, f, indent=2)
+
+    print(f"Mismatches are persisted in {output_file}.")

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -178,24 +178,29 @@ class CompareWorkflowOutputs:
                 if call not in mismatches:
                     mismatches[call] = []
                 mismatches[call].append([reference, target])
-                print(f"{color_red}mismatch{color_endc}")
-            else:
-                print(f"{color_green}match{color_endc}")
 
         mismatches = {}
         i = 0
         for call, ref_outputs in ref_output_files.items():
             i += 1
+            matched = True
             print(f"Comparing\t{i}/{len(ref_output_files)}\t{call} ... ", end="")
             for extension, objs in ref_outputs.items():
                 if len(objs) != len(test_output_files[call][extension]):
                     record_compare_result(False, objs, test_output_files[call][extension])
+                    matched = False
                     continue
                 for idx, obj in enumerate(objs):
                     equals, x, y = \
                         self.filetypes_to_compare[extension].equals(
                             obj, test_output_files[call][extension][idx])
                     record_compare_result(equals, x, y)
+                    if not equals:
+                        matched = False
+            if matched:
+                print(f"{color_green}match{color_endc}")
+            else:
+                print(f"{color_red}mismatch{color_endc}")
         return mismatches
 
 

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -6,6 +6,16 @@ from metadata import ITaskOutputFilters, Metadata
 from subprocess import DEVNULL, STDOUT, check_call
 
 
+# For coloring the prints; see the following SO
+# answer for details: https://stackoverflow.com/a/287944/947889
+COLOR_ENDC = "\033[0m"
+COLOR_ULINE = "\033[04m"
+COLOR_BLINKING = "\033[05m"
+COLOR_RED = "\033[91m"
+COLOR_GREEN = "\033[92m"
+COLOR_YELLOW = "\033[93m"
+
+
 class FilterBasedOnExtensions(ITaskOutputFilters):
 
     def __init__(self, extensions):
@@ -124,15 +134,6 @@ class CompareWorkflowOutputs:
         in the working directory, compares the corresponding
         files, and returns the files that do not match.
         """
-        # For coloring the prints; see the following SO
-        # answer for details: https://stackoverflow.com/a/287944/947889
-        color_endc = "\033[0m"
-        color_uline = "\033[04m"
-        color_blinking = "\033[05m"
-        color_red = "\033[91m"
-        color_green = "\033[92m"
-        color_yellow = "\033[93m"
-
         def record_compare_result(match, reference, target):
             if not match:
                 if call not in mismatches:
@@ -162,29 +163,33 @@ class CompareWorkflowOutputs:
 
         r_t = ref_output_files.keys() - test_output_files.keys()
         t_r = test_output_files.keys() - ref_output_files.keys()
-        if t_r or r_t:
-            print(f"\n{color_blinking}WARNING!{color_endc}")
+        if r_t or t_r:
+            print(f"\n{COLOR_BLINKING}WARNING!{COLOR_ENDC}")
             print(f"The reference and test metadata files differ "
                   f"in their outputs; "
-                  f"{color_uline}the differences will be skipped.{color_endc}")
-            print(f"\t{len(r_t)}/{len(ref_output_files.keys())} "
-                  f"outputs of the reference are not in the test:")
-            for x in r_t:
-                print(f"\t\t- {x}")
-            print(f"\t{len(t_r)}/{len(test_output_files.keys())} "
-                  f"outputs of the test are not in the reference:")
-            for x in t_r:
-                print(f"\t\t- {x}")
+                  f"{COLOR_ULINE}the differences will be skipped.{COLOR_ENDC}")
+            if r_t:
+                print(f"\t{len(r_t)}/{len(ref_output_files.keys())} "
+                      f"outputs of the reference are not in the test:")
+                for x in r_t:
+                    print(f"\t\t- {x}")
+            if t_r:
+                print(f"\t{len(t_r)}/{len(test_output_files.keys())} "
+                      f"outputs of the test are not in the reference:")
+                for x in t_r:
+                    print(f"\t\t- {x}")
             print("\n")
 
+        [ref_output_files.pop(x) for x in r_t]
+        print(f"{COLOR_YELLOW}Comparing {len(ref_output_files)} "
+              f"files that are common between reference and test "
+              f"metadata files and their respective task is executed "
+              f"successfully.{COLOR_ENDC}")
         for call, ref_outputs in ref_output_files.items():
             i += 1
-            matched, skipped = True, False
+            matched = True
             print(f"Comparing\t{i}/{len(ref_output_files)}\t{call} ... ", end="")
             for extension, objs in ref_outputs.items():
-                if call not in test_output_files or extension not in test_output_files[call]:
-                    skipped = True
-                    continue
                 if len(objs) != len(test_output_files[call][extension]):
                     record_compare_result(False, objs, test_output_files[call][extension])
                     matched = False
@@ -196,12 +201,10 @@ class CompareWorkflowOutputs:
                     record_compare_result(equals, x, y)
                     if not equals:
                         matched = False
-            if skipped:
-                print(f"{color_yellow}not comparable outputs; skipping{color_endc}")
-            elif matched:
-                print(f"{color_green}match{color_endc}")
+            if matched:
+                print(f"{COLOR_GREEN}match{COLOR_ENDC}")
             else:
-                print(f"{color_red}mismatch{color_endc}")
+                print(f"{COLOR_RED}mismatch{COLOR_ENDC}")
         return mismatches
 
 
@@ -255,12 +258,13 @@ if __name__ == '__main__':
         args.target_metadata,
         args.deep)
 
-    print(f"{len(mismatches)} files did not match.")
-
-    output_file = \
-        args.output if args.output else \
-        os.path.join(wd, "output.json")
-    with open(output_file, "w") as f:
-        json.dump(mismatches, f, indent=2)
-
-    print(f"Mismatches are persisted in {output_file}.")
+    if len(mismatches) == 0:
+        print(f"{COLOR_GREEN}All the compared files matched.{COLOR_ENDC}")
+    else:
+        print(f"{COLOR_RED}{len(mismatches)} of the compared files did not match.{COLOR_ENDC}")
+        output_file = \
+            args.output if args.output else \
+            os.path.join(wd, "output.json")
+        with open(output_file, "w") as f:
+            json.dump(mismatches, f, indent=2)
+        print(f"Mismatches are persisted in {output_file}.")

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -42,7 +42,7 @@ class VCFCompareAgent(BaseCompareAgent):
         extracted_filename = filename[:-len(".gz")]
         if not os.path.isfile(extracted_filename):
             if not os.path.isfile(filename):
-                check_call(["gsutil", "cp", obj, filename], stdout=DEVNULL, stderr=STDOUT)
+                check_call(["gsutil", "-m", "cp", obj, filename], stdout=DEVNULL, stderr=STDOUT)
             check_call(["gunzip", filename], stdout=DEVNULL, stderr=STDOUT)
         return extracted_filename
 

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -153,7 +153,7 @@ class CompareWorkflowOutputs:
                     self.filetypes_to_compare[extension].equals(
                         obj, test_output_files[call][extension])
                 if not equals:
-                    if not call in mismatches:
+                    if call not in mismatches:
                         mismatches[call] = []
                     mismatches[call].append([x, y])
                     print(f"{color_red}mismatch{color_endc}")

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -95,15 +95,17 @@ class CompareWorkflowOutputs:
         types defined in filetypes_to_compare).
         """
         filtered_outputs = {}
-        if isinstance(task_outputs, list):
-            for task_output in task_outputs:
-                for ext in self.filetypes_to_compare:
-                    if task_output.endswith(ext):
-                        filtered_outputs[ext] = task_output
-        elif isinstance(task_outputs, str):
+        if not isinstance(task_outputs, list):
+            task_outputs = [task_outputs]
+
+        for task_output in task_outputs:
+            if not isinstance(task_output, str):
+                # Happens when output is not a file,
+                # e.g., when it is a number.
+                continue
             for ext in self.filetypes_to_compare:
-                if task_outputs.endswith(ext):
-                    filtered_outputs[ext] = task_outputs
+                if task_output.endswith(ext):
+                    filtered_outputs[ext] = task_output
         return filtered_outputs
 
     def _get_output_files(self, filename):

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -174,7 +174,16 @@ if __name__ == '__main__':
                     "The two metadata files should belong to the execution "
                     "of a common workflow (e.g., one workflow with different "
                     "inputs). The script requires `gsutil` and `gzip` to be "
-                    "installed and configured.")
+                    "installed and configured."
+                    "\n\n"
+                    "The currently supported file types are as follows."
+                    "\n\t- VCF (.vcf.gz): The non-header lines of VCF files"
+                    "are compared; except for the ID column, all the other "
+                    "columns of a variation are expected to be identical. "
+                    "The two files are expected to be equally ordered (i.e., "
+                    "n-th variation in one file is compared to the "
+                    "n-th variation on the other file).",
+        formatter_class=argparse.RawTextHelpFormatter)
 
     parser.add_argument(
         "reference_metadata",

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -118,6 +118,9 @@ class CompareWorkflowOutputs:
         def update_output_files(outputs):
             if len(outputs) > 0:
                 output_files[
+                    # Some examples of constructed keys are:
+                    # - GATKSVPipelineSingleSample.Module00c.Module00c.PreprocessPESR.std_manta_vcf
+                    # - Module00c.PreprocessPESR.PreprocessPESR.StandardizeVCFs.std_vcf.0
                     ((parent_workflow + ".") if parent_workflow else "") +
                     f"{workflow}.{out_label}" +
                     (("." + str(run["shardIndex"])) if run["shardIndex"] != -1 else "")] \
@@ -204,7 +207,9 @@ if __name__ == '__main__':
                     "The two metadata files should belong to the execution "
                     "of a common workflow (e.g., one workflow with different "
                     "inputs). The script requires `gsutil` and `gzip` to be "
-                    "installed and configured."
+                    "installed and configured. If the output of a task is an "
+                    "array of files, the reference and target arrays are "
+                    "expected to be in the same order."
                     "\n\n"
                     "The currently supported file types are as follows."
                     "\n\t- VCF (.vcf.gz): The non-header lines of VCF files"

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -90,25 +90,20 @@ class VCFCompareAgent(BaseCompareAgent):
 
         with gzip.open(x, "rt", encoding="utf-8") as X, \
              gzip.open(y, "rt", encoding="utf-8") as Y:
-            # Not an optimal search, but it works
-            # if the files are not sorted, which
-            # is expected for some files in the
-            # pipeline.
-            for x_line in X:
-                if not x_line.startswith("#"):
-                    x_columns = x_line.split(self.d)
-                    for y_line in Y:
-                        if not y_line.startswith("#"):
-                            y_columns = y_line.split(self.d)
-                            if len(x_columns) == len(y_columns):
-                                if any(x_columns[c] != y_columns[c]
-                                       for c in range(0, len(x_columns))
-                                       if c != self.id_col):
-                                    break
-                            else:
-                                break
-                    else:
-                        return False, x, y
+            for x_line, y_line in zip(X, Y):
+                if x_line.startswith("#") and y_line.startswith("#"):
+                    continue
+
+                x_columns = x_line.strip().split(self.d)
+                y_columns = y_line.strip().split(self.d)
+
+                if len(x_columns) != len(y_columns):
+                    return False, x, y
+
+                if any(x_columns[c] != y_columns[c]
+                       for c in range(0, len(x_columns))
+                       if c != self.id_col):
+                    return False, x, y
         return True, x, y
 
 
@@ -140,6 +135,7 @@ class CompareWorkflowOutputs:
                 if call not in mismatches:
                     mismatches[call] = []
                 mismatches[call].append([reference, target])
+                exit()
 
         # First we define a method that takes a list
         # of a task outputs, and keeps only those that

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -96,7 +96,7 @@ class VCFCompareAgent(BaseCompareAgent):
             # is expected for some files in the
             # pipeline.
             for x_line in X:
-                if x_line.startswith("chr"):
+                if not x_line.startswith("#"):
                     x_columns = x_line.split(self.d)
                     for y_line in Y:
                         if y_line.startswith("chr"):

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -143,17 +143,17 @@ class CompareWorkflowOutputs:
 
         # First we define a method that takes a list
         # of a task outputs, and keeps only those that
-        # are files, and their extension match that
-        # file types that we want to compare (e.g., VCF)
+        # are files and their extension match the
+        # file types that we want to compare
+        # (e.g., filter only VCF files).
         filter_method = FilterBasedOnExtensions(
             self.filetypes_to_compare.keys()).filter
 
         # Then we create two instances of the Metadata
         # class, one for each metadata file, and we
-        # invoke the method that returns the task outputs
-        # that we want to assert their equality---using
-        # the above-defined filter. For instance, get
-        # all the output VCFs from a given metadata file.
+        # invoke the `get_outputs` method which traverses
+        # the outputs of task, and returns those filtered
+        # by the above-defined filter.
         ref_output_files = Metadata(reference_metadata).get_outputs(
             traverse_sub_workflows, filter_method)
         test_output_files = Metadata(target_metadata).get_outputs(

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -3,7 +3,6 @@ import gzip
 import json
 import os
 from metadata import ITaskOutputFilters, Metadata
-from itertools import chain
 from subprocess import DEVNULL, STDOUT, check_call
 
 
@@ -99,14 +98,15 @@ class VCFCompareAgent(BaseCompareAgent):
                 if not x_line.startswith("#"):
                     x_columns = x_line.split(self.d)
                     for y_line in Y:
-                        if y_line.startswith("chr"):
+                        if not y_line.startswith("#"):
                             y_columns = y_line.split(self.d)
                             if len(x_columns) == len(y_columns):
-                                for c in chain(range(0, self.id_col), range(self.id_col + 1, len(x_columns))):
-                                    if x_columns[c] != y_columns[c]:
-                                        break
-                                else:
+                                if any(x_columns[c] != y_columns[c]
+                                       for c in range(0, len(x_columns))
+                                       if c != self.id_col):
                                     break
+                            else:
+                                break
                     else:
                         return False, x, y
         return True, x, y

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -208,7 +208,7 @@ class CompareWorkflowOutputs:
         return mismatches
 
 
-if __name__ == '__main__':
+def main():
     parser = argparse.ArgumentParser(
         description="Takes two cromwell metadata files as input, "
                     "reference and target, compares their corresponding "
@@ -268,3 +268,7 @@ if __name__ == '__main__':
         with open(output_file, "w") as f:
             json.dump(mismatches, f, indent=2)
         print(f"Mismatches are persisted in {output_file}.")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/test/compare_files.py
+++ b/scripts/test/compare_files.py
@@ -52,7 +52,7 @@ class BaseCompareAgent:
         self.working_dir = working_dir
 
     def get_filename(self, obj):
-        return obj.replace("gs://", self.working_dir)
+        return obj.replace("gs://", os.path.join(self.working_dir, ""))
 
     def get_obj(self, obj):
         """

--- a/scripts/test/metadata.py
+++ b/scripts/test/metadata.py
@@ -68,25 +68,23 @@ class Metadata:
         output_files = {}
 
         def update_output_files(outputs):
-            if len(outputs) > 0:
+            if run["executionStatus"] == "Done" and len(outputs) > 0:
                 output_files[self._get_output_label(
                     parent_workflow, workflow, out_label,
                     run["shardIndex"])] = outputs
 
         for workflow, runs in calls.items():
             for run in runs:
-                if run["executionStatus"] != "Done":
-                    continue
-                for out_label, out_files in run["outputs"].items():
-                    if not out_files:
-                        continue
-                    update_output_files(self._get_filtered_outputs(out_files))
-                    if deep and "subWorkflowMetadata" in run:
+                if "outputs" in run:
+                    for out_label, out_files in run["outputs"].items():
+                        if not out_files:
+                            continue
                         update_output_files(self._get_filtered_outputs(out_files))
-                        output_files.update(
-                            self._traverse_outputs(
-                                run["subWorkflowMetadata"]["calls"],
-                                workflow, deep))
+                if deep and "subWorkflowMetadata" in run:
+                    output_files.update(
+                        self._traverse_outputs(
+                            run["subWorkflowMetadata"]["calls"],
+                            workflow, deep))
         return output_files
 
     def get_outputs(self, include_sub_workflows=False, filter_method=None):

--- a/scripts/test/metadata.py
+++ b/scripts/test/metadata.py
@@ -1,0 +1,131 @@
+import json
+import types
+from abc import ABC, abstractmethod
+
+
+class ITaskOutputFilters(ABC):
+    """
+    An interface that should be implemented by
+    custom filtering methods to be used with Metadata.
+
+    This design follows the principles of strategy pattern,
+    where a custom method can be used to augment the default
+    behavior of an algorithm. Here, this design is used to
+    decouple the filtering of tasks outputs (e.g., only extract
+    files with certain extension) from metadata traversal.
+    """
+
+    @abstractmethod
+    def filter(self, metadata, outputs):
+        """
+        How to filter the output of a task.
+
+        Note that the method is stateful; i.e.,
+        it has references to both self and to
+        the instance of Metadata class that
+        invokes this method.
+
+        :param metadata: `self` of the instance
+        of the Metadata class that calls this method.
+
+        :param outputs: The values of a key in the
+        `outputs` field in a metadata file. e.g.,
+        `metadata` in the following object is `a.vcf`:
+        'outputs': {'merged': 'a.vcf'}
+
+        :return: Filtered task outputs.
+        """
+        pass
+
+
+class Metadata:
+    """
+    Implements utilities for traversing, processing, and
+    querying the resulting metadata (in JSON) of running
+    a workflow on Cromwell.
+    """
+    def __init__(self, filename):
+        self.filename = filename
+
+    @staticmethod
+    def _get_output_label(parent_workflow, workflow, output_var, shard_index):
+        """
+        Composes a label for a task output.
+        :return: Some examples of constructed labels are:
+            - GATKSVPipelineSingleSample.Module00c.Module00c.PreprocessPESR.std_manta_vcf
+            - Module00c.PreprocessPESR.PreprocessPESR.StandardizeVCFs.std_vcf.0
+        """
+        return \
+            ((parent_workflow + ".") if parent_workflow else "") + \
+            f"{workflow}.{output_var}" + \
+            (("." + str(shard_index)) if shard_index != -1 else "")
+
+    @staticmethod
+    def _get_filtered_outputs(outputs):
+        return outputs
+
+    def _traverse_outputs(self, calls, parent_workflow="", deep=False):
+        output_files = {}
+
+        def update_output_files(outputs):
+            if len(outputs) > 0:
+                output_files[self._get_output_label(
+                    parent_workflow, workflow, out_label,
+                    run["shardIndex"])] = outputs
+
+        for workflow, runs in calls.items():
+            for run in runs:
+                if run["executionStatus"] != "Done":
+                    continue
+                for out_label, out_files in run["outputs"].items():
+                    if not out_files:
+                        continue
+                    update_output_files(self._get_filtered_outputs(out_files))
+                    if deep and "subWorkflowMetadata" in run:
+                        update_output_files(self._get_filtered_outputs(out_files))
+                        output_files.update(
+                            self._traverse_outputs(
+                                run["subWorkflowMetadata"]["calls"],
+                                workflow, deep))
+        return output_files
+
+    def get_outputs(self, include_sub_workflows=False, filter_method=None):
+        """
+        Iterates through a given cromwell metadata file
+        and filters the output files to be compared.
+
+        :param include_sub_workflows: Boolean, if set to True,
+        output files generated in sub-workflows will be traversed.
+
+        :param filter_method: A method to override the default
+        filter method. This method should be implement the
+        ITaskOutputFilters interface. Every traversed output of tasks
+        will be passed to this method, and this method's returned
+        value will be aggregated and returned. For instance, see
+        FilterBasedOnExtensions class for how the filter method can
+        be used to extract files with certain extension from the
+        metadata.
+
+        :return: A dictionary with keys and values being a composite label
+        for tasks outputs and the values of the task output, respectively.
+        For instance (serialized to JSON and simplified for brevity):
+        {
+           "GATKSVPipelineSingleSample.FilterMelt.out":{
+              "vcf.gz":["NA12878.melt.NA12878.vcf.gz"]
+           }
+        }
+        """
+        if filter_method:
+            if not issubclass(type(filter_method.__self__),
+                              ITaskOutputFilters):
+                raise TypeError(f"The class {type(filter_method.__self__)} "
+                                f"should implement the interface "
+                                f"{ITaskOutputFilters}.")
+            self._get_filtered_outputs = types.MethodType(filter_method, self)
+
+        with open(self.filename, "r") as metadata_file:
+            metadata = json.load(metadata_file)
+            output_files = self._traverse_outputs(
+                metadata["calls"],
+                deep=include_sub_workflows)
+        return output_files


### PR DESCRIPTION
The script takes two Cromwell metadata files and compares the specified files types (currently VCF only) across them. The script can be used to study divergence in a feature branch w.r.t. to a base execution. 