### PR TITLE
Allow missing vcf samples or gvcfs in Module00c

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -13,7 +13,7 @@
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/vjalili/sv-base:lint-24b9cda",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/vjalili/sv-base-mini:lint-24b9cda",
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/vjalili/sv-pipeline-base:lint-24b9cda",
-  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/vjalili/sv-pipeline:lint-24b9cda",
+  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:mw-missing-baf-f14df3b",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/vjalili/sv-pipeline-qc:lint-24b9cda",
   "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/vjalili/sv-pipeline-rdtest:lint-24b9cda",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa",

--- a/src/sv-pipeline/02_evidence_assessment/02d_baftest/scripts/Filegenerate/generate_baf.py
+++ b/src/sv-pipeline/02_evidence_assessment/02d_baftest/scripts/Filegenerate/generate_baf.py
@@ -3,7 +3,6 @@
 import argparse
 import numpy as np
 import pysam
-import sys
 
 
 def filter_record(record, unfiltered=False):
@@ -17,7 +16,7 @@ def filter_record(record, unfiltered=False):
 
     Parameters
     ----------
-    records : iterator of pysam.VariantRecords
+    record : Object of pysam.VariantRecords
 
     Returns
     ------
@@ -124,11 +123,11 @@ def main():
         samples_list = read_samples_list(args.samples_list)
         samples_list_intersection = set(samples_list).intersection(set(vcf_samples))
         if args.ignore_missing_vcf_samples:
-            samples_list = [s for s in samples_list if s in samples_list_intersection] # Preserves order
+            samples_list = [s for s in samples_list if s in samples_list_intersection]  # Preserves order
         elif len(samples_list) > len(samples_list_intersection):
             missing_samples = set(samples_list) - samples_list_intersection
-            raise ValueError("VCF is missing samples in the samples list. Use --ignore-missing-vcf-samples to bypass " \
-                + "this error. Samples: {}".format(", ".join(missing_samples)))
+            raise ValueError("VCF is missing samples in the samples list. Use --ignore-missing-vcf-samples to bypass "
+                             "this error. Samples: {}".format(", ".join(missing_samples)))
     else:
         samples_list = vcf_samples
 

--- a/wdl/BAFFromShardedVCF.wdl
+++ b/wdl/BAFFromShardedVCF.wdl
@@ -10,6 +10,7 @@ workflow BAFFromShardedVCF {
     Array[File] vcfs
     File? vcf_header  # If provided, added to the beginning of each VCF
     Array[String] samples  # Can be a subset of samples in the VCF
+    Boolean ignore_missing_vcf_samples
     String batch
     String sv_base_mini_docker
     String sv_pipeline_docker
@@ -19,11 +20,12 @@ workflow BAFFromShardedVCF {
   }
 
   scatter (idx in range(length(vcfs))) {
-    call GenerateBAF {
+    call baf.GenerateBAF {
       input:
         vcf = vcfs[idx],
         vcf_header = vcf_header,
         samples = samples,
+        ignore_missing_vcf_samples = ignore_missing_vcf_samples,
         batch = batch,
         shard = "~{idx}",
         sv_pipeline_docker = sv_pipeline_docker,
@@ -31,10 +33,10 @@ workflow BAFFromShardedVCF {
     }
   }
 
-  call baf.GatherBAF {
+  call GatherBAF {
     input:
       batch = batch,
-      BAF = GenerateBAF.BAF,
+      BAF = GenerateBAF.out,
       sv_base_mini_docker = sv_base_mini_docker,
       runtime_attr_override = runtime_attr_gather
   }
@@ -53,51 +55,6 @@ workflow BAFFromShardedVCF {
     Array[File] baf_files = ScatterBAFBySample.out
     Array[File] baf_file_indexes = ScatterBAFBySample.out_index
   }
-}
-
-task GenerateBAF {
-  input {
-    File vcf
-    File? vcf_header
-    Array[String] samples
-    String batch
-    String shard
-    String sv_pipeline_docker
-    RuntimeAttr? runtime_attr_override
-  }
-
-  RuntimeAttr default_attr = object {
-    cpu_cores: 1,
-    mem_gb: 3.75,
-    disk_gb: 10,
-    boot_disk_gb: 10,
-    preemptible_tries: 3,
-    max_retries: 1
-  }
-  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
-
-  output {
-    File BAF = "BAF.~{batch}.shard-~{shard}.txt"
-  }
-  command <<<
-
-    set -euo pipefail
-    bcftools view -M2 -v snps ~{if defined(vcf_header) then "<(cat ~{vcf_header} ~{vcf})" else vcf} \
-      | python /opt/sv-pipeline/02_evidence_assessment/02d_baftest/scripts/Filegenerate/generate_baf.py \
-               --unfiltered --samples-list ~{write_lines(samples)} \
-      > BAF.~{batch}.shard-~{shard}.txt
-
-  >>>
-  runtime {
-    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
-    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
-    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
-    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
-    docker: sv_pipeline_docker
-    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
-    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
-  }
-
 }
 
 task ScatterBAFBySample {
@@ -129,6 +86,46 @@ task ScatterBAFBySample {
     set -euo pipefail
     zcat ~{BAF} | awk -F "\t" -v OFS="\t" '{if ($4=="~{sample}") print}' | bgzip -c > BAF.~{sample}.txt.gz
     tabix -s 1 -b 2 -e 2 BAF.~{sample}.txt.gz
+
+  >>>
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: sv_base_mini_docker
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
+  }
+}
+
+task GatherBAF {
+  input {
+    String batch
+    Array[File] BAF
+    String sv_base_mini_docker
+    RuntimeAttr? runtime_attr_override
+  }
+
+  RuntimeAttr default_attr = object {
+                               cpu_cores: 1,
+                               mem_gb: 3.75,
+                               disk_gb: 100,
+                               boot_disk_gb: 10,
+                               preemptible_tries: 3,
+                               max_retries: 1
+                             }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+  output {
+    File out = "~{batch}.BAF.txt.gz"
+    File out_index = "~{batch}.BAF.txt.gz.tbi"
+  }
+  command <<<
+
+    set -euo pipefail
+    cat ~{sep=" "  BAF} > ~{batch}.BAF.txt.gz
+    tabix -s1 -b2 -e2 ~{batch}.BAF.txt.gz
 
   >>>
   runtime {

--- a/wdl/Module00c.wdl
+++ b/wdl/Module00c.wdl
@@ -55,9 +55,11 @@ workflow Module00c {
     # BAF generation
     # Required for cohorts if BAF_files not provided
 
+    # Only set true if some samples are missing from the VCF or some gVCFs are not available
+    Boolean? ignore_missing_baf_samples
 
     # BAF Option #1, GVCFs
-    Array[File]? gvcfs
+    Array[File?]? gvcfs
     File? unpadded_intervals_file
     File? dbsnp_vcf
     File? dbsnp_vcf_index
@@ -246,11 +248,14 @@ workflow Module00c {
     }
   }
 
+  Boolean ignore_missing_baf_samples_ = if defined(ignore_missing_baf_samples) then select_first([ignore_missing_baf_samples]) else false
+
   if (!defined(BAF_files) && defined(gvcfs)) {
     call baf.BAFFromGVCFs {
       input:
         gvcfs = select_first([gvcfs]),
         samples = samples,
+        ignore_missing_gvcfs = ignore_missing_baf_samples_,
         unpadded_intervals_file = select_first([unpadded_intervals_file]),
         dbsnp_vcf = select_first([dbsnp_vcf]),
         dbsnp_vcf_index = dbsnp_vcf_index,
@@ -269,6 +274,7 @@ workflow Module00c {
     }
   }
 
+
   if (!defined(BAF_files) && !defined(gvcfs) && (defined(snp_vcfs) || defined(snp_vcfs_shard_list))) {
     Array[File] snp_vcfs_ = if (defined(snp_vcfs)) then select_first([snp_vcfs]) else read_lines(select_first([snp_vcfs_shard_list]))
     call sbaf.BAFFromShardedVCF {
@@ -276,6 +282,7 @@ workflow Module00c {
         vcfs = snp_vcfs_,
         vcf_header = snp_vcf_header,
         samples = select_first([vcf_samples, samples]),
+        ignore_missing_vcf_samples = ignore_missing_baf_samples_,
         batch = batch,
         sv_base_mini_docker = sv_base_mini_docker,
         sv_pipeline_docker = sv_pipeline_docker,

--- a/wdl/Module00c.wdl
+++ b/wdl/Module00c.wdl
@@ -54,11 +54,13 @@ workflow Module00c {
 
     # BAF generation
     # Required for cohorts if BAF_files not provided
+    # Note: pipeline output is not sensitive to having some samples (~1%) missing BAF
 
     # Only set true if some samples are missing from the VCF or some gVCFs are not available
     Boolean? ignore_missing_baf_samples
 
-    # BAF Option #1, GVCFs
+    # BAF Option #1, gVCFs
+    # Missing gVCFs may be "null" (without quotes in the input json)
     Array[File?]? gvcfs
     File? unpadded_intervals_file
     File? dbsnp_vcf


### PR DESCRIPTION
For large cohorts, it is useful in practice to be able to omit certain samples from BAF generation (in many cases owing to issues with SNP/indel calling on a small subset of samples). This typically does not affect results, as BAF is used only for training in Module03.

This PR adds a `ignore_missing_baf_samples` option to 00c that is off by default. Setting to true skips cross-checks between the sample list and provided VCF/gVCF samples (an error is thrown if an expected sample is not present in the snp data). When using gVCFs for BAF generation, the input type has been changed from `Array[File]?` to `Array[File?]?` to allow for null inputs. For the sharded VCF method of BAF generation, samples can simply be absent.

This branch was tested using the default 00c test_small, and a modified version of the `Module00cTest.test_baf_from_vcf.json` input where the first sample gVCF was omitted.