### PR TITLE
Rewrite cleanVCF part 1b using single-pass on the input VCF

### DIFF
--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
@@ -787,8 +787,9 @@ def main(int_vcf_gz):
     f = Filter()
     overlapping_variants_ids, overlap_test_text, geno_normal_revise_txt, geno_normal_revise_dict, header = f.get_overlapping_variants(int_vcf_gz)
     new_normal_revise_vcf_gz, multi_cnvs_txt = f.modify_variants(int_vcf_gz, geno_normal_revise_dict, header)
-    print(f"new normal revise vcf:\t{new_normal_revise_vcf_gz}")
-    print(f"multi_cnvs_txt:\t{multi_cnvs_txt}")
+    shutil.move(new_normal_revise_vcf_gz, "./normal.revise.vcf.gz")
+    shutil.move(new_normal_revise_vcf_gz + ".csi", "./normal.revise.vcf.gz.csi")
+    shutil.move(multi_cnvs_txt, "./multi.cnvs.txt")
     exit()
 
 

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
@@ -445,6 +445,23 @@ def find_multi_allelic_for_del(copystate_per_variant_txt_gz, int_bed_gz):
     return output.name
 
 
+def find_multi_allelic_for_dup(copystate_per_variant_txt_gz, int_bed_gz, multi_cnvs_txt):
+    variants = set()
+    with gzip.open(copystate_per_variant_txt_gz, "rt") as f:
+        for l in f:
+            sl = l.strip().split("\t")
+            if sl[1] != "." and (int(sl[1]) < 1 or int(sl[1]) > 4):
+                variants.add(sl[0])
+
+    with gzip.open(int_bed_gz, "rt") as f, open(multi_cnvs_txt, "a") as o:
+        for l in f:
+            sl = l.strip().split("\t")
+            if sl[3] in variants:
+                if sl[4] == "DUP" and int(sl[2]) - int(sl[1]) >= 1000:
+                    o.write(sl[3] + "\n")
+
+    return multi_cnvs_txt
+
 def main(int_vcf_gz):
     headers = get_columns_headers(int_vcf_gz)
     headers = headers.strip().split("\t")
@@ -466,6 +483,7 @@ def main(int_vcf_gz):
     copystate_rd_cn_format_gz = get_copystate_per_variant(normal_revise_vcf_gz)
     copystate_per_variant_txt_gz = get_copystate_per_variant_2(copystate_rd_cn_format_gz)
     multi_cnvs_txt = find_multi_allelic_for_del(copystate_per_variant_txt_gz, int_bed_gz)
+    multi_cnvs_txt = find_multi_allelic_for_dup(copystate_per_variant_txt_gz, int_bed_gz, multi_cnvs_txt)
     print(multi_cnvs_txt)
 
 

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
@@ -3,13 +3,16 @@ Remove CNVs that are improperly genotyped by depth because they are nested
 within a real CNV
 """
 
+import enum
 import os
-import pybedtools
-import pysam
 import svtk.utils as svu
 import sys
+from abc import ABC, abstractmethod
+from enum import Enum
 from pathlib import Path
-from subprocess import check_call, Popen, PIPE, STDOUT
+from pysam.libcbcf import VariantFile, VariantRecord
+from subprocess import check_call
+from typing import Iterator
 
 
 SVTYPE = "SVTYPE"
@@ -28,15 +31,93 @@ class VariantFormatTypes:
     EV = "EV"
 
 
-class VCFReviser:
-    def __init__(self):
-        self.rd_cn = {}
-        self.rd_cn_idx = None
-        self.ev = {}
-        self.ev_idx = None
-        self.samples = {}
+@enum.unique
+class WindowTypes(Enum):
 
-    def _update_rd_cn_ev(self, variant):
+    """
+    Revise Nested CNVs.
+    """
+    RNCNV = 1
+
+
+class BaseWindow(ABC):
+    """
+    A 'window' encapsulates a set of overlapping intervals.
+    In the following illustration, the five intervals to left
+    form Window_1, and the two interval to right form Window_2
+    (Window_1 and Window_2 are different instances of BaseWindow).
+
+    ----------- Window_1 -------------       ---- Window_2 ----
+    ░░░░░░░░░░░░░░░░░░░░░░░   ░░░░░░░░       ░░░░░░░░░░░░
+       ░░░░░░  ░░░░░░  ░░░░░░░░░                   ░░░░░░░░░░░░
+    """
+    def __init__(self):
+        self.intervals = []
+        self.overlapping_pairs = []
+        self.stop = 0
+
+    @staticmethod
+    def _determine_wider(x: VariantRecord, y: VariantRecord) \
+            -> (VariantRecord, VariantRecord):
+        """
+        Returns the input intervals ordered as: wider, narrower
+        """
+        if x.stop - x.start >= y.stop - y.start:
+            return x, y
+        else:
+            return y, x
+
+    def get_coverage(self, x: VariantRecord, y: VariantRecord) -> float:
+        """
+        Returns the Jaccard index of the overlapping intervals;
+        returns 0.0 if the intervals do not overlap.
+        """
+        w, n = self._determine_wider(x, y)
+        if w.start <= n.stop and n.start <= w.stop:
+            intersection = min(n.stop, w.stop) - max(n.start, w.start)
+            return intersection / (n.stop - n.start)
+        else:
+            return 0.0
+
+    def add(self, interval: VariantRecord) -> None:
+        self.intervals.append(interval)
+        self.stop = max(self.stop, interval.stop)
+
+    @abstractmethod
+    def add_overlapping_pairs(self, x: VariantRecord, y: VariantRecord) \
+            -> None:
+        """
+        Implement application-specific logic for pairs of overlapping
+        intervals in the window.
+        Should be implemented in a derived type.
+        """
+        raise NotImplementedError
+
+
+class RNCNVWindow(BaseWindow):
+    def __init__(self, min_var_width=5000, min_coverage=0.5,
+                 include_var_types=None):
+        super().__init__()
+        self.include_variant_types = include_var_types or [SVType.DEL,
+                                                           SVType.DUP]
+        self.min_width = min_var_width
+        self.min_coverage = min_coverage
+        self.rd_cn = {}
+        self.ev = {}
+        # A set of OverlappingVariantsDifferBySample
+        self.ovds = set()
+
+    def _shall_process(self, variant: VariantRecord) -> bool:
+        """
+        Returns true if the variation type matches the specified types
+        and is wider than a given width threshold.
+        """
+        return \
+            variant.info[SVTYPE] in self.include_variant_types and \
+            variant.stop - variant.start >= self.min_width
+
+    def add(self, variant: VariantRecord) -> None:
+        super().add(variant)
         rd_cn = []
         ev = []
         for k, v in variant.samples.items():
@@ -45,138 +126,187 @@ class VCFReviser:
         self.rd_cn[variant.id] = rd_cn
         self.ev[variant.id] = ev
 
-    def filter_variant_types(self, variants, filter_types=None,
-                             min_width=5000):
-        for variant in variants:
-            sv_type = variant.info[SVTYPE]
-            if filter_types and sv_type not in filter_types:
+    def add_overlapping_pairs(self, x: VariantRecord, y: VariantRecord) \
+            -> None:
+        if not self._shall_process(x) or not self._shall_process(y):
+            return
+
+        if x.info[SVTYPE] == y.info[SVTYPE]:
+            return
+
+        wider, narrower = self._determine_wider(x, y)
+        w_samples = set(svu.get_called_samples(wider))
+        n_samples = set(svu.get_called_samples(narrower))
+        if not w_samples:
+            return
+
+        non_common_samples = []
+        for sample in w_samples:
+            if sample not in n_samples:
+                non_common_samples.append(sample)
+
+        coverage_percentage = self.get_coverage(wider, narrower)
+        if coverage_percentage >= self.min_coverage:
+            for sample in non_common_samples:
+                self.ovds.add(OverlappingVariantsDifferBySample(
+                    wider, narrower, sample))
+
+
+class WindowFactory:
+    def __init__(self):
+        self.windows = {WindowTypes.RNCNV: RNCNVWindow}
+
+    def get_window(self, window_type: WindowTypes) -> BaseWindow:
+        return self.windows[window_type]()
+
+
+class StreamIntersect:
+    """
+    Finds and processes overlapping intervals on a stream of intervals
+    and provides a stream of processed intervals. In other words, it takes
+    an iterator on input intervals and returns a generator of processed
+    intervals.
+
+    It requires the iterator to yield sorted intervals.
+
+    It yields a set of overlapping intervals encapsulated in a "Window"
+    (BaseWindow or derived type). A window contains overlapping intervals
+    and implements any business logic on the overlapping pairs.
+    """
+
+    def __init__(self, window_type: WindowTypes):
+        self.factory = WindowFactory()
+        self.window_type = window_type
+
+    def _get_window(self):
+        return self.factory.get_window(self.window_type)
+
+    def get_windows(self, intervals: VariantFile) -> Iterator[RNCNVWindow]:
+        """
+        A generator of "window"s, each encapsulating a
+        set of overlapping intervals.
+        """
+        window = self._get_window()
+
+        # window.add(next(intervals))
+        # while interval := next(intervals, None):
+        # Since this ^^ syntax is not supported on python versions earlier
+        # than 3.8 (at the time of writing this, gatk-sv-base is using
+        # python 3.6.5); then the following four lines are used instead.
+        for interval in intervals:
+            if not window.intervals:
+                window.add(interval)
                 continue
-            if variant.stop - variant.start < min_width:
-                continue
 
-            self._update_rd_cn_ev(variant)
+            if interval.start <= window.stop:
+                for x in window.intervals:
+                    if x.start <= interval.stop and x.stop >= interval.start:
+                        window.add_overlapping_pairs(x, interval)
+                window.add(interval)
+            else:
+                yield window
+                window = self._get_window()
+                window.add(interval)
 
-            samples = ','.join(svu.get_called_samples(variant))
-            if len(samples) == 0:
-                samples = BLANK_SAMPLES
+        yield window
 
-            yield variant.contig, variant.start, variant.stop, \
-                variant.id, sv_type, samples
 
-    @staticmethod
-    def get_wider(f):
-        if int(f[2]) - int(f[1]) >= int(f[8]) - int(f[7]):
-            return f[0:6], f[6:12]
+# TODO: any better descriptive/shorter name?!
+class OverlappingVariantsDifferBySample:
+    """
+    This is container of two overlapping variants that differ
+    in their called sample. The wider variant is called on
+    the given sample, but the not the narrower variant.
+    See the :func:`RNCNVWindow.add_overlapping_pair` for details.
+    """
+    def __init__(self, wider: VariantRecord, narrower: VariantRecord,
+                 sample: str):
+        self.wider = wider
+        self.narrower = narrower
+        self.sample = sample
+
+    def __hash__(self):
+        return hash((self.wider.id, self.narrower.id, self.sample))
+
+    def __eq__(self, other):
+        if isinstance(other, OverlappingVariantsDifferBySample):
+            return self.__hash__() == other.__hash__()
         else:
-            return f[6:12], f[0:6]
+            return False
 
-    @staticmethod
-    def get_coverage(wider, narrower):
-        n_start = int(narrower[1])
-        n_stop = int(narrower[2])
-        w_start = int(wider[1])
-        w_stop = int(wider[2])
 
-        coverage = 0
-        if w_start <= n_stop and n_start <= w_stop:
-            intersection_size = min(n_stop, w_stop) - max(n_start, w_start)
-            coverage = intersection_size / (n_stop - n_start)
-        return coverage
+class VCFReviser:
+    def __init__(self):
+        self.samples = {}
+        self.multi_cnvs = []
 
-    def get_geno_normal_revise(self, int_vcf_gz):
-        overlap_test_text = {}
-        with pysam.VariantFile(int_vcf_gz, "r") as f:
-            header = f.header
+    def get_revised_variants(self, variants: VariantFile) \
+            -> Iterator[VariantRecord]:
+        """
+        This is a generator; it iterates through the input variants,
+        revises them as necessary, and yields them.
+        """
+        si = StreamIntersect(WindowTypes.RNCNV)
+        for window in si.get_windows(variants):
+            geno_normal_revise_dict = {}
+
+            for x in window.ovds:
+                sample_index = self.samples[x.sample]
+                new_val = None
+                if x.wider.info[SVTYPE] == SVType.DUP and \
+                        window.rd_cn[x.narrower.id][sample_index] == 2 and \
+                        window.rd_cn[x.wider.id][sample_index] == 3:
+                    new_val = 1
+                elif x.wider.info[SVTYPE] == SVType.DEL and \
+                        window.rd_cn[x.narrower.id][sample_index] == 2 and \
+                        window.rd_cn[x.wider.id][sample_index] == 1:
+                    new_val = 3
+
+                if new_val:
+                    if x.narrower.id not in geno_normal_revise_dict:
+                        geno_normal_revise_dict[x.narrower.id] = {}
+                    geno_normal_revise_dict[x.narrower.id][x.sample] = new_val
+
+            for variant in window.intervals:
+                if variant.id in geno_normal_revise_dict:
+                    for sample_id in geno_normal_revise_dict[variant.id]:
+                        # original sample
+                        o = variant.samples[sample_id]
+                        o.update({"GT": (0, 1)})
+                        o.update({"GQ": o["RD_GQ"]})
+
+                if variant.stop - variant.start >= 1000:
+                    if variant.info[SVTYPE] in [SVType.DEL, SVType.DUP]:
+                        is_del = variant.info[SVTYPE] == SVType.DEL
+                        for k, v in variant.samples.items():
+                            rd_cn = v[VariantFormatTypes.RD_CN]
+                            if not rd_cn:
+                                continue
+                            if (is_del and rd_cn > 3) or \
+                                    (not is_del and (rd_cn < 1 or rd_cn > 4)):
+                                self.multi_cnvs.append(variant.id)
+                                break
+                yield variant
+
+    def revise(self, input_vcf: str, output_vcf: str,
+               multi_cnvs_filename: str) -> None:
+        with VariantFile(input_vcf, "r") as f_in:
+            header = f_in.header
             i = -1
             for sample in header.samples:
                 i += 1
                 self.samples[sample] = i
 
-            dels_and_dups = pybedtools.BedTool(
-                self.filter_variant_types(
-                    f.fetch(), [SVType.DEL, SVType.DUP], 5000)).saveas()
+            with VariantFile(output_vcf, "w", header=header) as f_out:
+                for revised_variant in self.get_revised_variants(f_in.fetch()):
+                    f_out.write(revised_variant)
 
-            overlapping_variants = dels_and_dups.intersect(
-                dels_and_dups, wa=True, wb=True)
-
-            for interval in overlapping_variants.intervals:
-                # IDs are identical, hence it is the overlap
-                # of an interval with itself.
-                if interval.fields[3] == interval.fields[9]:
-                    continue
-
-                # Variant types are identical.
-                if interval.fields[4] == interval.fields[10]:
-                    continue
-
-                wider, narrower = self.get_wider(interval.fields)
-                if wider[5] == BLANK_SAMPLES:
-                    continue
-                non_common_samples = []
-                for x in wider[5].split(","):
-                    if x not in narrower[5].split(","):
-                        non_common_samples.append(x)
-
-                coverage = self.get_coverage(wider, narrower)
-                if coverage >= 0.5:
-                    for x in non_common_samples:
-                        overlap_test_text[f"{narrower[3]}@{x}"] = \
-                            [f"{narrower[3]}@{x}", wider[3], wider[4]]
-
-        geno_normal_revise_dict = {}
-        for k, v in overlap_test_text.items():
-            var_id = k.split("@")[0]
-            sample_index = self.samples[k.split("@")[1]]
-            new_val = None
-            if v[2] == SVType.DUP and \
-                    self.rd_cn[var_id][sample_index] == 2 and \
-                    self.rd_cn[v[1]][sample_index] == 3:
-                new_val = 1
-            elif v[2] == SVType.DEL and \
-                    self.rd_cn[var_id][sample_index] == 2 \
-                    and self.rd_cn[v[1]][sample_index] == 1:
-                new_val = 3
-
-            if new_val:
-                if var_id not in geno_normal_revise_dict:
-                    geno_normal_revise_dict[var_id] = {}
-                geno_normal_revise_dict[var_id][v[0].split("@")[1]] = new_val
-
-        return geno_normal_revise_dict
-
-    def modify_variants(self, int_vcf_gz, revised_vcf, multi_cnvs):
-        geno_normal_revise_dict = self.get_geno_normal_revise(int_vcf_gz)
-
-        with pysam.VariantFile(int_vcf_gz, "r") as f_in:
-            header = f_in.header
-
-            with pysam.VariantFile(revised_vcf, "w", header=header) as f_out, \
-                    open(multi_cnvs, "w") as multi_cnvs_f:
-                variants = f_in.fetch()
-                for variant in variants:
-                    if variant.id in geno_normal_revise_dict:
-                        for sample_id in geno_normal_revise_dict[variant.id]:
-                            o = variant.samples[sample_id]
-                            o.update({"GT": (0, 1)})
-                            o.update({"GQ": o["RD_GQ"]})
-
-                    if variant.stop - variant.start >= 1000:
-                        if variant.info[SVTYPE] in [SVType.DEL, SVType.DUP]:
-                            is_del = variant.info[SVTYPE] == SVType.DEL
-                            for k, v in variant.samples.items():
-                                rd_cn = v[VariantFormatTypes.RD_CN]
-                                if not rd_cn:
-                                    continue
-                                if (is_del and rd_cn > 3) or \
-                                   (not is_del and (rd_cn < 1 or rd_cn > 4)):
-                                    multi_cnvs_f.write(variant.id + "\n")
-                                    break
-
-                    f_out.write(variant)
+        with open(multi_cnvs_filename, "w") as f:
+            for x in self.multi_cnvs:
+                f.write(x + "\n")
 
 
-def ensure_file(filename):
-    filename = os.path.join(".", filename)
+def ensure_file(filename: str) -> str:
     filename = Path(filename)
     if filename.exists():
         os.remove(filename)
@@ -184,21 +314,21 @@ def ensure_file(filename):
 
 
 def main(int_vcf_gz):
-    revised_vcf_filename = ensure_file("normal.revise.unsorted.vcf")
-    multi_cnvs_filename = ensure_file("multi.cnvs.txt")
-
     reviser = VCFReviser()
-    reviser.modify_variants(
-        int_vcf_gz, revised_vcf_filename, multi_cnvs_filename)
+    revised_vcf = ensure_file("./normal.revise.vcf")
+    revised_vcf_zipped = ensure_file(revised_vcf + ".gz")
+    multi_cnvs = ensure_file("./multi.cnvs.txt")
 
-    sorted_output = ensure_file("normal.revise.vcf")
-    cmd = f"cat {revised_vcf_filename} | vcf-sort > {sorted_output}"
-    ps = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT)
-    ps.communicate()[0]
-    ensure_file("normal.revise.vcf.gz")
-    check_call(["bgzip", sorted_output])
-    output_name = sorted_output + ".gz"
-    check_call(["bcftools", "index", output_name])
+    reviser.revise(int_vcf_gz, revised_vcf, multi_cnvs)
+
+    # Since the input is sorted and the script preserves
+    # their order, hence sorting output should not be necessary.
+    # sorted_output = revised_vcf + "sorted"
+    # cmd = f"cat {revised_vcf} | vcf-sort > {sorted_output}"
+    # ps = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT)
+    # ps.communicate()[0]
+    check_call(["bgzip", revised_vcf])
+    check_call(["bcftools", "index", revised_vcf_zipped])
 
 
 if __name__ == '__main__':

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
@@ -315,8 +315,7 @@ def ensure_file(filename: str) -> str:
 
 def main(int_vcf_gz):
     reviser = VCFReviser()
-    revised_vcf = ensure_file("./normal.revise.vcf")
-    revised_vcf_zipped = ensure_file(revised_vcf + ".gz")
+    revised_vcf = ensure_file("./normal.revise.vcf.gz")
     multi_cnvs = ensure_file("./multi.cnvs.txt")
 
     reviser.revise(int_vcf_gz, revised_vcf, multi_cnvs)
@@ -327,8 +326,7 @@ def main(int_vcf_gz):
     # cmd = f"cat {revised_vcf} | vcf-sort > {sorted_output}"
     # ps = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT)
     # ps.communicate()[0]
-    check_call(["bgzip", revised_vcf])
-    check_call(["bcftools", "index", revised_vcf_zipped])
+    check_call(["bcftools", "index", revised_vcf])
 
 
 if __name__ == '__main__':

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
@@ -1,0 +1,63 @@
+"""
+Remove CNVs that are improperly genotyped by depth because they are nested
+within a real CNV
+"""
+
+import gzip
+import os
+import sys
+import tempfile
+from subprocess import check_call
+
+
+VCF_DELIMITER = "\t"
+BED_DELIMITER = "\t"
+
+
+def get_columns_headers(filename):
+    with gzip.open(filename, "rt") as f:
+        for line in f:
+            if line.startswith("##"):
+                continue
+            else:
+                return line
+
+
+def get_filtered_vcf_in_bed(filename):
+    # TODO: This script uses intermediate files for multiple manipulations,
+    #  can all manipulations implemented in a single pass?
+    int_bed = "./int.bed"
+    tmp_filtered_vcf = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    with gzip.open(filename, "rt") as f, tmp_filtered_vcf as tf:
+        for line in f:
+            sline = line.split(VCF_DELIMITER)
+            if "#" in sline[0] or "DEL" in sline[4] or "DUP" in sline[4]:
+                tf.write(line)
+
+    tmp_bed = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    check_call(["svtk", "vcf2bed", tmp_filtered_vcf.name, tmp_bed.name])
+
+    with open(tmp_bed.name, "r") as f, open(int_bed, "w") as m:
+        for line in f:
+            sline = line.strip().split(BED_DELIMITER)
+            if len(sline) < 6:
+                m.write(f"{line.strip()}{BED_DELIMITER}blanksample\n")
+            else:
+                m.write(line)
+
+    check_call(["gzip", "--force", int_bed])
+    os.remove(tmp_filtered_vcf.name)
+    os.remove(tmp_bed.name)
+    return int_bed + ".gz"
+
+
+def main(input_vcf):
+    headers = get_columns_headers(input_vcf)
+    headers = headers.replace("\t", "\n")
+    with open("col.txt", "w") as f:
+        f.writelines(headers)
+    int_bed_gz = get_filtered_vcf_in_bed(input_vcf)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
@@ -3,44 +3,32 @@ Remove CNVs that are improperly genotyped by depth because they are nested
 within a real CNV
 """
 
-# TODO: most operations compress intermediate files and processed
-#  the compressed files; if there is no particular reason for compressing
-#  the intermediate files, replace them with their uncompressed versions.
-
-# TODO: many intermediate files are used, some algorithm changes are
-#  required to aggregate operations, and maybe using stdio/stdout for
-#  streaming data would be better alternatives.
-
-import copy
-import gzip
-import json
 import os
 import pybedtools
 import pysam
-import shutil
-import sys
-import tempfile
-import time
 import svtk.utils as svu
+import sys
+from pathlib import Path
 from subprocess import check_call, Popen, PIPE, STDOUT
-from typing import Iterable, Iterator, Tuple
 
 
-DELIMITER = "\t"
-VCF_DELIMITER = "\t"
-BED_DELIMITER = "\t"
+SVTYPE = "SVTYPE"
+BLANK_SAMPLES = "Blank_Samples"
 
 
-class Keys:
-    SVTYPE = "SVTYPE"
+class SVType:
     DUP = "DUP"
     DEL = "DEL"
 
 
-BLANK_SAMPLES = "Blank_Samples"
+class VariantFormatTypes:
+    # Predicted copy state
+    RD_CN = "RD_CN"
+    # Classes of evidence supporting final genotype
+    EV = "EV"
 
 
-class Filter:
+class VCFReviser:
     def __init__(self):
         self.rd_cn = {}
         self.rd_cn_idx = None
@@ -52,787 +40,165 @@ class Filter:
         rd_cn = []
         ev = []
         for k, v in variant.samples.items():
-            rd_cn.append(v.values()[self.rd_cn_idx])
-            ev.append(v.values()[self.ev_idx])
+            rd_cn.append(v[VariantFormatTypes.RD_CN])
+            ev.append(v[VariantFormatTypes.EV])
         self.rd_cn[variant.id] = rd_cn
         self.ev[variant.id] = ev
 
-    def filter_variant_types(self, records: Iterable[pysam.VariantRecord], filter_types=None, min_interval_width=1) -> Iterator[Tuple]:
-        # TODO: rename records to variants
-        for record in records:
-            sv_type = record.info[Keys.SVTYPE]
+    def filter_variant_types(self, variants, filter_types=None,
+                             min_width=5000):
+        for variant in variants:
+            sv_type = variant.info[SVTYPE]
             if filter_types and sv_type not in filter_types:
                 continue
-            if record.stop - record.start < min_interval_width:
+            if variant.stop - variant.start < min_width:
                 continue
 
-            self._update_rd_cn_ev(record)
+            self._update_rd_cn_ev(variant)
 
-            samples = ','.join(svu.get_called_samples(record))
+            samples = ','.join(svu.get_called_samples(variant))
             if len(samples) == 0:
                 samples = BLANK_SAMPLES
-            yield record.contig, record.start, record.stop, record.id, sv_type, samples
 
-    def get_overlapping_variants(self, int_vcf_gz):
-        overlapping_variants_ids = set()
+            yield variant.contig, variant.start, variant.stop, \
+                variant.id, sv_type, samples
+
+    @staticmethod
+    def get_wider(f):
+        if int(f[2]) - int(f[1]) >= int(f[8]) - int(f[7]):
+            return f[0:6], f[6:12]
+        else:
+            return f[6:12], f[0:6]
+
+    @staticmethod
+    def get_coverage(wider, narrower):
+        n_start = int(narrower[1])
+        n_stop = int(narrower[2])
+        w_start = int(wider[1])
+        w_stop = int(wider[2])
+
+        coverage = 0
+        if w_start <= n_stop and n_start <= w_stop:
+            intersection_size = min(n_stop, w_stop) - max(n_start, w_start)
+            coverage = intersection_size / (n_stop - n_start)
+        return coverage
+
+    def get_geno_normal_revise(self, int_vcf_gz):
         overlap_test_text = {}
         with pysam.VariantFile(int_vcf_gz, "r") as f:
             header = f.header
-            # print(header)
-            # print("\n\n")
-            # print(dir(header))
-            # print("\n\n")
-            # print(len(header.samples))
-            # print(dir(header.samples))
             i = -1
             for sample in header.samples:
                 i += 1
                 self.samples[sample] = i
-                # SAMPLES.append(sample)
-            # print("\n\n----------")
-            # print(dir(header.formats))
-            formats = header.formats.keys()
 
-            # TODO: this should be re-checked with every line
-            #  since the lines can differ on this. This part
-            #  should be moved to where the variants are traversed.
-            self.rd_cn_idx = formats.index("RD_CN")
-            self.ev_idx = formats.index("EV")
-            # print(rd_cn_idx)
-            # print(header.formats.keys())
-            # print(header.formats.values())
-            # exit()
-            dels_and_dups = pybedtools.BedTool(self.filter_variant_types(f.fetch(), [Keys.DEL, Keys.DUP], 5000)).saveas()
-            overlapping_variants = dels_and_dups.intersect(dels_and_dups, wa=True, wb=True)
+            dels_and_dups = pybedtools.BedTool(
+                self.filter_variant_types(
+                    f.fetch(), [SVType.DEL, SVType.DUP], 5000)).saveas()
+
+            overlapping_variants = dels_and_dups.intersect(
+                dels_and_dups, wa=True, wb=True)
+
             for interval in overlapping_variants.intervals:
                 # IDs are identical, hence it is the overlap
                 # of an interval with itself.
-                var_a_id = interval.fields[3]
-                var_b_id = interval.fields[9]
-                if var_a_id == var_b_id:
+                if interval.fields[3] == interval.fields[9]:
                     continue
 
                 # Variant types are identical.
                 if interval.fields[4] == interval.fields[10]:
                     continue
 
-                f = interval.fields
+                wider, narrower = self.get_wider(interval.fields)
+                if wider[5] == BLANK_SAMPLES:
+                    continue
                 non_common_samples = []
-                if int(f[2]) - int(f[1]) >= int(f[8]) - int(f[7]):
-                    if f[5] == BLANK_SAMPLES:
-                        continue
-                    overlapping_variants_ids.add(var_a_id)
-                    overlapping_variants_ids.add(var_b_id)
-                    wider_var_id = f[3]
-                    wider_var_interval = [int(f[1]), int(f[2])]
-                    wider_var_type = f[4]
-                    narrower_var_id = f[9]
-                    narrower_var_interval = [int(f[7]), int(f[8])]
-                    for x in interval.fields[5].split(","):
-                        if x not in interval.fields[11].split(","):
-                            non_common_samples.append(x)
-                else:
-                    if f[11] == BLANK_SAMPLES:
-                        continue
-                    overlapping_variants_ids.add(var_a_id)
-                    overlapping_variants_ids.add(var_b_id)
-                    narrower_var_id = f[3]
-                    narrower_var_interval = [int(f[1]), int(f[2])]
-                    wider_var_id = f[9]
-                    wider_var_interval = [int(f[7]), int(f[8])]
-                    wider_var_type = f[10]
-                    for x in interval.fields[11].split(","):
-                        if x not in interval.fields[5].split(","):
-                            non_common_samples.append(x)
+                for x in wider[5].split(","):
+                    if x not in narrower[5].split(","):
+                        non_common_samples.append(x)
 
-                ss = narrower_var_interval[0]
-                se = narrower_var_interval[1]
-                ls = wider_var_interval[0]
-                le = wider_var_interval[1]
-
-                coverage_percentage = 0
-                if ls <= se and ss <= le:
-                    intersection_size = min(se, le) - max(ss, ls)
-                    coverage_percentage = intersection_size / (se-ss)
-
-                if coverage_percentage >= 0.5:
+                coverage = self.get_coverage(wider, narrower)
+                if coverage >= 0.5:
                     for x in non_common_samples:
-                        overlap_test_text[f"{narrower_var_id}@{x}"] = [f"{narrower_var_id}@{x}", wider_var_id, wider_var_type]
+                        overlap_test_text[f"{narrower[3]}@{x}"] = \
+                            [f"{narrower[3]}@{x}", wider[3], wider[4]]
 
-        geno_normal_revise_txt = []
         geno_normal_revise_dict = {}
         for k, v in overlap_test_text.items():
             var_id = k.split("@")[0]
             sample_index = self.samples[k.split("@")[1]]
-            if v[2] == "DUP" and self.rd_cn[var_id][sample_index] == 2 and self.rd_cn[v[1]][sample_index] == 3:
-                geno_normal_revise_txt.append(v[0].replace("@", "\t") + "\t" + "1" + "\n")
+            new_val = None
+            if v[2] == SVType.DUP and \
+                    self.rd_cn[var_id][sample_index] == 2 and \
+                    self.rd_cn[v[1]][sample_index] == 3:
+                new_val = 1
+            elif v[2] == SVType.DEL and \
+                    self.rd_cn[var_id][sample_index] == 2 \
+                    and self.rd_cn[v[1]][sample_index] == 1:
+                new_val = 3
+
+            if new_val:
                 if var_id not in geno_normal_revise_dict:
                     geno_normal_revise_dict[var_id] = {}
-                geno_normal_revise_dict[var_id][v[0].split("@")[1]] = 1
-            elif v[2] == "DEL" and self.rd_cn[var_id][sample_index] == 2 and self.rd_cn[v[1]][sample_index] == 1:
-                geno_normal_revise_txt.append(v[0].replace("@", "\t") + "\t" + "3" + "\n")
-                if var_id not in geno_normal_revise_dict:
-                    geno_normal_revise_dict[var_id] = {}
-                geno_normal_revise_dict[var_id][v[0].split("@")[1]] = 3
-
-        return overlapping_variants_ids, overlap_test_text, geno_normal_revise_txt, geno_normal_revise_dict, header
-
-    def modify_variants(self, int_vcf_gz, geno_normal_revise_dict, header):
-        output_vcf = get_tmp_file(get_working_dir())
-        multi_cnvs_txt = get_tmp_file(get_working_dir())
-        with pysam.VariantFile(int_vcf_gz, "r") as f_in, pysam.VariantFile(output_vcf.name, "w", header=header) as f_out, multi_cnvs_txt as multi_cnvs_f:
-            variants = f_in.fetch()
-            for variant in variants:
-                # TODO: minimize dict access here.
-                if variant.id in geno_normal_revise_dict:
-                    for sample_id in geno_normal_revise_dict[variant.id]:
-                        original_sample = variant.samples[sample_id]
-                        original_sample.update({"GT": (0, 1)})
-                        original_sample.update({"GQ": original_sample["RD_GQ"]})
-                        # TODO: double-check above with shell script & Harison.
-
-                if variant.stop - variant.start >= 1000:
-                    if variant.info[Keys.SVTYPE] == Keys.DEL or variant.info[Keys.SVTYPE] == Keys.DUP:
-                        is_del = variant.info[Keys.SVTYPE] == Keys.DEL
-                        for k, v in variant.samples.items():
-                            rd_cn_val = v.values()[self.rd_cn_idx]
-                            if (is_del and rd_cn_val > 3) or (not is_del and (rd_cn_val < 1 or rd_cn_val > 4)):
-                                multi_cnvs_f.write(variant.id + "\n")
-                                break
-
-                f_out.write(variant)
-
-        # TODO: redo the following in a better way.
-        sorted_output = output_vcf.name + "sorted"
-        cmd = f"cat {output_vcf.name} | vcf-sort > {sorted_output}"
-        ps = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT)
-        ps.communicate()[0]
-        check_call(["bgzip", sorted_output])
-        output_name = sorted_output + ".gz"
-        check_call(["bcftools", "index", output_name])
-        return output_name, multi_cnvs_txt.name
-
-
-def get_columns_headers(filename):
-    with gzip.open(filename, "rt") as f:
-        for line in f:
-            if line.startswith("##"):
-                continue
-            else:
-                return line
-
-
-def get_working_dir(base_dir="."):
-    while True:
-        working_dir = os.path.join(base_dir, "tmp_" + str(int(time.time())))
-        if not os.path.isdir(working_dir):
-            os.mkdir(working_dir)
-            return working_dir
-
-
-def get_tmp_file(working_dir):
-    return tempfile.NamedTemporaryFile(dir=working_dir, mode="w", delete=False)
-
-
-def filter_variant_types(records: Iterable[pysam.VariantRecord], filter_types=None, min_interval_width=1) -> Iterator[Tuple]:
-    for record in records:
-        sv_type = record.info[Keys.SVTYPE]
-        if filter_types and sv_type not in filter_types:
-            continue
-        if record.stop - record.start < min_interval_width:
-            continue
-
-        rd_cn = []
-        for k, v in record.samples.items():
-            print("\n-----------")
-            print(f"{k}\t{v}")
-            print(v.values())
-            print(rd_cn_idx)
-            print(v.values()[rd_cn_idx])
-            print(dir(v))
-            exit()
-        exit()
-
-        samples = ','.join(svu.get_called_samples(record))
-        if len(samples) == 0:
-            samples = BLANK_SAMPLES
-
-
-        yield record.contig, record.start, record.stop, record.id, sv_type, samples
-
-RD_CN = {}
-rd_cn_idx = None
-SAMPLES = []
-
-def get_overlapping_variants(int_vcf_gz):
-    overlapping_variants_ids = set()
-    overlap_test_text = {}
-    with pysam.VariantFile(int_vcf_gz, "r") as f:
-        header = f.header
-        # print(header)
-        # print("\n\n")
-        # print(dir(header))
-        # print("\n\n")
-        # print(len(header.samples))
-        # print(dir(header.samples))
-        for sample in header.samples:
-            SAMPLES.append(sample)
-        # print("\n\n----------")
-        # print(dir(header.formats))
-        formats = header.formats.keys()
-
-        rd_cn_idx = formats.index("RD_CN")
-        # print(rd_cn_idx)
-        # print(header.formats.keys())
-        # print(header.formats.values())
-        # exit()
-        dels_and_dups = pybedtools.BedTool(filter_variant_types(f.fetch(), [Keys.DEL, Keys.DUP], 5000)).saveas()
-        overlapping_variants = dels_and_dups.intersect(dels_and_dups, wa=True, wb=True)
-        for interval in overlapping_variants.intervals:
-            # IDs are identical, hence it is the overlap
-            # of an interval with itself.
-            var_a_id = interval.fields[3]
-            var_b_id = interval.fields[9]
-            if var_a_id == var_b_id:
-                continue
-
-            # Variant types are identical.
-            if interval.fields[4] == interval.fields[10]:
-                continue
-
-            f = interval.fields
-            non_common_samples = []
-            if int(f[2]) - int(f[1]) >= int(f[8]) - int(f[7]):
-                if f[5] == BLANK_SAMPLES:
-                    continue
-                overlapping_variants_ids.add(var_a_id)
-                overlapping_variants_ids.add(var_b_id)
-                wider_var_id = f[3]
-                wider_var_interval = [int(f[1]), int(f[2])]
-                wider_var_type = f[4]
-                narrower_var_id = f[9]
-                narrower_var_interval = [int(f[7]), int(f[8])]
-                for x in interval.fields[5].split(","):
-                    if x not in interval.fields[11].split(","):
-                        non_common_samples.append(x)
-            else:
-                if f[11] == BLANK_SAMPLES:
-                    continue
-                overlapping_variants_ids.add(var_a_id)
-                overlapping_variants_ids.add(var_b_id)
-                narrower_var_id = f[3]
-                narrower_var_interval = [int(f[1]), int(f[2])]
-                wider_var_id = f[9]
-                wider_var_interval = [int(f[7]), int(f[8])]
-                wider_var_type = f[10]
-                for x in interval.fields[11].split(","):
-                    if x not in interval.fields[5].split(","):
-                        non_common_samples.append(x)
-
-            ss = narrower_var_interval[0]
-            se = narrower_var_interval[1]
-            ls = wider_var_interval[0]
-            le = wider_var_interval[1]
-
-            coverage_percentage = 0
-            if ls <= se and ss <= le:
-                intersection_size = min(se, le) - max(ss, ls)
-                coverage_percentage = intersection_size / (se-ss)
-
-            if coverage_percentage >= 0.5:
-                for x in non_common_samples:
-                    overlap_test_text[f"{narrower_var_id}@{x}"] = [f"{narrower_var_id}@{x}", wider_var_id, wider_var_type]
-
-    return overlapping_variants_ids, overlap_test_text
-
-
-def get_depth_based_copy_number_variant_2(vcf_gz, overlapping_variants_id):
-    pass
-
-
-def get_filtered_vcf_in_bed(working_dir, int_vcf_gz):
-    # TODO: This script uses intermediate files for multiple manipulations,
-    #  can all manipulations implemented in a single pass?
-    int_bed = get_tmp_file(working_dir)
-    filtered_vcf = get_tmp_file(working_dir)
-    with gzip.open(int_vcf_gz, "rt") as f, filtered_vcf as tf:
-        for line in f:
-            columns = line.split(VCF_DELIMITER)
-            if "#" in columns[0] or "DEL" in columns[4] or "DUP" in columns[4]:
-                tf.write(line)
-
-    tmp_bed = get_tmp_file(working_dir)
-    check_call(["svtk", "vcf2bed", filtered_vcf.name, tmp_bed.name])
-
-    with open(tmp_bed.name, "r") as f, open(int_bed.name, "w") as m:
-        for line in f:
-            columns = line.strip().split(DELIMITER)
-            if len(columns) < 6:
-                # TODO: seems like we can ignore writing this line
-                #  as it is skipped downstream.
-                m.write(f"{line.strip()}{DELIMITER}blanksample\n")
-            else:
-                m.write(line)
-
-    check_call(["gzip", "--force", int_bed.name])
-    os.remove(filtered_vcf.name)
-    os.remove(tmp_bed.name)
-    return int_bed.name + ".gz"
-
-
-def get_normal_overlap(int_bed_gz):
-    """
-    list of potential overlaps with a normal copy state variant
-    (>5kb variants require depth but nested events could be missed;
-    i.e a duplication with a nest deletion will have a normal copy
-    state for the deletion).
-
-    Flip bed intersect so largest is CNV is always first.
-    """
-    tmp = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    tmp2 = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    tmp3 = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    normaloverlap = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with gzip.open(int_bed_gz, "rt") as f, tmp as t:
-        for line in f:
-            # TODO: maybe skip writing header line in the first place.
-            if line.startswith("#"):
-                continue
-            sline = line.split(DELIMITER)
-            if int(sline[2]) - int(sline[1]) >= 5000:
-                t.write(line)
-
-    check_call(["bedtools", "intersect", "-wa", "-wb", "-a", tmp.name, "-b", tmp.name], stdout=tmp2)
-
-    with open(tmp2.name, "r") as f, tmp3 as t:
-        for line in f:
-            line = line.strip()
-            s = line.strip().split(BED_DELIMITER)
-            if s[3] != s[9] and int(s[2]) - int(s[1]) >= int(s[8]) - int(s[7]) and s[4] != s[10]:
-                if s[5] == "blanksample":
-                    continue
-                t.write(line + "\n")
-            elif s[3] != s[9] and s[4] != s[10]:
-                x = [s[6], s[7], s[8], s[9], s[10], s[11], s[0], s[1], s[2], s[3], s[4], s[5]]
-                if x[5] == "blanksample":
-                    continue
-                t.write(BED_DELIMITER.join(x) + "\n")
-
-    check_call(["sort", "-u", tmp3.name], stdout=normaloverlap)
-    os.remove(tmp.name)
-    os.remove(tmp2.name)
-    os.remove(tmp3.name)
-    return normaloverlap.name
-
-
-def get_depth_based_copy_number_variant(vcf_gz, normaloverlap):
-    # A set, implemented as a hashtable, so lookup
-    # should be O(log n) or O(1) depending on how it is implemented.
-    ids = set()
-    with open(normaloverlap) as f:
-        for line in f:
-            sline = line.strip().split(BED_DELIMITER)
-            ids.add(sline[3])
-            ids.add(sline[9])
-
-    # keep only those lines in vcf whose ID is in the ids set.
-    tmp = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with gzip.open(vcf_gz, "rt") as f, tmp as t:
-        for line in f:
-            if line.startswith("#"):
-                t.write(line)
-            else:
-                sline = line.split(VCF_DELIMITER)
-                if sline[2] in ids:
-                    t.write(line)
-
-    tmp2 = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with open(tmp.name) as t1, tmp2 as t2:
-        for line in t1:
-            sline = line.strip().split(VCF_DELIMITER)
-            if "#" not in sline[0]:
-                sline[0] = sline[2]
-            if "#" in sline[0] or sline[4] == "<DEL>" or sline[4] == "<DUP>":
-                t2.write(VCF_DELIMITER.join(sline) + "\n")
-
-    tmp3 = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    tmp3.close()
-    format_id = "RD_CN"
-    check_call(["vcftools", "--vcf", tmp2.name, "--extract-FORMAT-info", format_id, "--out", tmp3.name])
-    vcftools_output = f"{tmp3.name}.{format_id}.FORMAT"
-
-    c = 0
-    header = []
-    tmp4 = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with open(vcftools_output, "r") as f, tmp4 as t:
-        for line in f:
-            sline = line.strip().split(VCF_DELIMITER)
-            c += 1
-            if c == 1:
-                for i in range(2, len(sline)):
-                    header.append(sline[i])
-            else:
-                for i in range(2, len(sline)):
-                    t.write(f"{sline[0]}@{header[i-2]}\t{sline[i]}\n")
-
-    tmp5 = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    check_call(["sort", "-k1,1", tmp4.name], stdout=tmp5)
-    check_call(["gzip", tmp5.name])
-    return tmp5.name + ".gz"
-
-
-def get_evidence_supporting_each_normal_overlapping_variant(vcf_gz, normaloverlap):
-    # Probably the only difference between this method and the previous one
-    # is the VCF filter they use. another diff is at creating tmp2,
-    # double-check the above method, it seems that method is doing an
-    # unnecessary additional step.
-    ids = set()
-    with open(normaloverlap) as f:
-        for line in f:
-            sline = line.strip().split(BED_DELIMITER)
-            ids.add(sline[3])
-            ids.add(sline[9])
-
-    # keep only those lines in vcf whose ID is in the ids set.
-    tmp = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with gzip.open(vcf_gz, "rt") as f, tmp as t:
-        for line in f:
-            if line.startswith("#"):
-                t.write(line)
-            else:
-                sline = line.split(VCF_DELIMITER)
-                if sline[2] in ids:
-                    t.write(line)
-
-    tmp2 = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with open(tmp.name) as t1, tmp2 as t2:
-        for line in t1:
-            sline = line.strip().split(VCF_DELIMITER)
-            if "#" not in sline[0]:
-                sline[0] = sline[2]
-            t2.write(VCF_DELIMITER.join(sline) + "\n")
-
-    tmp3 = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    tmp3.close()
-    format_id = "EV"
-    check_call(["vcftools", "--vcf", tmp2.name, "--extract-FORMAT-info", format_id, "--out", tmp3.name])
-    vcftools_output = f"{tmp3.name}.{format_id}.FORMAT"
-
-    c = 0
-    header = []
-    tmp4 = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with open(vcftools_output, "r") as f, tmp4 as t:
-        for line in f:
-            sline = line.strip().split(VCF_DELIMITER)
-            c += 1
-            if c == 1:
-                for i in range(2, len(sline)):
-                    header.append(sline[i])
-            else:
-                for i in range(2, len(sline)):
-                    t.write(f"{sline[0]}@{header[i-2]}\t{sline[i]}\n")
-
-    tmp5 = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    check_call(["sort", "-k1,1", tmp4.name], stdout=tmp5)
-    check_call(["gzip", tmp5.name])
-    return tmp5.name + ".gz"
-
-
-def check_if_nested_is_incorrectly_classified_as_normal(normaloverlap):
-    overlap_test_txt = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with open(normaloverlap, "r") as f, overlap_test_txt as o:
-        for line in f:
-            line = line.strip()
-            line = line.replace(" ", "\t")
-            sline = line.split("\t")
-            # lfile.write("\t".join(sline[0:6]) + "\n") # maybe 5
-            # sfile.write("\t".join(sline[6:12]) + "\n") # maybe 11
-
-            ss = int(sline[7])
-            se = int(sline[8])
-            ls = int(sline[1])
-            le = int(sline[2])
-
-            coverage_percentage = 0
-            if ls <= se and ss <= le:
-                intersection_size = min(se, le) - max(ss, ls)
-                coverage_percentage = intersection_size / (se-ss)
-
-            alist = []
-            if coverage_percentage >= 0.5:
-                fgrep_part_a = sline[11].split(",")
-                smallid = sline[9]
-                # wrong variable name
-                large_ids = sline[5].split(",")
-                for x in large_ids:
-                    alist.append(f"{smallid}@{x}\t{sline[3]}@{x}\t{sline[4]}")
-
-                not_match_count = 0
-                # not sure if this check is what it was intended.
-                for x in alist:
-                    for y in fgrep_part_a:
-                        if y in x:
-                            break
-                    else:
-                        o.write(x + "\n")
-    return overlap_test_txt.name
-
-
-def get_variants_to_be_revised_from_normal_copy_state_into_cnv(
-        overlap_test_txt, rd_cn_normalcheck_format_gz,
-        ev_normalcheck_format_gz):
-    data = {}
-    with open(overlap_test_txt) as f:
-        for line in f:
-            sline = line.strip().split("\t")
-            data[sline[0]] = [sline[0], sline[1], sline[2]]
-
-    rd_cn_dict = {}
-    with gzip.open(rd_cn_normalcheck_format_gz, "rt") as f:
-        for line in f:
-            sline = line.strip().split("\t")
-            if sline[0] in data:
-                data[sline[0]].append(int(sline[1]))
-            rd_cn_dict[sline[0]] = int(sline[1])
-
-    with gzip.open(ev_normalcheck_format_gz, "rt") as f:
-        for line in f:
-            sline = line.strip().split("\t")
-            if sline[0] in data:
-                data[sline[0]].append(sline[1])
-
-    joined = []
-    output = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with output as t:
-        for k, v in data.items():
-            if v[0] in rd_cn_dict:
-                joined.append([v[0], v[1], v[2], v[3], v[4], rd_cn_dict[v[1]]])
-                if v[2] == "DUP" and v[3] == 2 and rd_cn_dict[v[1]] == 3:
-                    aaa = v[0].replace("@", "\t") + "\t" + "1" + "\n"
-                    t.write(aaa)
-                elif v[2] == "DEL" and v[3] == 2 and rd_cn_dict[v[1]] == 1:
-                    t.write(v[0].replace("@", "\t") + "\t" + "3" + "\n")
-
-    return output.name
-
-
-def get_subset_vcf(geno_normal_revise_txt, int_vcf_gz):
-    ids = set()
-    with open(geno_normal_revise_txt, "r") as f:
-        for line in f:
-            ids.add(line.strip().split("\t")[0])
-
-    output = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with gzip.open(int_vcf_gz, "rt") as f, output as o:
-        for line in f:
-            if line.startswith("#"):
-                continue
-            id = line.split("\t")[2]
-            if id in ids:
-                o.write(line)
-
-    return output.name
-
-
-def pull_out_and_revise_vcf_line_that_needs_to_be_edited(geno_normal_revise_txt, subset_vcf, col_txt, cols):
-    output = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    variants_dict = {}
-    col_headers = {}
-    for x in range(len(cols)):
-        col_headers[cols[x][0]] = x
-
-    with open(subset_vcf) as f:
-        for line in f:
-            sline = line.strip().split("\t")
-            variants_dict[sline[2]] = sline
-
-    ids = []
-    with open(geno_normal_revise_txt) as f:
-        for line in f:
-            sline = line.strip().split("\t")
-            ids.append(sline)
-
-    for _id in ids:  # variant, v in ids.items():
-        variant = _id[0]
-        # copy the dict to its state is reset at every iteration.
-        tmp_cols = copy.deepcopy(cols)
-
-        sline_txt = variants_dict[variant]
-        for x in range(len(sline_txt)):
-            tmp_cols[x].extend(sline_txt[x].split(":"))
-
-        i = col_headers[_id[1]]
-        tmp_cols[i][1] = "0/1"
-        tmp_cols[i][2] = tmp_cols[i][4]  # ??? should not be the value in the third column of _id? also are you sure to modify the 2nd item and not the one related to RD_CN or EV?
-
-        for i in range(len(sline_txt)):
-            if i < 9:
-                continue
-            sline_txt[i] = ":".join(tmp_cols[i][1:])
-
-    with output as o:
-        sorted_keys = list(variants_dict.keys())
-        sorted_keys.sort()
-        for key in sorted_keys:
-            o.write("\t".join(variants_dict[key]) + "\n")
-    return output.name
-
-
-def modify_vcf(int_vcf_gz, normal_revise_vcf_lines_txt):
-    output = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with gzip.open(int_vcf_gz, "rt") as in_file, open(output.name, "wt") as out_file:
-        for l in in_file:
-            if not l.startswith("#"):
-                sl = l.strip().split("\t")
-                variant_id = sl[2]
-                with open(normal_revise_vcf_lines_txt) as m_file:
-                    for l2 in m_file:
-                        sl2 = l2.strip().split("\t")
-                        if sl2[2] == variant_id:
-                            sl = sl2
-                            break
-                l = "\t".join(sl) + "\n"
-            out_file.write(l)
-
-    sorted_output = output.name + "sorted"
-    cmd = f"cat {output.name} | vcf-sort > {sorted_output}"
-    ps = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT)
-    ps.communicate()[0]
-    check_call(["bgzip", sorted_output])
-    output_name = sorted_output + ".gz"
-    check_call(["bcftools", "index", output_name])
-    return output_name
-
-
-def get_copystate_per_variant(normal_revise_vcf_gz):
-    tmp = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with gzip.open(normal_revise_vcf_gz, "rt") as f, tmp as t:
-        for l in f:
-            if l.startswith("#"):
-                t.write(l)
-                continue
-            sline = l.strip().split("\t")
-            sline[0] = sline[2]
-            t.write("\t".join(sline) + "\n")
-
-    format_id = "RD_CN"
-    output = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    check_call(["vcftools", "--vcf", tmp.name, "--extract-FORMAT-info", format_id, "--out", output.name])
-    output_name = output.name + "." + format_id + ".FORMAT"
-    check_call(["gzip", output_name])
-    return output_name + ".gz"
-
-
-def get_copystate_per_variant_2(copystate_rd_cn_format_gz):
-    output = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    output_data = set()
-    with gzip.open(copystate_rd_cn_format_gz, "rt") as f, output as o:
-        c = 0
-        for l in f:
-            c += 1
-            if c <= 1:
-                continue
-            sl = l.strip().split("\t")
-            for i in range(2, len(sl)):
-                x = f"{sl[0]}\t{sl[i]}"
-                if x not in output_data:
-                    output_data.add(x)
-
-        for x in output_data:
-            o.write(x + "\n")
-    check_call(["gzip", output.name])
-    return output.name + ".gz"
-
-
-def find_multi_allelic_for_del(copystate_per_variant_txt_gz, int_bed_gz):
-    variants = set()
-    with gzip.open(copystate_per_variant_txt_gz, "rt") as f:
-        for l in f:
-            sl = l.strip().split("\t")
-            if sl[1] != "." and int(sl[1]) > 3:
-                variants.add(sl[0])
-
-    output = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    with gzip.open(int_bed_gz, "rt") as f, output as o:
-        for l in f:
-            sl = l.strip().split("\t")
-            if sl[3] in variants:
-                if sl[4] == "DEL" and int(sl[2]) - int(sl[1]) >= 1000:
-                    o.write(sl[3] + "\n")
-
-    return output.name
-
-
-def find_multi_allelic_for_dup(copystate_per_variant_txt_gz, int_bed_gz, multi_cnvs_txt):
-    variants = set()
-    with gzip.open(copystate_per_variant_txt_gz, "rt") as f:
-        for l in f:
-            sl = l.strip().split("\t")
-            if sl[1] != "." and (int(sl[1]) < 1 or int(sl[1]) > 4):
-                variants.add(sl[0])
-
-    with gzip.open(int_bed_gz, "rt") as f, open(multi_cnvs_txt, "a") as o:
-        for l in f:
-            sl = l.strip().split("\t")
-            if sl[3] in variants:
-                if sl[4] == "DUP" and int(sl[2]) - int(sl[1]) >= 1000:
-                    o.write(sl[3] + "\n")
-
-    return multi_cnvs_txt
+                geno_normal_revise_dict[var_id][v[0].split("@")[1]] = new_val
+
+        return geno_normal_revise_dict
+
+    def modify_variants(self, int_vcf_gz, revised_vcf, multi_cnvs):
+        geno_normal_revise_dict = self.get_geno_normal_revise(int_vcf_gz)
+
+        with pysam.VariantFile(int_vcf_gz, "r") as f_in:
+            header = f_in.header
+
+            with pysam.VariantFile(revised_vcf, "w", header=header) as f_out, \
+                    open(multi_cnvs, "w") as multi_cnvs_f:
+                variants = f_in.fetch()
+                for variant in variants:
+                    if variant.id in geno_normal_revise_dict:
+                        for sample_id in geno_normal_revise_dict[variant.id]:
+                            o = variant.samples[sample_id]
+                            o.update({"GT": (0, 1)})
+                            o.update({"GQ": o["RD_GQ"]})
+
+                    if variant.stop - variant.start >= 1000:
+                        if variant.info[SVTYPE] in [SVType.DEL, SVType.DUP]:
+                            is_del = variant.info[SVTYPE] == SVType.DEL
+                            for k, v in variant.samples.items():
+                                rd_cn = v[VariantFormatTypes.RD_CN]
+                                if not rd_cn:
+                                    continue
+                                if (is_del and rd_cn > 3) or \
+                                   (not is_del and (rd_cn < 1 or rd_cn > 4)):
+                                    multi_cnvs_f.write(variant.id + "\n")
+                                    break
+
+                    f_out.write(variant)
+
+
+def ensure_file(filename):
+    filename = os.path.join(".", filename)
+    filename = Path(filename)
+    if filename.exists():
+        os.remove(filename)
+    return filename.name
 
 
 def main(int_vcf_gz):
-    working_dir = get_working_dir()
+    revised_vcf_filename = ensure_file("normal.revise.unsorted.vcf")
+    multi_cnvs_filename = ensure_file("multi.cnvs.txt")
 
-    f = Filter()
-    overlapping_variants_ids, overlap_test_text, geno_normal_revise_txt, geno_normal_revise_dict, header = f.get_overlapping_variants(int_vcf_gz)
-    new_normal_revise_vcf_gz, multi_cnvs_txt = f.modify_variants(int_vcf_gz, geno_normal_revise_dict, header)
-    shutil.move(new_normal_revise_vcf_gz, "./normal.revise.vcf.gz")
-    shutil.move(new_normal_revise_vcf_gz + ".csi", "./normal.revise.vcf.gz.csi")
-    shutil.move(multi_cnvs_txt, "./multi.cnvs.txt")
-    exit()
+    reviser = VCFReviser()
+    reviser.modify_variants(
+        int_vcf_gz, revised_vcf_filename, multi_cnvs_filename)
 
-
-
-    headers = get_columns_headers(int_vcf_gz)
-    headers = headers.strip().split("\t")
-    col_txt = "col.txt"
-    cols = {}
-    with open(col_txt, "w") as f:
-        for x in range(len(headers)):
-            f.write(f"{x}\t{headers[x]}\n")
-            cols[x] = [headers[x]]
-    int_bed_gz = get_filtered_vcf_in_bed(working_dir, int_vcf_gz)
-    normaloverlap_txt = get_normal_overlap(int_bed_gz)
-    rd_cn_normalcheck_FORMAT_gz = get_depth_based_copy_number_variant(int_vcf_gz, normaloverlap_txt)
-    ev_normalcheck_format_gz = get_evidence_supporting_each_normal_overlapping_variant(int_vcf_gz, normaloverlap_txt)
-    overlap_test_txt = check_if_nested_is_incorrectly_classified_as_normal(normaloverlap_txt)
-    geno_normal_revise_txt = get_variants_to_be_revised_from_normal_copy_state_into_cnv(overlap_test_txt, rd_cn_normalcheck_FORMAT_gz, ev_normalcheck_format_gz)
-    subset_vcf = get_subset_vcf(geno_normal_revise_txt, int_vcf_gz)
-    normal_revise_vcf_lines_txt = pull_out_and_revise_vcf_line_that_needs_to_be_edited(geno_normal_revise_txt, subset_vcf, col_txt, cols)
-    normal_revise_vcf_gz = modify_vcf(int_vcf_gz, normal_revise_vcf_lines_txt)
-    copystate_rd_cn_format_gz = get_copystate_per_variant(normal_revise_vcf_gz)
-    copystate_per_variant_txt_gz = get_copystate_per_variant_2(copystate_rd_cn_format_gz)
-    multi_cnvs_txt = find_multi_allelic_for_del(copystate_per_variant_txt_gz, int_bed_gz)
-    multi_cnvs_txt = find_multi_allelic_for_dup(copystate_per_variant_txt_gz, int_bed_gz, multi_cnvs_txt)
-
-    shutil.move(int_bed_gz, "/Users/vahid/Desktop/mine/int_bed.gz")
-    shutil.move(normaloverlap_txt, "/Users/vahid/Desktop/mine/normaloverlap")
-    shutil.move(rd_cn_normalcheck_FORMAT_gz, "/Users/vahid/Desktop/mine/rd_cn_normalcheck_FORMAT.gz")
-    shutil.move(ev_normalcheck_format_gz, "/Users/vahid/Desktop/mine/ev_normalcheck_format.gz")
-    shutil.move(overlap_test_txt, "/Users/vahid/Desktop/mine/overlap_test_txt")
-    shutil.move(geno_normal_revise_txt, "/Users/vahid/Desktop/mine/geno_normal_revise_txt")
-    shutil.move(subset_vcf, "/Users/vahid/Desktop/mine/subset_vcf")
-    shutil.move(normal_revise_vcf_lines_txt, "/Users/vahid/Desktop/mine/normal_revise_vcf_lines_txt")
-    shutil.copy(normal_revise_vcf_gz, "/Users/vahid/Desktop/mine/normal_revise_vcf.gz")
-    shutil.move(copystate_rd_cn_format_gz, "/Users/vahid/Desktop/mine/copystate_rd_cn_format.gz")
-    shutil.move(copystate_per_variant_txt_gz, "/Users/vahid/Desktop/mine/copystate_per_variant_txt.gz")
-    shutil.copy(multi_cnvs_txt, "/Users/vahid/Desktop/mine/multi_cnvs_txt")
-
-    assert os.path.getsize(multi_cnvs_txt) == 5854
-    assert os.path.getsize(normal_revise_vcf_gz) == 5814655
-
-    return multi_cnvs_txt, normal_revise_vcf_gz, normal_revise_vcf_gz + "csi"
+    sorted_output = ensure_file("normal.revise.vcf")
+    cmd = f"cat {revised_vcf_filename} | vcf-sort > {sorted_output}"
+    ps = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT)
+    ps.communicate()[0]
+    ensure_file("normal.revise.vcf.gz")
+    check_call(["bgzip", sorted_output])
+    output_name = sorted_output + ".gz"
+    check_call(["bcftools", "index", output_name])
 
 
 if __name__ == '__main__':

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
@@ -405,6 +405,27 @@ def get_copystate_per_variant(normal_revise_vcf_gz):
     return output_name + ".gz"
 
 
+def get_copystate_per_variant_2(copystate_rd_cn_format_gz):
+    output = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    output_data = set()
+    with gzip.open(copystate_rd_cn_format_gz, "rt") as f, output as o:
+        c = 0
+        for l in f:
+            c += 1
+            if c <= 1:
+                continue
+            sl = l.strip().split("\t")
+            for i in range(3, len(sl)):
+                x = f"{sl[0]}\t{sl[i]}"
+                if x not in output_data:
+                    output_data.add(x)
+
+        for x in output_data:
+            o.write(x + "\n")
+    check_call(["gzip", output.name])
+    return output.name + ".gz"
+
+
 def main(int_vcf_gz):
     headers = get_columns_headers(int_vcf_gz)
     headers = headers.strip().split("\t")
@@ -424,7 +445,8 @@ def main(int_vcf_gz):
     normal_revise_vcf_lines_txt = pull_out_and_revise_vcf_line_that_needs_to_be_edited(geno_normal_revise_txt, subset_vcf, col_txt, cols)
     normal_revise_vcf_gz = modify_vcf(int_vcf_gz, normal_revise_vcf_lines_txt)
     copystate_rd_cn_format_gz = get_copystate_per_variant(normal_revise_vcf_gz)
-    print(copystate_rd_cn_format_gz)
+    copystate_per_variant_txt_gz = get_copystate_per_variant_2(copystate_rd_cn_format_gz)
+    print(copystate_per_variant_txt_gz)
 
 
 if __name__ == '__main__':

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
@@ -280,7 +280,7 @@ class VCFReviser:
                         is_del = variant.info[SVTYPE] == SVType.DEL
                         for k, v in variant.samples.items():
                             rd_cn = v[VariantFormatTypes.RD_CN]
-                            if not rd_cn:
+                            if rd_cn is None:
                                 continue
                             if (is_del and rd_cn > 3) or \
                                     (not is_del and (rd_cn < 1 or rd_cn > 4)):

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.py
@@ -14,6 +14,7 @@ within a real CNV
 import copy
 import gzip
 import os
+import shutil
 import sys
 import tempfile
 from subprocess import check_call, Popen, PIPE, STDOUT
@@ -415,7 +416,7 @@ def get_copystate_per_variant_2(copystate_rd_cn_format_gz):
             if c <= 1:
                 continue
             sl = l.strip().split("\t")
-            for i in range(3, len(sl)):
+            for i in range(2, len(sl)):
                 x = f"{sl[0]}\t{sl[i]}"
                 if x not in output_data:
                     output_data.add(x)
@@ -462,6 +463,7 @@ def find_multi_allelic_for_dup(copystate_per_variant_txt_gz, int_bed_gz, multi_c
 
     return multi_cnvs_txt
 
+
 def main(int_vcf_gz):
     headers = get_columns_headers(int_vcf_gz)
     headers = headers.strip().split("\t")
@@ -484,7 +486,19 @@ def main(int_vcf_gz):
     copystate_per_variant_txt_gz = get_copystate_per_variant_2(copystate_rd_cn_format_gz)
     multi_cnvs_txt = find_multi_allelic_for_del(copystate_per_variant_txt_gz, int_bed_gz)
     multi_cnvs_txt = find_multi_allelic_for_dup(copystate_per_variant_txt_gz, int_bed_gz, multi_cnvs_txt)
-    print(multi_cnvs_txt)
+
+    shutil.move(int_bed_gz, "/Users/vahid/Desktop/mine/int_bed.gz")
+    shutil.move(normaloverlap_txt, "/Users/vahid/Desktop/mine/normaloverlap")
+    shutil.move(rd_cn_normalcheck_FORMAT_gz, "/Users/vahid/Desktop/mine/rd_cn_normalcheck_FORMAT.gz")
+    shutil.move(ev_normalcheck_format_gz, "/Users/vahid/Desktop/mine/ev_normalcheck_format.gz")
+    shutil.move(overlap_test_txt, "/Users/vahid/Desktop/mine/overlap_test_txt")
+    shutil.move(geno_normal_revise_txt, "/Users/vahid/Desktop/mine/geno_normal_revise_txt")
+    shutil.move(subset_vcf, "/Users/vahid/Desktop/mine/subset_vcf")
+    shutil.move(normal_revise_vcf_lines_txt, "/Users/vahid/Desktop/mine/normal_revise_vcf_lines_txt")
+    shutil.move(normal_revise_vcf_gz, "/Users/vahid/Desktop/mine/normal_revise_vcf.gz")
+    shutil.move(copystate_rd_cn_format_gz, "/Users/vahid/Desktop/mine/copystate_rd_cn_format.gz")
+    shutil.move(copystate_per_variant_txt_gz, "/Users/vahid/Desktop/mine/copystate_per_variant_txt.gz")
+    shutil.move(multi_cnvs_txt, "/Users/vahid/Desktop/mine/multi_cnvs_txt")
 
 
 if __name__ == '__main__':

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.sh
@@ -27,7 +27,7 @@ zcat $int_vcf_gz\
 zcat $int_vcf_gz \
   |awk '{if ($5~"DEL" || $5~"DUP" || $1~"#") print}' \
   |svtk vcf2bed stdin stdout \
-  |awk -F"\t" '{if ($6=="") print $6="blanksample";print $0}' OFS='\t' \
+  |awk -F"\t" '{if ($6=="") $6="blanksample";print $0}' OFS='\t' \
   |gzip>int.bed.gz
 
 ##list of potenital overlaps with a normal copy state variant (>5kb variants require depth but nested events could be missed; i.e a duplication with a nest deletion will have a normal copy state for the deletion)##
@@ -101,6 +101,7 @@ cat overlap.test.txt \
   |join -1 2 -2 1 - <(zcat RD_CN.normalcheck.FORMAT.gz) \
   |awk '{if ($3=="DUP" && $4==2 && $6==3) print $2 "\t" 1; else if ($3=="DEL" && $4==2 && $6==1)  print $2 "\t" 3 }' \
   |tr '@' '\t'\
+  |sort -u \
   >geno.normal.revise.txt
 
 ##Update genotypes##
@@ -114,7 +115,7 @@ do
  
  echo $variant
  #note no longer change depth from id.txt (column 2)##
- { fgrep $variant geno.normal.revise.txt || true; }|awk '{print $2 "\t" $3}'>id.txt
+ { fgrep -w $variant geno.normal.revise.txt || true; }|awk '{print $2 "\t" $3}'>id.txt
  zcat subset.vcf.gz |{ fgrep -w $variant || true; }>line.txt
  
  cat line.txt  \

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b.sh
@@ -127,6 +127,7 @@ do
    |cut -f3-|tr '\t' ':' \
    |tr '\n' '\t' \
    |awk '{print $0}' \
+   |awk '{ sub(/[ \t]+$/, ""); print }' \
    >>normal.revise.vcf.lines.txt
 
 done< <(awk '{print $1}' geno.normal.revise.txt|sort -u)


### PR DESCRIPTION
This PR improves on https://github.com/broadinstitute/gatk-sv/pull/235 by cleaning the VCF using a single-pass on the input instead of the two passes implemented in https://github.com/broadinstitute/gatk-sv/pull/235. 