### PR TITLE
Update GatherSampleEvidence description: no BAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ Note: a list of sample IDs must be provided. Refer to the [sample ID requirement
 * Binned read counts file
 * Split reads (SR) file
 * Discordant read pairs (PE) file
-* B-allele fraction (BAF) file
 
 ## <a name="evidence-qc">EvidenceQC</a>
 *Formerly Module00b*


### PR DESCRIPTION
Remove BAF from list of outputs from GatherSampleEvidence in README. Addresses #246 