### PR TITLE
Replace nested scatter in TinyResolve with sharding subworkflow

### DIFF
--- a/wdl/GatherBatchEvidence.wdl
+++ b/wdl/GatherBatchEvidence.wdl
@@ -170,7 +170,6 @@ workflow GatherBatchEvidence {
     String gatk_docker
     String? gcnv_gatk_docker
     String cnmops_docker
-    String? python_docker
 
     RuntimeAttr? median_cov_runtime_attr        # Memory ignored, use median_cov_mem_gb_per_sample
     Float? median_cov_mem_gb_per_sample
@@ -197,7 +196,6 @@ workflow GatherBatchEvidence {
     RuntimeAttr? add_sample_to_ped_runtime_attr
     RuntimeAttr? condense_counts_runtime_attr
     RuntimeAttr? preprocess_calls_runtime_attr
-    RuntimeAttr? runtime_attr_tiny_shard
     RuntimeAttr? depth_merge_set_runtime_attr
     RuntimeAttr? depth_merge_sample_runtime_attr
     RuntimeAttr? cnmops_ped_runtime_attr
@@ -488,9 +486,7 @@ workflow GatherBatchEvidence {
           discfile=PE_files,
           mei_bed=mei_bed,
           sv_pipeline_docker = sv_pipeline_docker,
-          runtime_attr = preprocess_calls_runtime_attr,
-          runtime_attr_shard = runtime_attr_tiny_shard,
-          python_docker = python_docker
+          runtime_attr = preprocess_calls_runtime_attr
       }
   }
   File? baf_out = if defined(EvidenceMerging.merged_BAF) then EvidenceMerging.merged_BAF else BAFFromGVCFs.out

--- a/wdl/GatherBatchEvidence.wdl
+++ b/wdl/GatherBatchEvidence.wdl
@@ -170,6 +170,7 @@ workflow GatherBatchEvidence {
     String gatk_docker
     String? gcnv_gatk_docker
     String cnmops_docker
+    String? python_docker
 
     RuntimeAttr? median_cov_runtime_attr        # Memory ignored, use median_cov_mem_gb_per_sample
     Float? median_cov_mem_gb_per_sample
@@ -196,6 +197,7 @@ workflow GatherBatchEvidence {
     RuntimeAttr? add_sample_to_ped_runtime_attr
     RuntimeAttr? condense_counts_runtime_attr
     RuntimeAttr? preprocess_calls_runtime_attr
+    RuntimeAttr? runtime_attr_tiny_shard
     RuntimeAttr? depth_merge_set_runtime_attr
     RuntimeAttr? depth_merge_sample_runtime_attr
     RuntimeAttr? cnmops_ped_runtime_attr
@@ -486,7 +488,9 @@ workflow GatherBatchEvidence {
           discfile=PE_files,
           mei_bed=mei_bed,
           sv_pipeline_docker = sv_pipeline_docker,
-          runtime_attr = preprocess_calls_runtime_attr
+          runtime_attr = preprocess_calls_runtime_attr,
+          runtime_attr_shard = runtime_attr_tiny_shard,
+          python_docker = python_docker
       }
   }
   File? baf_out = if defined(EvidenceMerging.merged_BAF) then EvidenceMerging.merged_BAF else BAFFromGVCFs.out

--- a/wdl/GetShardInputs.wdl
+++ b/wdl/GetShardInputs.wdl
@@ -1,0 +1,21 @@
+version 1.0
+
+workflow GetShardInputs {
+  input {
+    Array[String] all_items
+    Int shard_number
+    Int items_per_shard
+    Int num_items
+  }
+
+  scatter (j in range(items_per_shard)) {
+    Int idx = shard_number * items_per_shard + j
+    if (idx < num_items) {
+      String shard_items_ = all_items[idx]
+    }
+  }
+
+  output {
+    Array[String] shard_items = select_all(shard_items_)
+  }
+}

--- a/wdl/TinyResolve.wdl
+++ b/wdl/TinyResolve.wdl
@@ -11,7 +11,9 @@ workflow TinyResolve {
     File mei_bed
     Int samples_per_shard = 25
     String sv_pipeline_docker
+    String? python_docker
     RuntimeAttr? runtime_attr
+    RuntimeAttr? runtime_attr_shard
   }
 
   scatter (disc in discfile) {
@@ -24,29 +26,28 @@ workflow TinyResolve {
   Int num_shards = ceil(num_samples_float / samples_per_shard)
 
   scatter (i in range(num_shards)) {
-    scatter (j in range(samples_per_shard)) {
-      Int idx_ = i * samples_per_shard + j
-      if (idx_ < num_samples) {
-        String shard_samples_ = samples[idx_]
-        File shard_vcfs_ = manta_vcfs[idx_]
-        File shard_discfiles_ = discfile[idx_]
-        File shard_discfiles_idx_ = discfile_idx[idx_]
-      }
+    call GetShardInputs {
+      input:
+        samples_per_shard = samples_per_shard,
+        shard_number = i,
+        num_samples = num_samples,
+        all_samples = samples,
+        all_discfiles = discfile,
+        all_discfile_idxs = discfile_idx,
+        all_vcfs = manta_vcfs,
+        python_docker = python_docker,
+        runtime_attr_override = runtime_attr_shard
     }
-    Array[String] shard_samples = select_all(shard_samples_)
-    Array[File] shard_vcfs = select_all(shard_vcfs_)
-    Array[File] shard_discfiles = select_all(shard_discfiles_)
-    Array[File] shard_discfiles_idx = select_all(shard_discfiles_idx_)
 
     call ResolveManta {
       input:
-        raw_vcfs=shard_vcfs,
-        samples=shard_samples,
+        raw_vcfs=GetShardInputs.shard_vcfs,
+        samples=GetShardInputs.shard_samples,
         sv_pipeline_docker = sv_pipeline_docker,
         cytoband=cytoband,
         cytoband_idx=cytoband_idx,
-        discfile=shard_discfiles,
-        discfile_idx=shard_discfiles_idx,
+        discfile=GetShardInputs.shard_discfiles,
+        discfile_idx=GetShardInputs.shard_discfiles_idx,
         mei_bed=mei_bed,
         runtime_attr_override=runtime_attr
     }
@@ -54,6 +55,61 @@ workflow TinyResolve {
 
   output {
     Array[File] tloc_manta_vcf = flatten(ResolveManta.tloc_vcf)
+  }
+}
+
+task GetShardInputs {
+  input {
+    Int samples_per_shard
+    Int shard_number
+    Int num_samples
+    Array[String] all_samples
+    Array[String] all_discfiles
+    Array[String] all_discfile_idxs
+    Array[String] all_vcfs
+    String? python_docker
+    RuntimeAttr? runtime_attr_override
+  }
+  String python_docker_ = select_first([python_docker, "python:3.7.12-bullseye"])
+  RuntimeAttr default_attr = object {
+    cpu_cores: 1, 
+    mem_gb: 3.75, 
+    disk_gb: 10,
+    boot_disk_gb: 10,
+    preemptible_tries: 3,
+    max_retries: 1
+  }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+  command <<<
+    set -euo pipefail
+    python3 <<CODE
+    all_samples = ['~{sep = "','" all_samples}']
+    all_discfiles = ['~{sep = "','" all_discfiles}']
+    all_discfile_idxs = ['~{sep = "','" all_discfile_idxs}']
+    all_vcfs = ['~{sep = "','" all_vcfs}']
+    start = ~{shard_number} * ~{samples_per_shard}
+    end = min(start + ~{samples_per_shard}, ~{num_samples})
+    with open("shard_discfiles.txt", 'w') as disc, open("shard_samples.txt", 'w') as samp, open("shard_disc_idx.txt", 'w') as idxs, open("shard_vcfs.txt", 'w') as vcfs:
+      disc.write("\n".join(all_discfiles[start:end]))
+      idxs.write("\n".join(all_discfile_idxs[start:end]))
+      samp.write("\n".join(all_samples[start:end]))
+      vcfs.write("\n".join(all_vcfs[start:end]))
+    CODE
+  >>>
+  output {
+    Array[String] shard_discfiles = read_lines("shard_discfiles.txt")
+    Array[String] shard_discfiles_idx = read_lines("shard_disc_idx.txt")
+    Array[String] shard_vcfs = read_lines("shard_vcfs.txt")
+    Array[String] shard_samples = read_lines("shard_samples.txt")
+  }
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: python_docker_
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }
 }
 

--- a/wdl/TinyResolve.wdl
+++ b/wdl/TinyResolve.wdl
@@ -13,9 +13,7 @@ workflow TinyResolve {
     File mei_bed
     Int samples_per_shard = 25
     String sv_pipeline_docker
-    String? python_docker
     RuntimeAttr? runtime_attr
-    RuntimeAttr? runtime_attr_shard
   }
 
   scatter (disc in discfile) {


### PR DESCRIPTION
### Updates
Since nested WDL scatters can cause Cromwell issues, replaced nested scatter in `GatherBatchEvidence.TinyResolve` with a task to perform the sharding.

### Testing
* Validated all WDLs and JSONs with womtool
* Successfully ran `GatherBatchEvidence.wdl` with 105 samples and verified that the first four shards had 25 samples and the final shard had 5 samples based on the outputs from the sharding task. Also spot-checked the script for the resolve task for one shard and verified that it had the correct number of samples.