### PR TITLE
Remove subprocesses in MakeRdTestBed for error propagation

### DIFF
--- a/wdl/DepthClustering.wdl
+++ b/wdl/DepthClustering.wdl
@@ -120,12 +120,10 @@ task MakeRDTestBed {
   command <<<
 
     set -euo pipefail
-    cat \
-      <(python3 /opt/sv-pipeline/scripts/make_depth_rdtest_bed.py ~{dels} | sed '1d') \
-      <(python3 /opt/sv-pipeline/scripts/make_depth_rdtest_bed.py ~{dups} | sed '1d') \
-      | sort -k1,1V -k2,2n \
-      | cat <(echo -e "#chrom start end name samples svtype" | sed -e 's/ /\t/g') - \
-      > ~{batch}.depth.bed;
+    python3 /opt/sv-pipeline/scripts/make_depth_rdtest_bed.py ~{dels} | sed '1d' > del.bed
+    python3 /opt/sv-pipeline/scripts/make_depth_rdtest_bed.py ~{dups} | sed '1d' > dup.bed
+    echo -e "#chrom start end name samples svtype" | sed -e 's/ /\t/g' > ~{batch}.depth.bed
+    cat del.bed dup.bed | sort -k1,1V -k2,2n >> ~{batch}.depth.bed
   
   >>>
   runtime {


### PR DESCRIPTION
### Updates
Rewrite ClusterBatch.DepthClustering.MakeRdTestBed to write to intermediate files instead of using subprocesses, to avoid silent errors during subprocesses.

### Testing
* Validated with womtool
* Tested manually in pipeline docker image and confirmed output was identical to previous version
* Ran `ClusterBatch.wdl` with large test set and confirmed the run was successful