### PR TITLE
Expose metrics workflow runtime attributes

### DIFF
--- a/wdl/ClusterBatchMetrics.wdl
+++ b/wdl/ClusterBatchMetrics.wdl
@@ -24,13 +24,22 @@ workflow ClusterBatchMetrics {
     String? sv_base_mini_docker  # required if not providing samples array
     String sv_pipeline_base_docker
     String linux_docker
+
+    RuntimeAttr? runtime_attr_sample_ids_from_vcf
+    RuntimeAttr? runtime_attr_depth_metrics
+    RuntimeAttr? runtime_attr_delly_metrics
+    RuntimeAttr? runtime_attr_manta_metrics
+    RuntimeAttr? runtime_attr_melt_metrics
+    RuntimeAttr? runtime_attr_wham_metrics
+    RuntimeAttr? runtime_attr_cat_metrics
   }
 
   if (!defined(samples)) {
     call util.GetSampleIdsFromVcf {
       input:
         vcf = depth_vcf,
-        sv_base_mini_docker = select_first([sv_base_mini_docker])
+        sv_base_mini_docker = select_first([sv_base_mini_docker]),
+        runtime_attr_override = runtime_attr_sample_ids_from_vcf
     }
   }
 
@@ -42,7 +51,8 @@ workflow ClusterBatchMetrics {
       prefix = "depth_clustered",
       types = "DEL,DUP",
       contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      runtime_attr_override = runtime_attr_depth_metrics
   }
   if (defined(delly_vcf)) {
     call tu.VCFMetrics as delly_metrics {
@@ -53,7 +63,8 @@ workflow ClusterBatchMetrics {
         prefix = "delly_clustered",
         types = "DEL,DUP,INS,INV,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_delly_metrics
     }
   }
   if (defined(manta_vcf)) {
@@ -65,7 +76,8 @@ workflow ClusterBatchMetrics {
         prefix = "manta_clustered",
         types = "DEL,DUP,INS,INV,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_manta_metrics
     }
   }
   if (defined(melt_vcf)) {
@@ -77,7 +89,8 @@ workflow ClusterBatchMetrics {
         prefix = "melt_clustered",
         types = "INS",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_melt_metrics
     }
   }
   if (defined(wham_vcf)) {
@@ -89,7 +102,8 @@ workflow ClusterBatchMetrics {
         prefix = "wham_clustered",
         types = "DEL,DUP",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_wham_metrics
     }
   }
 
@@ -97,7 +111,8 @@ workflow ClusterBatchMetrics {
     input:
       prefix = "ClusterBatch." + name,
       metric_files = select_all([depth_metrics.out, delly_metrics.out, manta_metrics.out, melt_metrics.out, wham_metrics.out]),
-      linux_docker = linux_docker
+      linux_docker = linux_docker,
+      runtime_attr_override = runtime_attr_cat_metrics
   }
 
   output {

--- a/wdl/FilterBatchMetrics.wdl
+++ b/wdl/FilterBatchMetrics.wdl
@@ -25,6 +25,10 @@ workflow FilterBatchMetrics {
     String sv_base_mini_docker
 
     RuntimeAttr? runtime_attr_subset_ped
+    RuntimeAttr? runtime_attr_pesr_vcf_metrics
+    RuntimeAttr? runtime_attr_depth_vcf_metrics
+    RuntimeAttr? runtime_attr_cutoff_outlier_metrics
+    RuntimeAttr? runtime_attr_cat_metrics
   }
 
   Array[String] samples_post_filtering = read_lines(samples_post_filtering_file)
@@ -37,7 +41,8 @@ workflow FilterBatchMetrics {
       prefix = "filtered_pesr",
       types = "DEL,DUP,INS,INV,BND",
       contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      runtime_attr_override = runtime_attr_pesr_vcf_metrics
   }
 
   call tu.VCFMetrics as Depth_VCF_Metrics {
@@ -48,7 +53,8 @@ workflow FilterBatchMetrics {
       prefix = "filtered_depth",
       types = "DEL,DUP",
       contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      runtime_attr_override = runtime_attr_depth_vcf_metrics
   }
 
   call util.SubsetPedFile {
@@ -66,14 +72,16 @@ workflow FilterBatchMetrics {
       outlier_list = outlier_list,
       filtered_ped_file = SubsetPedFile.ped_subset_file,
       samples = samples,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      runtime_attr_override = runtime_attr_cutoff_outlier_metrics
   }
 
   call tu.CatMetrics {
     input:
       prefix = "FilterBatch." + name,
       metric_files = [PESR_VCF_Metrics.out, Depth_VCF_Metrics.out, CutoffAndOutlierMetrics.out],
-      linux_docker = linux_docker
+      linux_docker = linux_docker,
+      runtime_attr_override = runtime_attr_cat_metrics
   }
 
   output {

--- a/wdl/GATKSVPipelineBatch.wdl
+++ b/wdl/GATKSVPipelineBatch.wdl
@@ -103,6 +103,10 @@ workflow GATKSVPipelineBatch {
     String? wham_docker
     String cloud_sdk_docker
 
+    # Batch metrics
+    RuntimeAttr? runtime_attr_cat_metrics
+    RuntimeAttr? runtime_attr_plot_metrics
+
     # Do not use
     Array[File]? NONE_ARRAY_
     String? NONE_STRING_
@@ -305,7 +309,8 @@ workflow GATKSVPipelineBatch {
       input:
         prefix = "batch_sv." + batch,
         metric_files = select_all([GatherSampleEvidenceBatch.metrics_file_sampleevidence, GATKSVPipelinePhase1.metrics_file_batchevidence, GATKSVPipelinePhase1.metrics_file_clusterbatch, GATKSVPipelinePhase1.metrics_file_batchmetrics, GATKSVPipelinePhase1.metrics_file_filterbatch, GenotypeBatch.metrics_file_genotypebatch, MakeCohortVcf.metrics_file_makecohortvcf]),
-        linux_docker = linux_docker
+        linux_docker = linux_docker,
+        runtime_attr_override = runtime_attr_cat_metrics
     }
 
   Array[File] defined_baseline_metrics = select_all([baseline_sampleevidence_metrics, baseline_batchevidence_metrics, baseline_clusterbatch_metrics, baseline_batchmetrics_metrics, baseline_filterbatch_metrics, baseline_genotypebatch_metrics, baseline_makecohortvcf_metrics])
@@ -314,7 +319,8 @@ workflow GATKSVPipelineBatch {
       input:
         prefix = "baseline." + batch,
         metric_files = defined_baseline_metrics,
-        linux_docker = linux_docker
+        linux_docker = linux_docker,
+        runtime_attr_override = runtime_attr_cat_metrics
     }
     call tu.PlotMetrics {
       input:
@@ -322,7 +328,8 @@ workflow GATKSVPipelineBatch {
         samples = sample_ids,
         test_metrics = CatBatchMetrics.out,
         base_metrics = CatBaselineMetrics.out,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_plot_metrics
     }
   }
 

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -16,7 +16,6 @@ import "GermlineCNVCase.wdl" as gcnv
 import "SingleSampleFiltering.wdl" as SingleSampleFiltering
 import "GATKSVPipelineSingleSampleMetrics.wdl" as SingleSampleMetrics
 import "Utils.wdl" as utils
-import "TestUtils.wdl" as tu
 import "Structs.wdl"
 
 # GATK SV Pipeline single sample mode

--- a/wdl/GatherBatchEvidenceMetrics.wdl
+++ b/wdl/GatherBatchEvidenceMetrics.wdl
@@ -34,9 +34,9 @@ workflow GatherBatchEvidenceMetrics {
     RuntimeAttr? runtime_attr_manta_metrics
     RuntimeAttr? runtime_attr_melt_metrics
     RuntimeAttr? runtime_attr_wham_metrics
-    RuntimeAttr? runtime_attr_baf_metrics = {"mem_gb": 30, "disk_gb": 100}
-    RuntimeAttr? runtime_attr_sr_metrics = {"mem_gb": 30, "disk_gb": 100, "preemptible_tries": 0}
-    RuntimeAttr? runtime_attr_pe_metrics = {"mem_gb": 15, "disk_gb": 100, "preemptible_tries": 0}
+    RuntimeAttr? runtime_attr_baf_metrics
+    RuntimeAttr? runtime_attr_sr_metrics
+    RuntimeAttr? runtime_attr_pe_metrics
     RuntimeAttr? runtime_attr_bincov_metrics
     RuntimeAttr? runtime_attr_medcov_metrics
     RuntimeAttr? runtime_attr_merged_del
@@ -113,21 +113,21 @@ workflow GatherBatchEvidenceMetrics {
       baf_file = merged_BAF,
       samples = samples,
       sv_pipeline_base_docker = sv_pipeline_base_docker,
-      runtime_attr_override = runtime_attr_baf_metrics
+      runtime_attr_override = select_first([runtime_attr_baf_metrics, {"mem_gb": 30, "disk_gb": 100}])
   }
   call tu.SRMetrics {
     input:
       sr_file = merged_SR,
       samples = samples,
       sv_pipeline_base_docker = sv_pipeline_base_docker,
-      runtime_attr_override = runtime_attr_sr_metrics
+      runtime_attr_override = select_first([runtime_attr_sr_metrics, {"mem_gb": 30, "disk_gb": 100, "preemptible_tries": 0}])
   }
   call tu.PEMetrics {
     input:
       pe_file = merged_PE,
       samples = samples,
       sv_pipeline_base_docker = sv_pipeline_base_docker,
-      runtime_attr_override = runtime_attr_pe_metrics
+      runtime_attr_override = select_first([runtime_attr_pe_metrics, {"mem_gb": 15, "disk_gb": 100, "preemptible_tries": 0}])
   }
   call tu.BincovMetrics {
     input:

--- a/wdl/GatherSampleEvidenceBatch.wdl
+++ b/wdl/GatherSampleEvidenceBatch.wdl
@@ -100,6 +100,7 @@ workflow GatherSampleEvidenceBatch {
     RuntimeAttr? runtime_attr_wham_include_list
     RuntimeAttr? runtime_attr_ReviseBaseInBam
     RuntimeAttr? runtime_attr_ConcatBam
+    RuntimeAttr? runtime_attr_cat_metrics
 
     File? NONE_FILE_
     String? NONE_STRING_
@@ -184,7 +185,8 @@ workflow GatherSampleEvidenceBatch {
       input:
         prefix = "GatherSampleEvidence." + select_first([batch]),
         metric_files = flatten(sample_metrics_files_),
-        linux_docker = select_first([linux_docker])
+        linux_docker = select_first([linux_docker]),
+        runtime_attr_override = runtime_attr_cat_metrics
     }
   }
 

--- a/wdl/GatherSampleEvidenceMetrics.wdl
+++ b/wdl/GatherSampleEvidenceMetrics.wdl
@@ -22,6 +22,18 @@ workflow GatherSampleEvidenceMetrics {
     File contig_index
     Int min_size = 50
     String sv_pipeline_base_docker
+
+    RuntimeAttr? runtime_attr_delly_std
+    RuntimeAttr? runtime_attr_delly_metrics
+    RuntimeAttr? runtime_attr_manta_std
+    RuntimeAttr? runtime_attr_manta_metrics
+    RuntimeAttr? runtime_attr_melt_std
+    RuntimeAttr? runtime_attr_melt_metrics
+    RuntimeAttr? runtime_attr_wham_std
+    RuntimeAttr? runtime_attr_wham_metrics
+    RuntimeAttr? runtime_attr_sr_metrics
+    RuntimeAttr? runtime_attr_pe_metrics
+    RuntimeAttr? runtime_attr_counts_metrics
   }
 
   if (defined(delly_vcf)) {
@@ -32,7 +44,8 @@ workflow GatherSampleEvidenceMetrics {
         caller = "delly",
         contig_index = contig_index,
         min_size = min_size,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_delly_std
     }
     if (defined(baseline_delly_vcf)) {
       call tu.StandardizeVCF as Delly_Std_Base {
@@ -42,7 +55,8 @@ workflow GatherSampleEvidenceMetrics {
           caller = "delly",
           contig_index = contig_index,
           min_size = min_size,
-          sv_pipeline_base_docker = sv_pipeline_base_docker
+          sv_pipeline_base_docker = sv_pipeline_base_docker,
+          runtime_attr_override = runtime_attr_delly_std
       }
     }
     call tu.VCFMetrics as Delly_Metrics {
@@ -53,7 +67,8 @@ workflow GatherSampleEvidenceMetrics {
         prefix = "delly_" + sample,
         types = "DEL,DUP,INS,INV,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_delly_metrics
     }
   }
   if (defined(manta_vcf)) {
@@ -64,7 +79,8 @@ workflow GatherSampleEvidenceMetrics {
         caller = "manta",
         contig_index = contig_index,
         min_size = min_size,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_manta_std
     }
     if (defined(baseline_manta_vcf)) {
       call tu.StandardizeVCF as Manta_Std_Base {
@@ -74,7 +90,8 @@ workflow GatherSampleEvidenceMetrics {
           caller = "manta",
           contig_index = contig_index,
           min_size = min_size,
-          sv_pipeline_base_docker = sv_pipeline_base_docker
+          sv_pipeline_base_docker = sv_pipeline_base_docker,
+          runtime_attr_override = runtime_attr_manta_std
       }
     }
     call tu.VCFMetrics as Manta_Metrics {
@@ -85,7 +102,8 @@ workflow GatherSampleEvidenceMetrics {
         prefix = "manta_" + sample,
         types = "DEL,DUP,INS,INV,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_manta_metrics
     }
   }
   if (defined(melt_vcf)) {
@@ -96,7 +114,8 @@ workflow GatherSampleEvidenceMetrics {
         caller = "melt",
         contig_index = contig_index,
         min_size = min_size,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_melt_std
     }
     if (defined(baseline_melt_vcf)) {
       call tu.StandardizeVCF as Melt_Std_Base {
@@ -106,7 +125,8 @@ workflow GatherSampleEvidenceMetrics {
           caller = "melt",
           contig_index = contig_index,
           min_size = min_size,
-          sv_pipeline_base_docker = sv_pipeline_base_docker
+          sv_pipeline_base_docker = sv_pipeline_base_docker,
+          runtime_attr_override = runtime_attr_melt_std
       }
     }
     call tu.VCFMetrics as Melt_Metrics {
@@ -117,7 +137,8 @@ workflow GatherSampleEvidenceMetrics {
         prefix = "melt_" + sample,
         types = "DEL,DUP,INS,INV,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_melt_metrics
     }
   }
   if (defined(wham_vcf)) {
@@ -128,7 +149,8 @@ workflow GatherSampleEvidenceMetrics {
         caller = "wham",
         contig_index = contig_index,
         min_size = min_size,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_wham_std
     }
     if (defined(baseline_wham_vcf)) {
       call tu.StandardizeVCF as Wham_Std_Base {
@@ -138,7 +160,8 @@ workflow GatherSampleEvidenceMetrics {
           caller = "wham",
           contig_index = contig_index,
           min_size = min_size,
-          sv_pipeline_base_docker = sv_pipeline_base_docker
+          sv_pipeline_base_docker = sv_pipeline_base_docker,
+          runtime_attr_override = runtime_attr_wham_std
       }
     }
     call tu.VCFMetrics as Wham_Metrics {
@@ -149,7 +172,8 @@ workflow GatherSampleEvidenceMetrics {
         prefix = "wham_" + sample,
         types = "DEL,DUP,INS,INV,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_wham_metrics
     }
   }
   if (defined(pesr_split)) {
@@ -157,7 +181,8 @@ workflow GatherSampleEvidenceMetrics {
       input:
         sr_file = select_first([pesr_split]),
         samples = [sample],
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_sr_metrics
     }
   }
   if (defined(pesr_disc)) {
@@ -165,7 +190,8 @@ workflow GatherSampleEvidenceMetrics {
       input:
         pe_file = select_first([pesr_disc]),
         samples = [sample],
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_pe_metrics
     }
   }
   if (defined(coverage_counts)) {
@@ -173,7 +199,8 @@ workflow GatherSampleEvidenceMetrics {
       input:
         counts_file = select_first([coverage_counts]),
         sample_id = sample,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        runtime_attr_override = runtime_attr_counts_metrics
     }
   }
 

--- a/wdl/GenerateBatchMetricsMetrics.wdl
+++ b/wdl/GenerateBatchMetricsMetrics.wdl
@@ -10,6 +10,10 @@ workflow GenerateBatchMetricsMetrics {
     File contig_list
     String sv_pipeline_base_docker
     String linux_docker
+
+    RuntimeAttr? runtime_attr_metrics_file_metrics
+    RuntimeAttr? runtime_attr_common_metrics_metrics
+    RuntimeAttr? runtime_attr_cat_metrics
   }
 
   call tu.MetricsFileMetrics {
@@ -18,7 +22,8 @@ workflow GenerateBatchMetricsMetrics {
       contig_list = contig_list,
       common = false,
       prefix = "GenerateBatchMetrics.non_common." + name,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      runtime_attr_override = runtime_attr_metrics_file_metrics
   }
 
   call tu.MetricsFileMetrics as CommonMetricsFileMetrics {
@@ -27,14 +32,16 @@ workflow GenerateBatchMetricsMetrics {
       contig_list = contig_list,
       common = true,
       prefix = "GenerateBatchMetrics.common." + name,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      runtime_attr_override = runtime_attr_common_metrics_metrics
   }
 
   call tu.CatMetrics {
     input:
       prefix = "GenerateBatchMetrics." + name,
       metric_files = [MetricsFileMetrics.out, CommonMetricsFileMetrics.out],
-      linux_docker = linux_docker
+      linux_docker = linux_docker,
+      runtime_attr_override = runtime_attr_cat_metrics
   }
 
   output {

--- a/wdl/GenotypeBatchMetrics.wdl
+++ b/wdl/GenotypeBatchMetrics.wdl
@@ -22,6 +22,12 @@ workflow GenotypeBatchMetrics {
     File contig_list
     String linux_docker
     String sv_pipeline_base_docker
+
+    RuntimeAttr? runtime_attr_pesr_metrics
+    RuntimeAttr? runtime_attr_depth_metrics
+    RuntimeAttr? runtime_attr_cutoff_metrics
+    RuntimeAttr? runtime_attr_id_list_metrics
+    RuntimeAttr? runtime_attr_cat_metrics
   }
 
   call tu.VCFMetrics as PESR_VCF_Metrics {
@@ -32,7 +38,8 @@ workflow GenotypeBatchMetrics {
       prefix = "genotyped_pesr",
       types = "DEL,DUP,INS,INV,BND",
       contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      runtime_attr_override = runtime_attr_pesr_metrics
   }
 
   call tu.VCFMetrics as Depth_VCF_Metrics {
@@ -43,56 +50,64 @@ workflow GenotypeBatchMetrics {
       prefix = "genotyped_depth",
       types = "DEL,DUP",
       contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      runtime_attr_override = runtime_attr_depth_metrics
   }
 
   call tu.GenotypingCutoffMetrics as Cutoff_PESR_PESR {
     input:
       cutoffs = cutoffs_pesr_pesr,
       name = "pesr_pesr",
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      runtime_attr_override = runtime_attr_cutoff_metrics
   }
 
   call tu.GenotypingCutoffMetrics as Cutoff_PESR_Depth {
     input:
       cutoffs = cutoffs_pesr_depth,
       name = "pesr_depth",
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      runtime_attr_override = runtime_attr_cutoff_metrics
   }
 
   call tu.GenotypingCutoffMetrics as Cutoff_Depth_PESR {
     input:
       cutoffs = cutoffs_depth_pesr,
       name = "depth_pesr",
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      runtime_attr_override = runtime_attr_cutoff_metrics
   }
 
   call tu.GenotypingCutoffMetrics as Cutoff_Depth_Depth {
     input:
       cutoffs = cutoffs_depth_depth,
       name = "depth_depth",
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      runtime_attr_override = runtime_attr_cutoff_metrics
   }
 
   call tu.IdListMetrics as Background_Fail {
     input:
       id_list = sr_background_fail,
       name = "sr_background_fail",
-      linux_docker = linux_docker
+      linux_docker = linux_docker,
+      runtime_attr_override = runtime_attr_id_list_metrics
   }
 
   call tu.IdListMetrics as Bothside_Pass {
     input:
       id_list = sr_bothside_pass,
       name = "sr_bothside_pass",
-      linux_docker = linux_docker
+      linux_docker = linux_docker,
+      runtime_attr_override = runtime_attr_id_list_metrics
   }
 
   call tu.CatMetrics {
     input:
       prefix = "GenotypeBatch." + name,
       metric_files = [PESR_VCF_Metrics.out, Depth_VCF_Metrics.out, Cutoff_PESR_PESR.out, Cutoff_PESR_Depth.out, Cutoff_Depth_PESR.out, Cutoff_Depth_Depth.out, Background_Fail.out, Bothside_Pass.out],
-      linux_docker = linux_docker
+      linux_docker = linux_docker,
+      runtime_attr_override = runtime_attr_cat_metrics
   }
 
   output {


### PR DESCRIPTION
### Updates
Expose runtime attributes for metrics workflow tasks to the level of the metrics WDLs (and various workflows with standalone metrics tasks) to enable overcoming resource issues. Chose not to add inputs to all of the main workflows for now because it just seemed like too many inputs.

### Testing
* Validated all WDLs and JSONs with womtool
* Successfully ran `GATKSVPipelineBatch.wdl` and `GATKSVPipelineSingleSampleTest.wdl`. Caveat: didn't actually modify runtime attributes in these test runs, but at least the workflows themselves aren't messed up