### PR TITLE
Fix ref panel JSON templates for gCNV and batch pipeline

### DIFF
--- a/input_templates/GATKSVPipelineBatch.ref_panel_1kg.json.tmpl
+++ b/input_templates/GATKSVPipelineBatch.ref_panel_1kg.json.tmpl
@@ -104,7 +104,7 @@
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.rmsk": {{ reference_resources.rmsk | tojson }},
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.segdups": {{ reference_resources.segdups | tojson }},
 
-  "GATKSVPipelineBatch.GATKSVPipelinePhase1.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
+  "GATKSVPipelineBatch.GATKSVPipelinePhase1.outlier_cutoff_table" : {{ ref_panel.outlier_cutoff_table | tojson }},
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.outlier_cutoff_nIQR": "999999",
 
   "GATKSVPipelineBatch.Module04.n_RD_genotype_bins": "100000",
@@ -113,6 +113,9 @@
   "GATKSVPipelineBatch.Module04.seed_cutoffs": {{ reference_resources.seed_cutoffs | tojson }},
   "GATKSVPipelineBatch.Module04.reference_build": "hg38",
   "GATKSVPipelineBatch.Module04.bin_exclude": {{ reference_resources.bin_exclude | tojson }},
+
+  "GATKSVPipelineBatch.Module04b.n_RdTest_bins": "100000",
+  "GATKSVPipelineBatch.Module04b.n_per_split": "5000",
 
   "GATKSVPipelineBatch.Module0506.bin_exclude": {{ reference_resources.bin_exclude | tojson }},
   "GATKSVPipelineBatch.Module0506.empty_file" : {{ reference_resources.empty_file | tojson }},

--- a/input_templates/trainGCNV.ref_panel_1kg.json.tmpl
+++ b/input_templates/trainGCNV.ref_panel_1kg.json.tmpl
@@ -7,8 +7,8 @@
   "TrainGCNV.allosomal_contigs": {{ reference_resources.allosomal_contigs | tojson }},
 
   "TrainGCNV.contig_ploidy_priors": {{ reference_resources.contig_ploidy_priors | tojson }},
-  "TrainGCNV.exclude_intervals_for_filter_intervals_ploidy": {{ reference_resources.exclude_intervals_for_filter_intervals | tojson }},
-  "TrainGCNV.exclude_intervals_for_filter_intervals_cnv": {{ reference_resources.exclude_intervals_for_filter_intervals | tojson }},
+  "TrainGCNV.exclude_intervals_for_filter_intervals_ploidy": {{ reference_resources.exclude_intervals_for_gcnv_filter_intervals | tojson }},
+  "TrainGCNV.exclude_intervals_for_filter_intervals_cnv": {{ reference_resources.exclude_intervals_for_gcnv_filter_intervals | tojson }},
   "TrainGCNV.num_intervals_per_scatter": "5000",
   "TrainGCNV.do_explicit_gc_correction": "true",
   "TrainGCNV.gcnv_enable_bias_factors": "false",


### PR DESCRIPTION
### Updates
* Resolve #203 by adding Module04b inputs to ref panel batch pipeline JSON template
* Finish fixing ref panel batch pipeline JSON by correcting name of value `reference_resources.exclude_intervals_for_gcnv_filter_intervals`
* Fix ref panel gCNV JSON template by updating value for `outlier_cutoff_table` to refer to the right input values JSON

### Testing
* Generate JSONs with `scripts/inputs/build_default_inputs.sh` and check that the two JSONs are generated (they were previously not generated, which is why our validation script missed these errors). 
  * Side note: it is easy to miss genuine errors that cause JSONs to not be generated from templates because the build script generates so many extraneous warning messages (due to `test_small` not having inputs past Module02, the single-sample inputs not being meant for individual modules, Test & Mosaic JSON templates not being up to date, and the Vapor / Module09 JSONs not being templates at all). We should work to address this, preferably by removing unnecessary warning messages, or by checking for a certain number of JSONs to be validated in the validation script (which ignores those that are not expected to be generated). I would leave this for a future PR, though, in the interest of resolving issue #203 quickly.
* Validate all JSONs with `scripts/test/validate.sh` (49 regular and 19 Terra JSONs validated)