### PR TITLE
Add subset ped step at start of CleanVcf

### DIFF
--- a/wdl/MakeCohortVcf.wdl
+++ b/wdl/MakeCohortVcf.wdl
@@ -328,7 +328,9 @@ workflow MakeCohortVcf {
       runtime_override_split_include_list=runtime_override_split_include_list,
       runtime_override_combine_clean_vcf_2=runtime_override_combine_clean_vcf_2,
       runtime_override_combine_revised_4=runtime_override_combine_revised_4,
-      runtime_override_combine_multi_ids_4=runtime_override_combine_multi_ids_4
+      runtime_override_combine_multi_ids_4=runtime_override_combine_multi_ids_4,
+      runtime_attr_ids_from_vcf=runtime_attr_ids_from_vcf,
+      runtime_attr_subset_ped=runtime_attr_subset_ped
   }
 
   Array[String] contigs = transpose(read_tsv(contig_list))[0]


### PR DESCRIPTION
### Updates
Add step to subset ped file to only sample IDs that are in the input VCF at the start of CleanVcf. This is a patch to avoid a bug that can occur in CleanVcf1_20 when there are extra samples in the ped file (that are not in the VCF) whose sex is listed as a value other than 1 or 2 (under some circumstances). This subset step will become unnecessary and should be removed once the rewrite of CleanVcf, which uses the sample IDs in the VCF as a starting point, is merged.

### Testing
* Validated all WDLs and JSONs with womtool
* Successfully ran MakeCohortVcf.wdl with test_large dataset with extra sex=0 samples in the PED file. 
  * Caveat: based on the outputs of CleanVcf1_5, CleanVcf1_6 and subsequently CleanVcf1_20 were skipped. Please advise if further testing is recommended. It has already been confirmed that manually subsetting the PED file to remove extra samples solved the problem for the user that encountered it.