### PR TITLE
Add single-batch configs to Terra for cohort-level modules & update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Repository structure:
 ## <a name="cohort-mode">Cohort mode</a>
 A minimum cohort size of 100 with roughly equal number of males and females is recommended. For modest cohorts (~100-500 samples), the pipeline can be run as a single batch using `GATKSVPipelineBatch.wdl`.
 
-For larger cohorts, samples should be split up into batches of ~100-500 samples. We recommend batching based on overall coverage and dosage score (WGD), which can be generated in [Module 00b](#module00b). 
+For larger cohorts, samples should be split up into batches of about 100-500 samples. Refer to the [Batching](#batching) section for further guidance on creating batches.
 
 The pipeline should be executed as follows:
 * Modules [00a](#module00a) and [00b](#module00b) can be run on arbitrary cohort partitions
@@ -158,6 +158,13 @@ The pipeline should be executed as follows:
 * [Module 05/06](#module0506) and beyond are run on all batches together
 
 Note: [Module 00c](#module00c) requires a [trained gCNV model](#gcnv-training).
+
+### <a name="batching">Batching</a>
+For larger cohorts, samples should be split up into batches of about 100-500 samples with similar characteristics. We recommend batching based on overall coverage and dosage score (WGD), which can be generated in [Module 00b](#module00b). An example batching process is outlined below:
+1. Divide the cohort into PCR+ and PCR- samples
+2. Partition the samples by median coverage from [Module00b](#module00b)
+3. Optionally, divide the samples further by dosage score (WGD) from [Module00b](#module00b) to obtain roughly equal-sized batches of about 100-500 samples
+4. Maintain a roughly equal sex balance within each batch, based on sex assignments from [Module00b](#module00b)
 
 
 ## <a name="sample-sample-mode">Single-sample mode</a>
@@ -213,7 +220,7 @@ Note: a list of sample IDs must be provided. Refer to the [sample ID requirement
 ## <a name="module00b">Module 00b</a>
 Runs ploidy estimation, dosage scoring, and optionally VCF QC. The results from this module can be used for QC and batching.
 
-For large cohorts, we recommend dividing samples into smaller batches (~500 samples) with ~1:1 male:female ratio.
+For large cohorts, we recommend dividing samples into smaller batches (~500 samples) with ~1:1 male:female ratio. Refer to the [Batching](#batching) section for further guidance on creating batches.
 
 We also recommend using sex assignments generated from the ploidy estimates and incorporating them into the PED file.
 
@@ -228,6 +235,13 @@ We also recommend using sex assignments generated from the ploidy estimates and 
 * Per-sample dosage scores with plots
 * Ploidy estimates, sex assignments, with plots
 * (Optional) Outlier samples detected by call counts
+
+#### <a name="prelim-sample-qc">Preliminary Sample QC</a>
+The purpose of sample filtering at this stage after Module00b is to prevent very poor quality samples from interfering with the results for the rest of the callset. In general, samples that are borderline are okay to leave in, but you should choose filtering thresholds to suit the needs of your cohort and study. There will be future opportunities (as part of [Module03](#module03)) for filtering before the joint genotyping stage if necessary. Here are a few of the basic QC checks that we recommend:
+* Look at the X and Y ploidy plots, and check that sex assignments match your expectations. If there are discrepancies, check for sample swaps and update your PED file before proceeding.
+* Look at the dosage score (WGD) distribution and check that it is centered around 1. Optionally filter outliers.
+* Look at the low outliers for each SV caller (samples with much lower than typical numbers of SV calls per contig for each caller). An empty low outlier file means there were no outliers below the median and no filtering is necessary. Check that no samples had zero calls.
+* Look at the high outliers for each SV caller and optionally filter outliers; samples with many more SV calls than average may be poor quality.
 
 
 ## <a name="gcnv-training">gCNV Training</a>

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Runs CNV callers (cnMOPs, GATK gCNV) and combines single-sample raw evidence int
 
 #### Inputs:
 * PED file (updated with [Module 00b](#module00b) sex assignments, including sex = 0 for sex aneuploidies. Calls will not be made on sex chromosomes when sex = 0 in order to avoid generating many confusing calls or upsetting normalized copy numbers for the batch.)
-* Per-sample GVCFs generated with HaplotypeCaller (`gvcfs` input), or a jointly-genotyped VCF (position-sharded, `snp_vcfs` input or `snp_vcfs_shard_list` input)
+* Per-sample GVCFs generated with HaplotypeCaller (`gvcfs` input), or a jointly-genotyped VCF (position-sharded, `snp_vcfs` input or `snp_vcfs_shard_list` input). The jointly-genotyped VCF may contain multi-allelic sites and indels, but only biallelic SNVs will be used by the pipeline. We recommend shards of 10 GB or less to lower compute time and resources.
 * Read count, BAF, PE, and SR files ([Module 00a](#module00a))
 * Caller VCFs ([Module 00a](#module00a))
 * Contig ploidy model and gCNV model files (gCNV training)

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ Note: [Module 00c](#module00c) requires a [trained gCNV model](#gcnv-training).
 #### <a name="batching">Batching</a>
 For larger cohorts, samples should be split up into batches of about 100-500 samples with similar characteristics. We recommend batching based on overall coverage and dosage score (WGD), which can be generated in [Module 00b](#module00b). An example batching process is outlined below:
 1. Divide the cohort into PCR+ and PCR- samples
-2. Partition the samples by median coverage from [Module00b](#module00b)
-3. Optionally, divide the samples further by dosage score (WGD) from [Module00b](#module00b) to obtain roughly equal-sized batches of about 100-500 samples
+2. Partition the samples by median coverage from [Module00b](#module00b), grouping samples with similar median coverage together. The end goal is to divide the cohort into roughly equal-sized batches of about 100-500 samples; if your partitions based on coverage are larger or uneven, you can partition the cohort further in the next step to obtain the final batches. 
+3. Optionally, divide the samples further by dosage score (WGD) from [Module00b](#module00b), grouping samples with similar WGD score together, to obtain roughly equal-sized batches of about 100-500 samples
 4. Maintain a roughly equal sex balance within each batch, based on sex assignments from [Module00b](#module00b)
 
 
@@ -239,7 +239,7 @@ We also recommend using sex assignments generated from the ploidy estimates and 
 #### <a name="prelim-sample-qc">Preliminary Sample QC</a>
 The purpose of sample filtering at this stage after Module00b is to prevent very poor quality samples from interfering with the results for the rest of the callset. In general, samples that are borderline are okay to leave in, but you should choose filtering thresholds to suit the needs of your cohort and study. There will be future opportunities (as part of [Module03](#module03)) for filtering before the joint genotyping stage if necessary. Here are a few of the basic QC checks that we recommend:
 * Look at the X and Y ploidy plots, and check that sex assignments match your expectations. If there are discrepancies, check for sample swaps and update your PED file before proceeding.
-* Look at the dosage score (WGD) distribution and check that it is centered around 1. Optionally filter outliers.
+* Look at the dosage score (WGD) distribution and check that it is centered around 0 (the distribution of WGD for PCR- samples is expected to be slightly lower than 0, and the distribution of WGD for PCR+ samples is expected to be slightly greater than 0. Refer to the [gnomAD-SV paper](https://doi.org/10.1038/s41586-020-2287-8) for more information on WGD score). Optionally filter outliers.
 * Look at the low outliers for each SV caller (samples with much lower than typical numbers of SV calls per contig for each caller). An empty low outlier file means there were no outliers below the median and no filtering is necessary. Check that no samples had zero calls.
 * Look at the high outliers for each SV caller and optionally filter outliers; samples with many more SV calls than average may be poor quality.
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The pipeline should be executed as follows:
 
 Note: [Module 00c](#module00c) requires a [trained gCNV model](#gcnv-training).
 
-### <a name="batching">Batching</a>
+#### <a name="batching">Batching</a>
 For larger cohorts, samples should be split up into batches of about 100-500 samples with similar characteristics. We recommend batching based on overall coverage and dosage score (WGD), which can be generated in [Module 00b](#module00b). An example batching process is outlined below:
 1. Divide the cohort into PCR+ and PCR- samples
 2. Partition the samples by median coverage from [Module00b](#module00b)

--- a/input_templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
+++ b/input_templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
@@ -135,14 +135,21 @@ To create batches (in the `sample_set` table), the easiest way is to upload a ta
 
 * It is recommended to run each workflow first on one sample/batch to check that the method is properly configured before you attempt to process all of your data.
 * We recommend enabling call-caching (on by default in each workflow configuration), but be aware this will cause large intermediate data storage that can be tricky to clean up.
+* Managing storage in Terra can be difficult. Always exercise caution with file deletion as it is permanent. 
+	* One option is to manually delete large files, or directories containing failed workflow intermediates (after re-running the workflow successfully to take advantage of call-caching) with the command `gsutil -m rm gs://path/to/workflow/directory/**file_extension_to_delete` to delete all files with the given extension for that workflow, or `gsutil -m rm -r gs://path/to/workflow/directory/` to delete an entire workflow directory (only after you are done with all the files!). 
+	* Another option is to use the `fiss mop` API call to delete all files that do not appear in one of the Terra data tables. Always ensure that you are completely done with a step and you will not need to return before using this option, as it will break call-caching. See [this blog post](https://terra.bio/deleting-intermediate-workflow-outputs/) for more details. This can also be done [via the command line](https://github.com/broadinstitute/fiss/wiki/MOP:-reducing-your-cloud-storage-footprint).
 * If your workflow fails, check the job manager for the error message. Most issues can be resolved by increasing the memory or disk. Do not delete workflow log files until you are done troubleshooting. If call-caching is enabled, do not delete any files from the failed workflow until you have run it successfully.
+* To display run costs, see [this article](https://support.terra.bio/hc/en-us/articles/360037862771#h_01EX5ED53HAZ59M29DRCG24CXY) for one-time setup instructions for non-Broad users.
 * If you only have one batch, you will need to skip `merge-cohort-vcfs` and use the single-batch versions of all workflows after `module04`.
 
 #### Module00a
 
 Read the full Module00a documentation [here](https://github.com/broadinstitute/gatk-sv#module-00a).
 * This workflow runs on a per-sample level, but you can launch many (a few hundred) samples at once, in arbitrary partitions. Make sure to try just one sample first though!
+* It is normal for a few samples in a cohort to run out of memory during Wham SV calling, so we recommend enabling auto-retry for out-of-memory errors for `module00a` only. Before you launch the workflow, click the checkbox reading "Retry with more memory" and set the memory retry factor to 1.8. This action must be performed each time you launch a `module00a` job.
 * Please note that most large published joint call sets produced by GATK-SV, including gnomAD-SV, included the tool MELT, a state-of-the-art mobile element insertion (MEI) detector, as part of the pipeline. Due to licensing restrictions, we cannot provide a public docker image for this algorithm. The `module00a` workflow does not use MELT as one of the SV callers by default, which will result in less sensitivity to MEI calls. In order to use MELT, you will need to build your own docker image, share it with your Terra proxy account, enter it in the `melt_docker` input in the `module00a` configuration (as a string, surrounded by double-quotes), and then click "Save". No further changes are necessary beyond `module00a`.
+* Successful runs of `module00a` will automatically delete any BAM files generated during the workflow, but BAM files will not be deleted if the run fails. Since BAM files are large, we recommend deleting them to save on storage costs, but only after fixing and re-running the failed workflow, so that it will call-cache.
+
 
 #### Module00b
 

--- a/input_templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
+++ b/input_templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
@@ -1,7 +1,7 @@
 # GATK-SV
 GATK-SV is a structural variation discovery pipeline for Illumina short-read whole-genome sequencing (WGS) data. 
 
-Please refer to the README in the [GATK-SV GitHub repository](https://github.com/broadinstitute/gatk-sv) for full documentation of this pipeline. This dashboard will focus on the information necessary to run the pipeline through Terra.
+Before you begin processing, please read the full pipeline documentation in the README in the [GATK-SV GitHub repository](https://github.com/broadinstitute/gatk-sv). This dashboard will focus on additional information specific to Terra and cannot substitute for the full documentation.
 
 ## Data
 The sample data in this workspace is 312 publicly-available 1000 Genomes Project samples from the [NYGC/AnVIL high coverage data set](https://app.terra.bio/#workspaces/anvil-datastorage/1000G-high-coverage-2019), divided into two equally-sized batches.
@@ -28,8 +28,8 @@ The following cohort-level or batch-level inputs are also required:
 |---------|--------|--------------|
 |`String`|`sample_set_id`|Batch identifier|
 |`String`|`sample_set_set_id`|Cohort identifier|
-|`File`|`cohort_ped_file`|Path to the GCS location of a family structure definitions file in [PED format](https://gatk.broadinstitute.org/hc/en-us/articles/360035531972-PED-Pedigree-format). Sex aneuploidies (detected in Module 00b) should be entered as sex = 0.|
-|`Array[File]`|`snp_vcfs`|Paths to the GCS locations of a jointly-genotyped, position-sharded SNP VCF. Alternatively, provide a GCS path to a text file containing one SNP VCF shard path per line using the `File` input `snp_vcfs_shard_list`.**|
+|`File`|`cohort_ped_file`|Path to the GCS location of a family structure definitions file in [PED format](https://gatk.broadinstitute.org/hc/en-us/articles/360035531972-PED-Pedigree-format). Sex aneuploidies (detected in Module00b) should be entered as sex = 0.|
+|`Array[File]`|`snp_vcfs`|Paths to the GCS locations of a jointly-genotyped, position-sharded SNP VCF (may contain indels and multiallelic sites). Alternatively, provide a GCS path to a text file containing one SNP VCF shard path per line using the `File` input `snp_vcfs_shard_list`.**|
 
 **Only one of `gvcf` or `snp_vcfs` or `snp_vcfs_shard_list` is required
 
@@ -66,7 +66,7 @@ Additional modules, such as those for filtering and visualization, are under dev
 
 The metrics workflows in this workspace (`module01-metrics`, `module02-metrics`, etc.) are provided for testing purposes and do not need to be executed.
 
-For detailed instructions on running the pipeline, see **Step-by-step instructions** below.
+For detailed instructions on running the pipeline in Terra, see **Step-by-step instructions** below.
 
 ### How many samples can I process at once?
 
@@ -117,7 +117,7 @@ If using a SNP VCF in `module00c`, it does not need to be re-headered; simply pr
 2. In your new workspace, delete the sample, sample_set, and sample_set_set data tables. To do this, go to the *Data* tab of the workspace. Select the `sample` data table. Check the box to select all samples. Click the 3 blue dots that appear, and select "Delete Data". Confirm when prompted. Repeat for any remaining samples and for any remaining entries in the `sample_set` or `sample_set_set` tables. 
 <img alt="deleting data tables" title="How to delete the sample data table" src="https://i.imgur.com/jNSXAqj.png" width="600">
 
-3. Create and upload a new sample data table for your samples. This should be a tab-separated file (.tsv) with one line per sample, as well as a header (first) line. It should contain the columns `entity:sample_id` (first column), `bam_or_cram_file`, and `requester_pays_cram` at minimum. If you are using GVCFs instead of a joint SNP VCF in Module00c, there should be an additional `gvcf` column. See the **Required inputs** section above for more information on these inputs. For an example sample data table, refer to the sample data table for the 1000 Genomes samples in this workspace [here in the GATK-SV GitHub repository](https://github.com/broadinstitute/gatk-sv/blob/master/input_templates/terra_workspaces/cohort_mode/samples_1kgp.tsv.tmpl). To upload the TSV file, navigate to the *Data* tab of the workspace and click the `+` button next to "Tables".  
+3. Create and upload a new sample data table for your samples. This should be a tab-separated file (.tsv) with one line per sample, as well as a header (first) line. It should contain the columns `entity:sample_id` (first column), `bam_or_cram_file`, and `requester_pays_cram` at minimum. If you are using GVCFs instead of a joint SNP VCF in Module00c, there should be an additional `gvcf` column (if using a joint SNP VCF, you will provide this directly in `module00c` later on). See the **Required inputs** section above for more information on these inputs. For an example sample data table, refer to the sample data table for the 1000 Genomes samples in this workspace [here in the GATK-SV GitHub repository](https://github.com/broadinstitute/gatk-sv/blob/master/input_templates/terra_workspaces/cohort_mode/samples_1kgp.tsv.tmpl). To upload the TSV file, navigate to the *Data* tab of the workspace and click the `+` button next to "Tables".  
 <img alt="uploading a TSV data table" title="How to upload a TSV data table" src="https://i.imgur.com/h0hj2fT.png" width="400">
 
 4. Edit the `cohort_ped_file` item in the Workspace Data table (as shown in the screenshot below) to provide the Google URI to the PED file for your cohort (make sure to share it with your Terra proxy account!). 
@@ -140,49 +140,59 @@ To create batches (in the `sample_set` table), the easiest way is to upload a ta
 
 #### Module00a
 
+Read the full Module00a documentation [here](https://github.com/broadinstitute/gatk-sv#module-00a).
 * This workflow runs on a per-sample level, but you can launch many (a few hundred) samples at once, in arbitrary partitions. Make sure to try just one sample first though!
-* Please note that most large published joint call sets produced by GATK-SV, including gnomAD-SV, included the tool MELT, a state-of-the-art mobile element insertion (MEI) detector, as part of the pipeline. Due to licensing restrictions, we cannot provide a public docker image for this algorithm. The `module00a` workflow does not use MELT as one of the SV callers by default, which will result in less sensitivity to MEI calls. In order to use MELT, you will need to build your own docker image, enter it in the `melt_docker` input in the `module00a` configuration (as a string, surrounded by double-quotes), and then click "Save". No further changes are necessary beyond `module00a`.
+* Please note that most large published joint call sets produced by GATK-SV, including gnomAD-SV, included the tool MELT, a state-of-the-art mobile element insertion (MEI) detector, as part of the pipeline. Due to licensing restrictions, we cannot provide a public docker image for this algorithm. The `module00a` workflow does not use MELT as one of the SV callers by default, which will result in less sensitivity to MEI calls. In order to use MELT, you will need to build your own docker image, share it with your Terra proxy account, enter it in the `melt_docker` input in the `module00a` configuration (as a string, surrounded by double-quotes), and then click "Save". No further changes are necessary beyond `module00a`.
 
 #### Module00b
 
-* `module00b` is run on arbitrary batches of up to 500 samples.
+Read the full Module00b documentation [here](https://github.com/broadinstitute/gatk-sv#module-00b).
+* `module00b` is run on arbitrary cohort partitions of up to 500 samples.
+* The outputs from Module00b can be used for [preliminary sample QC](https://github.com/broadinstitute/gatk-sv#preliminary-sample-qc) and [batching](https://github.com/broadinstitute/gatk-sv#batching) before moving on to TrainGCNV.
 
 
 #### TrainGCNV
 
+Read the full TrainGCNV documentation [here](https://github.com/broadinstitute/gatk-sv#gcnv-training-1).
 * By default, `train-gCNV` is configured to be run once per `sample_set` on 100 randomly-chosen samples from that set to create a gCNV model for each batch. 
 * Before running this workflow, create the batches (~100-500 samples) you will use for the rest of the pipeline based on sample coverage, WGD score (from `module00b`), and PCR status. These will likely not be the same as the batches you used for `module00b`.
 
 #### Module00c
 
+Read the full Module00c documentation [here](https://github.com/broadinstitute/gatk-sv#module-00c).
 * Use the same `sample_set` definitions you used for `train-gCNV`.
 * The default configuration for `module00c` in this workspace uses sample GVCFs. To use a position-sharded joint SNP VCF instead, delete the `gvcfs` input, provide your file(s) for `snp_vcfs`, and click "Save". The `snp_vcfs` argument should be formatted as an `Array[File]`, ie. `["gs://bucket/shard1.vcf.gz", "gs://bucket/shard2.vcf.gz"]`. Alternatively, provide the input `snp_vcfs_shard_list`: a GCS path to a text file containing one SNP VCF shard path per line (this option is useful if the `Array[File]` of `snp_vcfs` shards is too long for Terra to handle).
 * If you are using GVCFs in a requester-pays bucket, you must provide the Terra billing project for the workspace to the `gvcf_gcs_project_for_requester_pays` argument as a string, surrounded by double-quotes.
 
 #### Module01 and Module02
 
+Read the full documentation for these modules [here](https://github.com/broadinstitute/gatk-sv#module-01).
 * Use the same `sample_set` definitions you used for `train-gCNV` and `module00c`.
 
 
 #### Module03
 
+Read the full Module03 documentation [here](https://github.com/broadinstitute/gatk-sv#module-03).
 * Use the same `sample_set` definitions you used for `train-gCNV` through `module02`.
 * The default value for `outlier_cutoff_nIQR`, which is used to filter samples that have an abnormal number of SV calls, is 10000. This essentially means that no samples are filtered. You should adjust this value depending on your scientific needs.
 
 #### MergeCohortVcfs
 
+Read the full MergeCohortVcfs documentation [here](https://github.com/broadinstitute/gatk-sv#merge-cohort-vcfs).
 * If you only have one batch, skip this workflow.
-* For a multi-batch cohort, `merge-cohort-vcfs` is a cohort-level workflow, so it is run on a `sample_set_set` containing all of the batches in the cohort. You can create this `sample_set_set` when you click "Select Data": choose "Create new sample_set_set [...]", check all the batches to include (the ones used in `train-gCNV` through `module03`), and give it a name that follows the **Sample ID requirements**. 
+* For a multi-batch cohort, `merge-cohort-vcfs` is a cohort-level workflow, so it is run on a `sample_set_set` containing all of the batches in the cohort. You can create this `sample_set_set` while you are launching the `merge-cohort-vcfs` workflow: click "Select Data", choose "Create new sample_set_set [...]", check all the batches to include (all of the ones used in `train-gCNV` through `module03`), and give it a name that follows the **Sample ID requirements**. 
 
 <img alt="creating a cohort sample_set_set" title="How to create a cohort sample_set_set" src="https://i.imgur.com/zKEtSbe.png" width="500">
 
 #### Module04
 
+Read the full Module04 documentation [here](https://github.com/broadinstitute/gatk-sv#module-04).
 * Use the same `sample_set` definitions you used for `train-gCNV` through `module03`.
 * If you only have one batch, use the `module04_single_batch` version of the workflow.
 
 #### Module04b, Module0506, and Module08Annotation
 
+Read the full documentation for [Module04b](https://github.com/broadinstitute/gatk-sv#module-04b), [Module0506](https://github.com/broadinstitute/gatk-sv#module-0506), and [Module08](https://github.com/broadinstitute/gatk-sv#module-08-in-development) on the README.
 * For a multi-batch cohort, use the same cohort `sample_set_set` you created and used for `merge-cohort-vcfs`.
 * If you only have one batch, use the `module0X_single_batch` version of the workflow.
 

--- a/input_templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
+++ b/input_templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
@@ -62,7 +62,7 @@ The following workflows are included in this workspace, to be executed in this o
 11. `module0506`: Cohort-level cross-batch integration; complex variant resolution and re-genotyping; VCF cleanup. Use `module0506_single_batch` if you only have one batch.
 12. `module08`: Cohort VCF annotations, including functional annotation, allele frequency (AF) annotation, and AF annotation with external population callsets. Use `module08_single_batch` if you only have one batch.
 
-Additional modules, such as those for filtering and visualization, are under development. They are not included in this workspace at this time, but the source code can be found in the [GATK-SV GitHub repository]([GATK-SV GitHub repository](https://github.com/broadinstitute/gatk-sv)).
+Additional modules, such as those for filtering and visualization, are under development. They are not included in this workspace at this time, but the source code can be found in the [GATK-SV GitHub repository](https://github.com/broadinstitute/gatk-sv).
 
 The metrics workflows in this workspace (`module01-metrics`, `module02-metrics`, etc.) are provided for testing purposes and do not need to be executed.
 

--- a/input_templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
+++ b/input_templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
@@ -11,7 +11,7 @@ The sample data in this workspace is 312 publicly-available 1000 Genomes Project
 This pipeline performs structural variation discovery from CRAMs, joint genotyping, and variant resolution on a cohort of samples. 
 
 ### Required inputs
-The following inputs must be provided for each sample in the cohort:
+The following inputs must be provided for each sample in the cohort, via the sample table described in **Workspace Setup** step 2:
 
 |Input Type|Input Name|Description|
 |---------|--------|--------------|
@@ -56,11 +56,11 @@ The following workflows are included in this workspace, to be executed in this o
 5. `module01`: Per-batch variant clustering
 6. `module02`: Per-batch variant filtering, metric generation
 7. `module03`: Per-batch variant filtering; outlier exclusion
-8. `merge-cohort-vcfs`: Site merging of SVs discovered across batches, run on a cohort-level `sample_set_set` (skip for a single batch)
-9. `module04`: Per-batch genotyping of all sites in the cohort
-10. `module04b`: Cohort-level genotype refinement of some depth calls
-11. `module0506`: Cohort-level cross-batch integration; complex variant resolution and re-genotyping; VCF cleanup
-12. `module08`: Cohort VCF annotations, including functional annotation, allele frequency (AF) annotation and AF annotation with external population callsets;
+8. (Skip for a single batch) `merge-cohort-vcfs`: Site merging of SVs discovered across batches, run on a cohort-level `sample_set_set`
+9. `module04`: Per-batch genotyping of all sites in the cohort. Use `module04_single_batch` if you only have one batch.
+10. `module04b`: Cohort-level genotype refinement of some depth calls. Use `module04b_single_batch` if you only have one batch.
+11. `module0506`: Cohort-level cross-batch integration; complex variant resolution and re-genotyping; VCF cleanup. Use `module0506_single_batch` if you only have one batch.
+12. `module08`: Cohort VCF annotations, including functional annotation, allele frequency (AF) annotation, and AF annotation with external population callsets. Use `module08_single_batch` if you only have one batch.
 
 Additional modules, such as those for filtering and visualization, are under development. They are not included in this workspace at this time, but the source code can be found in the [GATK-SV GitHub repository]([GATK-SV GitHub repository](https://github.com/broadinstitute/gatk-sv)).
 
@@ -76,7 +76,7 @@ There are three modes for this pipeline according to the number of samples you n
 
 1. Single-sample mode (<100 samples): The cohort mode of this pipeline requires at least 100 samples, so for smaller sets of samples we recommend the single-sample version of this pipeline, which is available as a [featured Terra workspace](https://app.terra.bio/#workspaces/help-gatk/GATK-Structural-Variants-Single-Sample).
 2. Single-batch mode (100-500 samples)
-3. Multi-batch mode (>200 samples): Batches should be 100-500 samples, so you may choose to divide your cohort into multiple batches if you have at least 200 samples. **The default configuration of this workspace is for multiple batches. Please refer to the step-by-step instructions for details on what to change if you only have one batch.**
+3. Multi-batch mode (>200 samples): Batches should be 100-500 samples, so you may choose to divide your cohort into multiple batches if you have at least 200 samples.
 
 
 #### What is the maximum number of samples the pipeline can handle?
@@ -98,14 +98,7 @@ This section will cover how to run the pipeline on your own data in Terra.
 
 ### Sample ID requirements 
 
-Sample IDs MUST:
-* Be unique within the cohort
-* Contain only alphanumeric characters and underscores (no dashes, whitespace, or special characters) 
-
-Sample IDs should NOT:
-* Contain only numeric characters
-* Be a substring of another sample ID in the same cohort
-* Contain any of the following substrings: `chr`, `name`, `DEL`, `DUP`, `CPX`, `CHROM`
+Refer to [the Sample ID Requirements section of the README](https://github.com/broadinstitute/gatk-sv#sample-id-requirements) for sample ID requirements for the pipeline. IDs that do not meet these requirements may cause errors.
 
 The same requirements apply to family IDs in the PED file, batch IDs (`sample_set_id`), and the cohort ID (`sample_set_set_id`).
 
@@ -141,9 +134,9 @@ To create batches (in the `sample_set` table), the easiest way is to upload a ta
 #### General recommendations
 
 * It is recommended to run each workflow first on one sample/batch to check that the method is properly configured before you attempt to process all of your data.
-* We recommend enabling call-caching, but be aware this will cause large intermediate data storage that can be tricky to clean up.
+* We recommend enabling call-caching (on by default in each workflow configuration), but be aware this will cause large intermediate data storage that can be tricky to clean up.
 * If your workflow fails, check the job manager for the error message. Most issues can be resolved by increasing the memory or disk. Do not delete workflow log files until you are done troubleshooting. If call-caching is enabled, do not delete any files from the failed workflow until you have run it successfully.
-* This workspace is configured assuming multiple batches. If you only have one batch, you will need to make changes to all workflows after `module04`.
+* If you only have one batch, you will need to skip `merge-cohort-vcfs` and use the single-batch versions of all workflows after `module04`.
 
 #### Module00a
 
@@ -163,7 +156,7 @@ To create batches (in the `sample_set` table), the easiest way is to upload a ta
 #### Module00c
 
 * Use the same `sample_set` definitions you used for `train-gCNV`.
-* The default configuration for `module00c` in this workspace uses sample GVCFs. To use a position-sharded joint SNP VCF instead, delete the `gvcfs` input, provide your file(s) for `snp_vcfs`, and click "Save". The `snp_vcfs` argument should be formatted as an `Array[File]`, ie. `["gs://bucket/shard1.vcf", "gs://bucket/shard2.vcf"]`. Alternatively, provide the input `snp_vcfs_shard_list`: a GCS path to a text file containing one SNP VCF shard path per line (this option is useful if the `Array[File]` of `snp_vcfs` shards is too long for Terra to handle).
+* The default configuration for `module00c` in this workspace uses sample GVCFs. To use a position-sharded joint SNP VCF instead, delete the `gvcfs` input, provide your file(s) for `snp_vcfs`, and click "Save". The `snp_vcfs` argument should be formatted as an `Array[File]`, ie. `["gs://bucket/shard1.vcf.gz", "gs://bucket/shard2.vcf.gz"]`. Alternatively, provide the input `snp_vcfs_shard_list`: a GCS path to a text file containing one SNP VCF shard path per line (this option is useful if the `Array[File]` of `snp_vcfs` shards is too long for Terra to handle).
 * If you are using GVCFs in a requester-pays bucket, you must provide the Terra billing project for the workspace to the `gvcf_gcs_project_for_requester_pays` argument as a string, surrounded by double-quotes.
 
 #### Module01 and Module02
@@ -178,7 +171,7 @@ To create batches (in the `sample_set` table), the easiest way is to upload a ta
 
 #### MergeCohortVcfs
 
-* You can skip this workflow if you only have one batch.
+* If you only have one batch, skip this workflow.
 * For a multi-batch cohort, `merge-cohort-vcfs` is a cohort-level workflow, so it is run on a `sample_set_set` containing all of the batches in the cohort. You can create this `sample_set_set` when you click "Select Data": choose "Create new sample_set_set [...]", check all the batches to include (the ones used in `train-gCNV` through `module03`), and give it a name that follows the **Sample ID requirements**. 
 
 <img alt="creating a cohort sample_set_set" title="How to create a cohort sample_set_set" src="https://i.imgur.com/zKEtSbe.png" width="500">
@@ -186,10 +179,10 @@ To create batches (in the `sample_set` table), the easiest way is to upload a ta
 #### Module04
 
 * Use the same `sample_set` definitions you used for `train-gCNV` through `module03`.
-* If you only have one batch and did not run `merge-cohort-vcfs`, change the `cohort_depth_vcf` input to `this.filtered_depth_vcf` and the `cohort_pesr_vcf` input to `this.filtered_pesr_vcf`.
+* If you only have one batch, use the `module04_single_batch` version of the workflow.
 
 #### Module04b, Module0506, and Module08Annotation
 
 * For a multi-batch cohort, use the same cohort `sample_set_set` you created and used for `merge-cohort-vcfs`.
-* For a single batch, change the entity type from `sample_set_set` to `sample_set`. Then, for all the inputs with the format `this.sample_sets.attribute`, delete `.sample_sets` so they are now `this.attribute`. Also change the `cohort` or `cohort_name` or or `prefix` input from `this.sample_set_set_id` to `this.sample_set_id`.
+* If you only have one batch, use the `module0X_single_batch` version of the workflow.
 

--- a/input_templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
+++ b/input_templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
@@ -76,7 +76,7 @@ There are three modes for this pipeline according to the number of samples you n
 
 1. Single-sample mode (<100 samples): The cohort mode of this pipeline requires at least 100 samples, so for smaller sets of samples we recommend the single-sample version of this pipeline, which is available as a [featured Terra workspace](https://app.terra.bio/#workspaces/help-gatk/GATK-Structural-Variants-Single-Sample).
 2. Single-batch mode (100-500 samples)
-3. Multi-batch mode (>200 samples): Batches should be 100-500 samples, so you may choose to divide your cohort into multiple batches if you have at least 200 samples.
+3. Cohort (multi-batch) mode (>200 samples): Batches should be 100-500 samples, so you may choose to divide your cohort into multiple batches if you have at least 200 samples. Refer to the [Batching](https://github.com/broadinstitute/gatk-sv#batching) section of the README for further information.
 
 
 #### What is the maximum number of samples the pipeline can handle?

--- a/input_templates/terra_workspaces/cohort_mode/workflow_configurations/Module04.SingleBatch.json.tmpl
+++ b/input_templates/terra_workspaces/cohort_mode/workflow_configurations/Module04.SingleBatch.json.tmpl
@@ -1,0 +1,26 @@
+{
+  "Module04.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+  "Module04.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "Module04.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",
+  "Module04.linux_docker" : "${workspace.linux_docker}",
+
+  "Module04.n_RD_genotype_bins": "100000", 
+  "Module04.n_per_split": "5000", 
+  "Module04.pesr_exclude_list": "${workspace.pesr_exclude_list}",
+  "Module04.seed_cutoffs": "${workspace.seed_cutoffs}",
+  "Module04.reference_build": "${workspace.reference_build}",
+  "Module04.ref_dict": "${workspace.reference_dict}",
+
+  "Module04.batch": "${this.sample_set_id}",
+  "Module04.rf_cutoffs": "${this.cutoffs}",
+  "Module04.batch_depth_vcf": "${this.filtered_depth_vcf}",
+  "Module04.batch_pesr_vcf": "${this.filtered_pesr_vcf}",
+  "Module04.ped_file": "${workspace.cohort_ped_file}",
+  "Module04.bin_exclude": "${workspace.bin_exclude}",
+  "Module04.discfile": "${this.merged_PE}",
+  "Module04.coveragefile": "${this.merged_bincov}",
+  "Module04.splitfile": "${this.merged_SR}",
+  "Module04.medianfile": "${this.median_cov}",
+  "Module04.cohort_depth_vcf": "${this.filtered_depth_vcf}",
+  "Module04.cohort_pesr_vcf": "${this.filtered_pesr_vcf}"
+}

--- a/input_templates/terra_workspaces/cohort_mode/workflow_configurations/Module04b.SingleBatch.json.tmpl
+++ b/input_templates/terra_workspaces/cohort_mode/workflow_configurations/Module04b.SingleBatch.json.tmpl
@@ -1,0 +1,25 @@
+{
+  "Module04b.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",
+  "Module04b.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
+  "Module04b.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+  "Module04b.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "Module04b.n_RdTest_bins": "100000",
+  "Module04b.n_per_split": "5000",
+
+  "Module04b.cohort": "${this.sample_set_id}",
+  "Module04b.contig_list": "${workspace.primary_contigs_list}",
+  "Module04b.regeno_coverage_medians": "${this.regeno_coverage_medians}",
+
+  "Module04b.RD_depth_sepcutoffs": "${this.trained_genotype_depth_depth_sepcutoff}",
+
+  "Module04b.cohort_depth_vcf": "${this.filtered_depth_vcf}",
+
+  "Module04b.ped_file": "${workspace.cohort_ped_file}",
+  "Module04b.batch_depth_vcfs": "${this.filtered_depth_vcf}",
+
+  "Module04b.depth_vcfs": "${this.genotyped_depth_vcf}",
+  "Module04b.coveragefiles": "${this.merged_bincov}",
+  "Module04b.coveragefile_idxs": "${this.merged_bincov_index}",
+  "Module04b.medianfiles": "${this.median_cov}",
+  "Module04b.batches": "${this.sample_set_id}"
+}

--- a/input_templates/terra_workspaces/cohort_mode/workflow_configurations/Module0506.SingleBatch.json.tmpl
+++ b/input_templates/terra_workspaces/cohort_mode/workflow_configurations/Module0506.SingleBatch.json.tmpl
@@ -1,0 +1,40 @@
+{
+  "Module0506.bin_exclude": "${workspace.bin_exclude}",
+  "Module0506.contig_list": "${workspace.primary_contigs_fai}",
+  "Module0506.allosome_fai": "${workspace.allosome_file}",
+  "Module0506.cytobands": "${workspace.cytobands}",
+  "Module0506.mei_bed": "${workspace.mei_bed}",
+  "Module0506.pe_exclude_list": "${workspace.pesr_exclude_list}",
+  "Module0506.depth_exclude_list": "${workspace.depth_exclude_list}",
+  "Module0506.empty_file" : "${workspace.empty_file}",
+  "Module0506.ref_dict": "${workspace.reference_dict}",
+
+  "Module0506.thousand_genomes_tarballs": {{ reference_resources.thousand_genomes_tarballs | tojson }},
+
+  "Module0506.min_sr_background_fail_batches": 0.5,
+  "Module0506.max_shards_per_chrom_clean_vcf_step1": 200,
+  "Module0506.min_records_per_shard_clean_vcf_step1": 5000,
+  "Module0506.samples_per_clean_vcf_step2_shard": 100,
+  "Module0506.random_seed": 0,
+  "Module0506.max_shards_per_chrom": 100,
+  "Module0506.min_variants_per_shard": 30,
+
+  "Module0506.linux_docker": "${workspace.linux_docker}",
+  "Module0506.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "Module0506.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+  "Module0506.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",
+  "Module0506.sv_pipeline_qc_docker": "${workspace.sv_pipeline_qc_docker}",
+
+  "Module0506.cohort_name": "${this.sample_set_id}",
+  "Module0506.batches": "${this.sample_set_id}",
+  "Module0506.ped_file": "${workspace.cohort_ped_file}",
+  "Module0506.disc_files": "${this.merged_PE}",
+  "Module0506.bincov_files": "${this.merged_bincov}",
+  "Module0506.median_coverage_files": "${this.median_cov}",
+  "Module0506.rf_cutoff_files": "${this.cutoffs}",
+  "Module0506.pesr_vcfs": "${this.genotyped_pesr_vcf}",
+  "Module0506.depth_vcfs": "${this.regenotyped_depth_vcfs}",
+  "Module0506.depth_gt_rd_sep_files": "${this.trained_genotype_depth_depth_sepcutoff}",
+  "Module0506.raw_sr_bothside_pass_files": "${this.sr_bothside_pass}",
+  "Module0506.raw_sr_background_fail_files": "${this.sr_background_fail}"
+}

--- a/input_templates/terra_workspaces/cohort_mode/workflow_configurations/Module08Annotation.SingleBatch.json.tmpl
+++ b/input_templates/terra_workspaces/cohort_mode/workflow_configurations/Module08Annotation.SingleBatch.json.tmpl
@@ -1,0 +1,24 @@
+{
+  "Module08Annotation.vcf" : "${this.vcf}",
+  "Module08Annotation.vcf_idx" : "${this.vcf_index}",
+
+  "Module08Annotation.protein_coding_gtf" : "${workspace.protein_coding_gtf}",
+  "Module08Annotation.linc_rna_gtf" : "${workspace.linc_rna_gtf}",
+  "Module08Annotation.promoter_bed" : "${workspace.promoter_bed}",
+  "Module08Annotation.noncoding_bed" : "${workspace.noncoding_bed}",
+  "Module08Annotation.ref_bed" : "${workspace.external_af_ref_bed}",
+  "Module08Annotation.ref_prefix" : "${workspace.external_af_ref_bed_prefix}",
+  "Module08Annotation.population" : {{ reference_resources.external_af_population | tojson }},
+
+
+  "Module08Annotation.contig_list" : "${workspace.primary_contigs_list}",
+  "Module08Annotation.ped_file": "${workspace.cohort_ped_file}",
+  "Module08Annotation.sv_per_shard" : "5000",
+  "Module08Annotation.max_shards_per_chrom_step1" : 200,
+  "Module08Annotation.min_records_per_shard_step1" : 5000,
+
+  "Module08Annotation.prefix" : "${this.sample_set_id}",
+
+  "Module08Annotation.sv_base_mini_docker" : "${workspace.sv_base_mini_docker}",
+  "Module08Annotation.sv_pipeline_docker" : "${workspace.sv_pipeline_docker}"
+}

--- a/scripts/test/terra_validation.py
+++ b/scripts/test/terra_validation.py
@@ -58,7 +58,7 @@ def get_wdl_json_pairs(wdl_path, terra_inputs_path, expected_num_inputs, expecte
     jsons = list_all_jsons(terra_inputs_path, expected_num_inputs, expected_num_metrics)
 
     for json_file in jsons:
-        path_to_wdl = os.path.join(wdl_path, os.path.basename(json_file)[:-5] + ".wdl")
+        path_to_wdl = os.path.join(wdl_path, os.path.basename(json_file).split(".")[0] + ".wdl")
         if os.path.isfile(path_to_wdl):
             yield path_to_wdl, os.path.join(terra_inputs_path, json_file)
         else:
@@ -116,7 +116,7 @@ def main():
     parser.add_argument("-j", "--womtool-jar", help="Path to womtool jar", required=True)
     parser.add_argument("-n", "--num-input-jsons",
                         help="Number of Terra input JSONs expected (excluding metrics workflows)",
-                        required=False, default=12, type=int)
+                        required=False, default=16, type=int)
     parser.add_argument("-m", "--num-metrics-jsons", help="Number of Terra metrics workflow input JSONs expected",
                         required=False, default=7, type=int)
     parser.add_argument("--log-level",


### PR DESCRIPTION
### Updates
* Add single-batch JSON templates for Terra for Module04 through Module08
* Update Terra documentation and README based on comments from beta testers - link back to README more, add guidance on batching and preliminary sample QC, and some smaller things
* Edit 8/4: add Terra docs on managing intermediate storage, wham memory retry, and displaying run costs

### Testing
* Tested JSON generation
* Single-batch configs and updated dashboard are live in 1kgp Terra workspace
* Edit 8/4: Testing of single-batch workflows in Terra is in progress (in a clone of the 1kgp workspace so that I don't overwrite any two-batch outputs in the sample_set data table)

### Still to do
* Change module names (save for a later PR)
* Update wham memory model instead of recommending auto-retry for OOM
* Rebase after metrics workflow updates and add a few inputs to single-batch configs