### PR TITLE
Update the Github action to build only the images impacted by the files changed in a PR

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -90,7 +90,7 @@ jobs:
             if [[ $i == *".github/workflows/sv_pipeline_docker.yml"* ]]; then
               # A change to this file may impact how images are built,
               # hence, if this file is changed, all the images are rebuilt.
-              try_add_target "all"
+              TARGETS=("all")
               break
             elif [[ $i == *"src/svtk"* ||
                   $i == *"src/sv-pipeline"* ||

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -56,11 +56,9 @@ jobs:
           # The commit SHA of the base branch which this PR targets;
           # ideally broadinstitute/gatk-sv:master.
           BASE_COMMIT_SHA=$(echo "$GITHUB_CONTEXT"| jq -r '.event.pull_request.base.sha')
-          echo "::debug::BASE_COMMIT_SHA: $BASE_COMMIT_SHA"
 
           # The commit SHA of the commit that triggered the action.
           COMMIT_SHA=${{ github.event.pull_request.head.sha }}
-          echo "::debug::COMMIT_SHA: $COMMIT_SHA"
 
           # A list of all the files changed between the current commit & base.
           CHANGED_FILES=$(git diff --name-only $BASE_COMMIT_SHA $COMMIT_SHA)
@@ -73,6 +71,12 @@ jobs:
           }
           for i in "${CHANGED_FILES[@]}"
           do
+            if [[ $i == *".github/workflows/sv_pipeline_docker.yml" ]]; then
+              # A change to this file may impact how images are built,
+              # hence all the images are rebuilt.
+              try_add_target "all"
+              break
+            fi
             if [[ $i == *"src/svtk"* ||
                   $i == *"src/sv-pipeline"* ||
                   $i == *"src/svtest"* ||

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -89,6 +89,24 @@ jobs:
             if [[ $i == *"scripts/docker/resources.Dockerfile"* ]]; then
               try_add_target "gatksv-pipeline-v1-resources"
             fi
+            if [[ $i == *"dockerfiles/delly/Dockerfile" ]]; then
+              try_add_target "delly"
+            fi
+            if [[ $i == *"dockerfiles/manta/Dockerfile" ]]; then
+              try_add_target "manta"
+            fi
+            if [[ $i == *"dockerfiles/wham/Dockerfile" ]]; then
+              try_add_target "wham"
+            fi
+            if [[ $i == *"dockerfiles/sv-base-mini/Dockerfile" ]]; then
+              try_add_target "sv-base-mini"
+            fi
+            if [[ $i == *"dockerfiles/sv-base/Dockerfile" ]]; then
+              try_add_target "sv-base"
+            fi
+            if [[ $i == *"dockerfiles/samtools-cloud/Dockerfile" ]]; then
+              try_add_target "samtools-cloud"
+            fi
           done
 
           # Join the determined targets in a space-delimited string.

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -52,73 +52,89 @@ jobs:
 
       - name: Determine Target Images
         id: target_images
+        # This step determines the target images to be rebuilt based
+        # on the files changed between the HEAD and BASE commits, where
+        # HEAD is the commit that its push triggered running this action and
+        # BASE is the commit the PR is targeting. For instance, if the
+        # commit changes the `dockerfiles/sv-base/Dockerfile`, then the
+        # `sv-base` docker image (and all its dependencies) are rebuilt.
+        #
+        # This step first gets the HEAD and BASE commit SHAs from the
+        # $GITHUB_CONTEXT environment variable. Then uses `git diff` to
+        # determine the files changed between the commits. Based on the
+        # changed files, it determines a list of docker images to be rebuilt.
+        # Finally, it stores the determined docker images in $TARGETS
+        # variable that can be accessed in other steps.
         run: |
           # The commit SHA of the base branch which this PR targets;
           # ideally broadinstitute/gatk-sv:master.
-          BASE_COMMIT_SHA=$(echo "$GITHUB_CONTEXT"| jq -r '.event.pull_request.base.sha')
+          BASE_SHA=$(echo "$GITHUB_CONTEXT"| jq -r '.event.pull_request.base.sha')
 
           # The commit SHA of the commit that triggered the action.
-          COMMIT_SHA=${{ github.event.pull_request.head.sha }}
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
 
-          # A list of all the files changed between the current commit & base.
-          CHANGED_FILES=$(git diff --name-only $BASE_COMMIT_SHA $COMMIT_SHA)
+          # A list of all the files changed in HEAD commit w.r.t BASE commit.
+          CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
 
+          # Add a given target image name to the TARGETS
+          # array if it is not already in the array.
           TARGETS=()
           try_add_target() {
             if [[ ! " ${TARGETS[*]} " =~ $1 ]]; then
               TARGETS+=($1)
             fi
           }
+
           for i in "${CHANGED_FILES[@]}"
           do
-            if [[ $i == *".github/workflows/sv_pipeline_docker.yml" ]]; then
+            if [[ $i == *".github/workflows/sv_pipeline_docker.yml"* ]]; then
               # A change to this file may impact how images are built,
-              # hence all the images are rebuilt.
+              # hence, if this file is changed, all the images are rebuilt.
               try_add_target "all"
               break
-            fi
-            if [[ $i == *"src/svtk"* ||
+            elif [[ $i == *"src/svtk"* ||
                   $i == *"src/sv-pipeline"* ||
                   $i == *"src/svtest"* ||
                   $i == *"src/svqc"* ]]; then
               try_add_target "sv-pipeline"
               try_add_target "sv-pipeline-base"
               try_add_target "sv-pipeline-children-r"
-            fi
-            if [[ $i == *"src/RdTest"* ]]; then
+            elif [[ $i == *"src/RdTest"* ]]; then
               try_add_target "sv-pipeline-rdtest"
-            fi
-            if [[ $i == *"src/WGD"* ]]; then
+            elif [[ $i == *"src/WGD"* ]]; then
               try_add_target "sv-pipeline-qc"
               try_add_target "cnmops"
-            fi
-            if [[ $i == *"scripts/docker/resources.Dockerfile"* ]]; then
+            elif [[ $i == *"scripts/docker/resources.Dockerfile"* ]]; then
               try_add_target "gatksv-pipeline-v1-resources"
             fi
-            if [[ $i == *"dockerfiles/delly/Dockerfile" ]]; then
-              try_add_target "delly"
-            fi
-            if [[ $i == *"dockerfiles/manta/Dockerfile" ]]; then
-              try_add_target "manta"
-            fi
-            if [[ $i == *"dockerfiles/wham/Dockerfile" ]]; then
-              try_add_target "wham"
-            fi
-            if [[ $i == *"dockerfiles/sv-base-mini/Dockerfile" ]]; then
-              try_add_target "sv-base-mini"
-            fi
-            if [[ $i == *"dockerfiles/sv-base/Dockerfile" ]]; then
-              try_add_target "sv-base"
-            fi
-            if [[ $i == *"dockerfiles/samtools-cloud/Dockerfile" ]]; then
-              try_add_target "samtools-cloud"
+
+            # Rebuild the docker image of the Dockerfiles specified in
+            # the `D` array. Use regular expression to extract the target
+            # image from the file path. For instance, if
+            # i = dockerfiles/delly/Dockerfile, then M="delly".
+            if [[ $i =~ (dockerfiles/)([^,]*)(/Dockerfile) ]]; then
+              M="${BASH_REMATCH[2]}"
+              D=("delly" "manta" "wham" "sv-base-mini" "sv-base" "samtools-cloud")
+              if [[ " ${D[*]} " =~ $M ]]; then
+                try_add_target $M
+              fi
             fi
           done
 
           # Join the determined targets in a space-delimited string.
           TARGETS=$(IFS=' '; echo "${TARGETS[*]}")
-          echo "::set-output name=TARGETS::$TARGETS"
+
+          # Print some debugging information.
+          echo "::debug::BASE_SHA: $BASE_SHA"
+          echo "::debug::HEAD_SHA: $HEAD_SHA"
           echo "::debug::Docker images to rebuild: $TARGETS"
+          echo "::debug::Changed files:"
+          for f in "${CHANGED_FILES[@]}"; do
+            echo "::debug::    $f"
+          done
+
+          # Set the output of this step so it can be accessed in other steps.
+          echo "::set-output name=TARGETS::$TARGETS"
 
       - name: Run build_docker.py [Pull Request]
         if: github.event_name == 'pull_request'

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -56,9 +56,11 @@ jobs:
           # The commit SHA of the base branch which this PR targets;
           # ideally broadinstitute/gatk-sv:master.
           BASE_COMMIT_SHA=$(echo "$GITHUB_CONTEXT"| jq -r '.event.pull_request.base.sha')
+          echo "::debug::BASE_COMMIT_SHA: $BASE_COMMIT_SHA"
 
           # The commit SHA of the commit that triggered the action.
           COMMIT_SHA=${{ github.event.pull_request.head.sha }}
+          echo "::debug::COMMIT_SHA: $COMMIT_SHA"
 
           # A list of all the files changed between the current commit & base.
           CHANGED_FILES=$(git diff --name-only $BASE_COMMIT_SHA $COMMIT_SHA)
@@ -111,8 +113,8 @@ jobs:
 
           # Join the determined targets in a space-delimited string.
           TARGETS=$(IFS=' '; echo "${TARGETS[*]}")
-          echo "::set-output name=TARGETS::$TARGETS"
           echo "::debug::Docker images to rebuild: $TARGETS"
+          echo "::set-output name=TARGETS::$TARGETS"
 
       - name: Run build_docker.py [Pull Request]
         if: github.event_name == 'pull_request'

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -32,6 +32,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          # By default, this checks out only the current commit;
+          # however, since a diff between the current commit and
+          # the base commit is required to determined which docker
+          # images to rebuild, we use the following to check out
+          # the complete git history.
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -43,6 +50,52 @@ jobs:
           python -m pip install --upgrade pip
           pip install termcolor
 
+      - name: Determine Target Images
+        id: target_images
+        run: |
+          # The commit SHA of the base branch which this PR targets;
+          # ideally broadinstitute/gatk-sv:master.
+          BASE_COMMIT_SHA=$(echo "$GITHUB_CONTEXT"| jq -r '.event.pull_request.base.sha')
+
+          # The commit SHA of the commit that triggered the action.
+          COMMIT_SHA=${{ github.event.pull_request.head.sha }}
+
+          # A list of all the files changed between the current commit & base.
+          CHANGED_FILES=$(git diff --name-only $BASE_COMMIT_SHA $COMMIT_SHA)
+
+          TARGETS=()
+          try_add_target() {
+            if [[ ! " ${TARGETS[*]} " =~ $1 ]]; then
+              TARGETS+=($1)
+            fi
+          }
+          for i in "${CHANGED_FILES[@]}"
+          do
+            if [[ $i == *"src/svtk"* ||
+                  $i == *"src/sv-pipeline"* ||
+                  $i == *"src/svtest"* ||
+                  $i == *"src/svqc"* ]]; then
+              try_add_target "sv-pipeline"
+              try_add_target "sv-pipeline-base"
+              try_add_target "sv-pipeline-children-r"
+            fi
+            if [[ $i == *"src/RdTest"* ]]; then
+              try_add_target "sv-pipeline-rdtest"
+            fi
+            if [[ $i == *"src/WGD"* ]]; then
+              try_add_target "sv-pipeline-qc"
+              try_add_target "cnmops"
+            fi
+            if [[ $i == *"scripts/docker/resources.Dockerfile"* ]]; then
+              try_add_target "gatksv-pipeline-v1-resources"
+            fi
+          done
+
+          # Join the determined targets in a space-delimited string.
+          TARGETS=$(IFS=' '; echo "${TARGETS[*]}")
+          echo "::set-output name=TARGETS::$TARGETS"
+          echo "::debug::Docker images to rebuild: $TARGETS"
+
       - name: Run build_docker.py [Pull Request]
         if: github.event_name == 'pull_request'
         run: |
@@ -51,7 +104,7 @@ jobs:
           IMAGE_TAG=${PR_NUM}-${COMMIT_SHA::8}
           echo "::debug::Image tag: $IMAGE_TAG"
           cd ./scripts/docker/
-          python build_docker.py --targets all --image-tag $IMAGE_TAG
+          python build_docker.py --targets ${{ steps.target_images.outputs.TARGETS }} --image-tag $IMAGE_TAG
 
       - name: Run build_docker.py [Push]
         if: github.event_name == 'push'
@@ -70,4 +123,4 @@ jobs:
           echo "::debug::Image tag: $IMAGE_TAG"
 
           cd ./scripts/docker/
-          python build_docker.py --targets all --image-tag $IMAGE_TAG
+          python build_docker.py --targets ${{ steps.target_images.outputs.TARGETS }} --image-tag $IMAGE_TAG

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -117,8 +117,8 @@ jobs:
 
           # Join the determined targets in a space-delimited string.
           TARGETS=$(IFS=' '; echo "${TARGETS[*]}")
-          echo "::debug::Docker images to rebuild: $TARGETS"
           echo "::set-output name=TARGETS::$TARGETS"
+          echo "::debug::Docker images to rebuild: $TARGETS"
 
       - name: Run build_docker.py [Pull Request]
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
The `sv_pipeline_docker.yml` triggers building all the docker images if a PR changes any files defined in `paths`. In other words, it always uses `--targets all` when calling `build_docker.py`. However, since rebuilding all the docker images takes a considerable amount of time (about 1h) and rebuilding all may not be necessary depending on the files changed in a PR, this PR improves the `sv_pipeline_docker` by setting `--targets` to only the images impacted by the files changed in the PR.

The action currently builds the images according to the following table: 

| Image                  | When to build                                                |
|------------------------|--------------------------------------------------------------|
| Delly                  | if the docker file is changed                                |
| Manta                  | if the docker file is changed                                |
| Wham                   | if the docker file is changed                                |
| sv-base-mini           | if the docker file is changed                                |
| sv-base                | if the docker file is changed                                |
| samtools-cloud         | if the docker file is changed                                |
| cnmops                 | /src/WGD                                                     |
| sv-pipeline-base       | /src/svtk /src/sv-pipeline /src/svtest /src/svqc             |
| sv-pipeline-children-r | /src/svtk /src/sv-pipeline /src/svtest /src/svqc             |
| sv-pipeline            | /src/svtk /src/sv-pipeline /src/svtest /src/svqc             |
| sv-pipeline-rdtest     | /src/svtk /src/sv-pipeline /src/svtest /src/svqc /src/RdTest |
| sv-pipeline-qc         | /src/svtk /src/sv-pipeline /src/svtest /src/svqc /src/WGD    |