### PR TITLE
Eliminate Array[File?] workflow outputs not supported by Terra

### DIFF
--- a/input_templates/terra_workspaces/cohort_mode/workflow_configurations/FilterBatchSamples.json.tmpl
+++ b/input_templates/terra_workspaces/cohort_mode/workflow_configurations/FilterBatchSamples.json.tmpl
@@ -6,9 +6,9 @@
   "FilterBatchSamples.N_IQR_cutoff": "10000",
 
   "FilterBatchSamples.batch": "${this.sample_set_id}",
-  "FilterBatchSamples.sites_filtered_manta_vcf" : "${this.sites_filtered_manta_vcf}",
-  "FilterBatchSamples.sites_filtered_delly_vcf" : "${this.sites_filtered_delly_vcf}",
-  "FilterBatchSamples.sites_filtered_wham_vcf" : "${this.sites_filtered_wham_vcf}",
-  "FilterBatchSamples.sites_filtered_melt_vcf" : "${this.sites_filtered_melt_vcf}",
-  "FilterBatchSamples.sites_filtered_depth_vcf" : "${this.sites_filtered_depth_vcf}"
+  "FilterBatchSamples.manta_vcf" : "${this.sites_filtered_manta_vcf}",
+  "FilterBatchSamples.delly_vcf" : "${this.sites_filtered_delly_vcf}",
+  "FilterBatchSamples.wham_vcf" : "${this.sites_filtered_wham_vcf}",
+  "FilterBatchSamples.melt_vcf" : "${this.sites_filtered_melt_vcf}",
+  "FilterBatchSamples.depth_vcf" : "${this.sites_filtered_depth_vcf}"
 }

--- a/input_templates/terra_workspaces/cohort_mode/workflow_configurations/FilterBatchSamples.json.tmpl
+++ b/input_templates/terra_workspaces/cohort_mode/workflow_configurations/FilterBatchSamples.json.tmpl
@@ -6,6 +6,9 @@
   "FilterBatchSamples.N_IQR_cutoff": "10000",
 
   "FilterBatchSamples.batch": "${this.sample_set_id}",
-  "FilterBatchSamples.vcfs" : "${this.sites_filtered_vcfs}",
-  "FilterBatchSamples.sv_counts": "${this.sv_counts}"
+  "FilterBatchSamples.sites_filtered_manta_vcf" : "${this.sites_filtered_manta_vcf}",
+  "FilterBatchSamples.sites_filtered_delly_vcf" : "${this.sites_filtered_delly_vcf}",
+  "FilterBatchSamples.sites_filtered_wham_vcf" : "${this.sites_filtered_wham_vcf}",
+  "FilterBatchSamples.sites_filtered_melt_vcf" : "${this.sites_filtered_melt_vcf}",
+  "FilterBatchSamples.sites_filtered_depth_vcf" : "${this.sites_filtered_depth_vcf}"
 }

--- a/input_templates/terra_workspaces/cohort_mode/workflow_configurations/PlotSVCountsPerSample.json.tmpl
+++ b/input_templates/terra_workspaces/cohort_mode/workflow_configurations/PlotSVCountsPerSample.json.tmpl
@@ -4,6 +4,6 @@
   "PlotSVCountsPerSample.N_IQR_cutoff": "6",
 
   "PlotSVCountsPerSample.prefix": "${this.sample_set_id}",
-  "PlotSVCountsPerSample.vcfs" : "${this.sites_filtered_vcfs}",
+  "PlotSVCountsPerSample.vcfs" : "${[this.sites_filtered_manta_vcf, this.sites_filtered_delly_vcf, this.sites_filtered_wham_vcf, this.sites_filtered_melt_vcf, this.sites_filtered_depth_vcf]}",
   "PlotSVCountsPerSample.vcf_identifiers" : "${this.algorithms_filtersites}"
 }

--- a/test_input_templates/FilterBatch/FilterBatchSamples.json.tmpl
+++ b/test_input_templates/FilterBatch/FilterBatchSamples.json.tmpl
@@ -7,14 +7,11 @@
   "FilterBatchSamples.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
 
   "FilterBatchSamples.batch": {{ test_batch.batch_name | tojson }},
-  "FilterBatchSamples.vcfs" : [ 
-    {{ test_batch.sites_filtered_manta_vcf | tojson }}, 
-    null,
-    {{ test_batch.sites_filtered_wham_vcf | tojson }}, 
-    {{ test_batch.sites_filtered_melt_vcf | tojson }}, 
-    {{ test_batch.sites_filtered_depth_vcf | tojson }}
-  ],
-  "FilterBatchSamples.sv_counts": [
+  "FilterBatchSamples.sites_filtered_manta_vcf": {{ test_batch.sites_filtered_manta_vcf | tojson }},
+  "FilterBatchSamples.sites_filtered_wham_vcf": {{ test_batch.sites_filtered_wham_vcf | tojson }},
+  "FilterBatchSamples.sites_filtered_melt_vcf": {{ test_batch.sites_filtered_melt_vcf | tojson }},
+  "FilterBatchSamples.sites_filtered_depth_vcf": {{ test_batch.sites_filtered_depth_vcf | tojson }},
+  "FilterBatchSamples.sv_counts_array": [
     {{ test_batch.sites_filtered_svcounts_manta | tojson }},
     null,
     {{ test_batch.sites_filtered_svcounts_wham | tojson }},

--- a/test_input_templates/FilterBatch/FilterBatchSamples.json.tmpl
+++ b/test_input_templates/FilterBatch/FilterBatchSamples.json.tmpl
@@ -7,15 +7,12 @@
   "FilterBatchSamples.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
 
   "FilterBatchSamples.batch": {{ test_batch.batch_name | tojson }},
-  "FilterBatchSamples.sites_filtered_manta_vcf": {{ test_batch.sites_filtered_manta_vcf | tojson }},
-  "FilterBatchSamples.sites_filtered_wham_vcf": {{ test_batch.sites_filtered_wham_vcf | tojson }},
-  "FilterBatchSamples.sites_filtered_melt_vcf": {{ test_batch.sites_filtered_melt_vcf | tojson }},
-  "FilterBatchSamples.sites_filtered_depth_vcf": {{ test_batch.sites_filtered_depth_vcf | tojson }},
-  "FilterBatchSamples.sv_counts_array": [
-    {{ test_batch.sites_filtered_svcounts_manta | tojson }},
-    null,
-    {{ test_batch.sites_filtered_svcounts_wham | tojson }},
-    {{ test_batch.sites_filtered_svcounts_melt | tojson }},
-    {{ test_batch.sites_filtered_svcounts_depth | tojson }}
-  ]
+  "FilterBatchSamples.manta_vcf": {{ test_batch.sites_filtered_manta_vcf | tojson }},
+  "FilterBatchSamples.wham_vcf": {{ test_batch.sites_filtered_wham_vcf | tojson }},
+  "FilterBatchSamples.melt_vcf": {{ test_batch.sites_filtered_melt_vcf | tojson }},
+  "FilterBatchSamples.depth_vcf": {{ test_batch.sites_filtered_depth_vcf | tojson }},
+  "FilterBatchSamples.manta_counts": {{ test_batch.sites_filtered_svcounts_manta | tojson }},
+  "FilterBatchSamples.wham_counts": {{ test_batch.sites_filtered_svcounts_wham | tojson }},
+  "FilterBatchSamples.melt_counts": {{ test_batch.sites_filtered_svcounts_melt | tojson }},
+  "FilterBatchSamples.depth_counts": {{ test_batch.sites_filtered_svcounts_depth | tojson }}
 }

--- a/wdl/FilterBatch.wdl
+++ b/wdl/FilterBatch.wdl
@@ -82,11 +82,11 @@ workflow FilterBatch {
       batch = batch,
       outlier_cutoff_table = outlier_cutoff_table,
       N_IQR_cutoff = outlier_cutoff_nIQR,
-      sites_filtered_manta_vcf = FilterBatchSites.sites_filtered_manta_vcf,
-      sites_filtered_delly_vcf = FilterBatchSites.sites_filtered_delly_vcf,
-      sites_filtered_wham_vcf = FilterBatchSites.sites_filtered_wham_vcf,
-      sites_filtered_melt_vcf = FilterBatchSites.sites_filtered_melt_vcf,
-      sites_filtered_depth_vcf = FilterBatchSites.sites_filtered_depth_vcf,
+      manta_vcf = FilterBatchSites.sites_filtered_manta_vcf,
+      delly_vcf = FilterBatchSites.sites_filtered_delly_vcf,
+      wham_vcf = FilterBatchSites.sites_filtered_wham_vcf,
+      melt_vcf = FilterBatchSites.sites_filtered_melt_vcf,
+      depth_vcf = FilterBatchSites.sites_filtered_depth_vcf,
       linux_docker = linux_docker,
       sv_pipeline_docker = sv_pipeline_docker,
       sv_base_mini_docker = sv_base_mini_docker,
@@ -136,8 +136,8 @@ workflow FilterBatch {
     File cutoffs = FilterBatchSites.cutoffs
     File scores = FilterBatchSites.scores
     File RF_intermediate_files = FilterBatchSites.RF_intermediate_files
-    Array[File?] sv_counts = PlotSVCountsPerSample.sv_counts
-    Array[File?] sv_count_plots = PlotSVCountsPerSample.sv_count_plots
+    Array[File] sv_counts = PlotSVCountsPerSample.sv_counts
+    Array[File] sv_count_plots = PlotSVCountsPerSample.sv_count_plots
     Array[String] outlier_samples_excluded = FilterBatchSamples.outlier_samples_excluded
     Array[String] batch_samples_postOutlierExclusion = FilterBatchSamples.filtered_batch_samples_list
     File outlier_samples_excluded_file = FilterBatchSamples.outlier_samples_excluded_file

--- a/wdl/FilterBatch.wdl
+++ b/wdl/FilterBatch.wdl
@@ -68,7 +68,7 @@ workflow FilterBatch {
   call sv_counts.PlotSVCountsPerSample {
     input:
       prefix = batch,
-      vcfs = FilterBatchSites.sites_filtered_vcfs,
+      vcfs = [FilterBatchSites.sites_filtered_manta_vcf, FilterBatchSites.sites_filtered_delly_vcf, FilterBatchSites.sites_filtered_wham_vcf, FilterBatchSites.sites_filtered_melt_vcf, FilterBatchSites.sites_filtered_depth_vcf],
       vcf_identifiers = FilterBatchSites.algorithms_filtersites,
       N_IQR_cutoff = outlier_cutoff_nIQR,
       sv_pipeline_docker = sv_pipeline_docker,
@@ -82,8 +82,11 @@ workflow FilterBatch {
       batch = batch,
       outlier_cutoff_table = outlier_cutoff_table,
       N_IQR_cutoff = outlier_cutoff_nIQR,
-      vcfs = FilterBatchSites.sites_filtered_vcfs,
-      sv_counts = PlotSVCountsPerSample.sv_counts,
+      sites_filtered_manta_vcf = FilterBatchSites.sites_filtered_manta_vcf,
+      sites_filtered_delly_vcf = FilterBatchSites.sites_filtered_delly_vcf,
+      sites_filtered_wham_vcf = FilterBatchSites.sites_filtered_wham_vcf,
+      sites_filtered_melt_vcf = FilterBatchSites.sites_filtered_melt_vcf,
+      sites_filtered_depth_vcf = FilterBatchSites.sites_filtered_depth_vcf,
       linux_docker = linux_docker,
       sv_pipeline_docker = sv_pipeline_docker,
       sv_base_mini_docker = sv_base_mini_docker,

--- a/wdl/FilterBatchSamples.wdl
+++ b/wdl/FilterBatchSamples.wdl
@@ -9,12 +9,16 @@ import "IdentifyOutlierSamples.wdl" as identify_outliers
 workflow FilterBatchSamples {
   input {
     String batch
-    File? sites_filtered_manta_vcf
-    File? sites_filtered_delly_vcf
-    File? sites_filtered_wham_vcf
-    File? sites_filtered_melt_vcf
-    File? sites_filtered_depth_vcf
-    Array[File?]? sv_counts_array  # one SV counts file from PlotSVCountsPerSample per VCF in the order ["manta", "delly", "wham", "melt", "depth"]. Enter null for missing SV counts
+    File? manta_vcf
+    File? delly_vcf
+    File? wham_vcf
+    File? melt_vcf
+    File? depth_vcf
+    File? manta_counts  # SV counts files from PlotSVCountsPerSample. If not provided, SV counts will be calculated as part of this workflow
+    File? delly_counts
+    File? wham_counts
+    File? melt_counts
+    File? depth_counts
     Int N_IQR_cutoff
     File? outlier_cutoff_table
     String sv_pipeline_docker
@@ -31,10 +35,10 @@ workflow FilterBatchSamples {
     File? NONE_FILE  # do not supply input
   }
 
-  Array[File?] vcfs = [sites_filtered_manta_vcf, sites_filtered_delly_vcf, sites_filtered_wham_vcf, sites_filtered_melt_vcf, sites_filtered_depth_vcf]
+  Array[File?] vcfs = [manta_vcf, delly_vcf, wham_vcf, melt_vcf, depth_vcf]
   Array[String] algorithms = ["manta", "delly", "wham", "melt", "depth"]  # fixed algorithms to enable File outputs to be determined
   Int num_algorithms = length(algorithms)
-  Array[File?] sv_counts_ = if defined(sv_counts_array) then select_first([sv_counts_array]) else [NONE_FILE, NONE_FILE, NONE_FILE, NONE_FILE, NONE_FILE]
+  Array[File?] sv_counts_ = [manta_counts, delly_counts, wham_counts, melt_counts, depth_counts]
 
   scatter (i in range(num_algorithms)) {
     if (defined(vcfs[i])) {

--- a/wdl/FilterBatchSamples.wdl
+++ b/wdl/FilterBatchSamples.wdl
@@ -31,8 +31,6 @@ workflow FilterBatchSamples {
     RuntimeAttr? runtime_attr_ids_from_vcf
     RuntimeAttr? runtime_attr_count_svs
     RuntimeAttr? runtime_attr_merge_pesr_vcfs
-
-    File? NONE_FILE  # do not supply input
   }
 
   Array[File?] vcfs = [manta_vcf, delly_vcf, wham_vcf, melt_vcf, depth_vcf]

--- a/wdl/FilterBatchSites.wdl
+++ b/wdl/FilterBatchSites.wdl
@@ -59,7 +59,11 @@ workflow FilterBatchSites {
   }
 
   output {
-    Array[File?] sites_filtered_vcfs = FilterAnnotateVcf.annotated_vcf
+    File? sites_filtered_manta_vcf = FilterAnnotateVcf.annotated_vcf[0]
+    File? sites_filtered_delly_vcf = FilterAnnotateVcf.annotated_vcf[1]
+    File? sites_filtered_wham_vcf = FilterAnnotateVcf.annotated_vcf[2]
+    File? sites_filtered_melt_vcf = FilterAnnotateVcf.annotated_vcf[3]
+    File? sites_filtered_depth_vcf = FilterAnnotateVcf.annotated_vcf[4]
     File cutoffs = AdjudicateSV.cutoffs
     File scores = RewriteScores.updated_scores
     File RF_intermediate_files = AdjudicateSV.RF_intermediate_files

--- a/wdl/PlotSVCountsPerSample.wdl
+++ b/wdl/PlotSVCountsPerSample.wdl
@@ -49,8 +49,8 @@ workflow PlotSVCountsPerSample {
 
 
   output {
-    Array[File?] sv_counts = CountSVsPerSamplePerType.sv_counts
-    Array[File?] sv_count_plots = PlotSVCountsWithCutoff.svcount_distrib_plots
+    Array[File] sv_counts = select_all(CountSVsPerSamplePerType.sv_counts)
+    Array[File] sv_count_plots = select_all(PlotSVCountsWithCutoff.svcount_distrib_plots)
     File outlier_samples_preview = CatOutliersPreview.outliers_preview_file
   }
 }


### PR DESCRIPTION
### Updates
Turns out null values in Array[File?] workflow outputs are not supported in Terra. So, had to eliminate them from FilterBatchSites and PlotSVCountsPerSample and update other inputs and JSONs accordingly.
* As a side effect, in the current implementation, the sv_counts calculated in PlotSVCountsPerSample can no longer be used in FilterBatchSamples because they may be in the wrong order of algorithms. So, cromwell will attempt to recalculate them but just call-cache. An alternative would be to create a version of PlotSVCountsPerSample that is specific to the FilterBatch context and a separate general version.

### Testing
* Validated all WDLs and JSONs
* Retested FilterBatch and verified outputs are identical
* Tested upload of JSON input to PlotSVCountsPerSample and tested a workflow with [this.filtered_manta_vcf, this.filtered_depth_vcf] input style to make sure it ran as expected