### PR TITLE
Rename the python linting job

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -7,10 +7,9 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  linting:
+    name: Linting
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8


### PR DESCRIPTION
Renames the GitHub Actions job used for lining python scripts from `build` to `Linting`.