### PR TITLE
EvidenceQC.MedianCov memory & make batched workflow output filenames unique

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -13,7 +13,7 @@
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-base:mw-gnomad-0506-pr-087d4df",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-base-mini:mw-gnomad-0506-pr-087d4df",
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-base:mw-gnomad-0506-pr-087d4df",
-  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:mw-gnomad-0506-pr-087d4df",
+  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/eph/sv-pipeline:eph_mediancov_mem_and_names-3f0c76d",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-qc:mw-gnomad-0506-pr-087d4df",
   "sv_pipeline_rdtest_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-rdtest:mw-gnomad-0506-pr-087d4df",
   "wham_docker" : "us.gcr.io/broad-dsde-methods/wham:8645aa",

--- a/src/sv-pipeline/04_variant_resolution/scripts/SR_genotype.opt_part1.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/SR_genotype.opt_part1.sh
@@ -19,6 +19,7 @@ RF_cutoffs=$5
 whitelist=$6
 petrainfile=$7
 pegenotypes=$8
+batch=$9
 
 sr_pval=$( awk -F'\t' '{if ( $5=="SR_sum_log_pval") print $2}' $RF_cutoffs | head -n 1)
 sr_count=$(/opt/sv-pipeline/04_variant_resolution/scripts/convert_poisson_p.py $sr_pval)
@@ -234,3 +235,4 @@ echo -e "rare_single"'\t'$rare_single>>sr_metric_file.txt
 echo -e "rare_both"'\t'$rare_both>>sr_metric_file.txt
 echo -e "common_single"'\t'$common_single>>sr_metric_file.txt
 echo -e "common_both"'\t'$common_both>>sr_metric_file.txt
+mv sr_metric_file.txt "$batch.sr_metric_file.txt"

--- a/wdl/TrainPEGenotyping.wdl
+++ b/wdl/TrainPEGenotyping.wdl
@@ -77,6 +77,7 @@ workflow TrainPEGenotyping {
       RD_genotypes = RD_genotypes,
       RD_melted_genotypes = RD_melted_genotypes,
       exclude_list = exclude_list,
+      batch = batch_ID,
       sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_genotype
   }
@@ -134,6 +135,7 @@ task GenotypePEPart1 {
     File RD_genotypes
     File RD_melted_genotypes
     File exclude_list
+    String batch
     String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
@@ -149,10 +151,10 @@ task GenotypePEPart1 {
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 
   output {
-    File PE_train = "pe.train.include.txt"
-    File PE_metrics = "pe_metric_file.txt"
-    File genotypes = "pe.geno.withquality.txt.gz"
-    File varGQ = "pe.variant.quality.final.txt.gz"
+    File PE_train = "~{batch}.pe.train.include.txt"
+    File PE_metrics = "~{batch}.pe_metric_file.txt"
+    File genotypes = "~{batch}.pe.geno.withquality.txt.gz"
+    File varGQ = "~{batch}.pe.variant.quality.final.txt.gz"
   }
   command <<<
 
@@ -163,7 +165,7 @@ task GenotypePEPart1 {
       ~{RD_melted_genotypes} \
       ~{RF_cutoffs} \
       ~{exclude_list} \
-      /opt/RdTest/generate_cutoff_PE.R 
+      ~{batch}
   
   >>>
   runtime {

--- a/wdl/TrainSRGenotyping.wdl
+++ b/wdl/TrainSRGenotyping.wdl
@@ -70,6 +70,7 @@ workflow TrainSRGenotyping {
       samples = samples,
       PE_train = PE_train,
       PE_genotypes = PE_genotypes,
+      batch = batch_ID,
       sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_genotype
   }
@@ -89,6 +90,7 @@ task GenotypeSRPart1 {
     Array[String] samples
     File PE_train
     File PE_genotypes
+    String batch
     String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
@@ -104,7 +106,7 @@ task GenotypeSRPart1 {
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 
   output {
-    File SR_metrics = "sr_metric_file.txt"
+    File SR_metrics = "~{batch}.sr_metric_file.txt"
   }
   command <<<
 
@@ -116,7 +118,8 @@ task GenotypeSRPart1 {
       ~{RF_cutoffs} \
       ~{write_lines(samples)} \
       ~{PE_train} \
-      ~{PE_genotypes}
+      ~{PE_genotypes} \
+      ~{batch}
   
   >>>
   runtime {


### PR DESCRIPTION
### Updates
* Add dynamic memory allocation based on number of samples to EvidenceQC.MedianCov (used same formula as GatherBatchEvidence.MedianCov)
* Make workflow output names that appear in Terra sample_sets table unique: outlier files from EvidenceQC and trained_PE/SR_metrics from GenotypeBatch (involved updating sv_pipeline_docker)
  * Requested by beta tester so that files from multiple batches can be downloaded from GCS without overwriting & without having to change the file name

### Testing
* Womtool validation of WDLs & JSONs
* Ran EvidenceQC on test_large data and verified that 60 GB of memory was allocated for 105 samples, that the memory allocated was reasonable compared to what was used (could probably do away with the 7.5 GB padding but doesn't appear to be a huge deal), and that the outlier files had `test_large.` prepended to the file names
* Ran `PE_genotype.sh` in the docker image on 1kgp data and verified that other than the filenames, all the files were bitwise identical to latest Terra run
* Ran GenotypeBatch on test_large data with rebuilt `sv_pipeline_docker` and verified that it completed successfully and the trained_PE_metrics and trained_SR_metrics files had `test_large.` prepended to the file names