### PR TITLE
Correct tox environment name for flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, flake8
+envlist = py38, lint
 skipsdist = True
 
 


### PR DESCRIPTION
`flake8` is defined as the environment for lining (`envlist = py38, flake8`), but the defined env is named `lint` (`[testenv:lint]`). This PR corrects the env naming. 