### PR TITLE
Add a WDL to run ExpansionHunter on multiple samples

### DIFF
--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -20,6 +20,7 @@ workflow ExpansionHunter {
         File reference_fasta
         File? reference_fasta_index
         File variant_catalog
+        File? output_prefix
         String docker_file
         RuntimeAttr? runtime_attr
     }
@@ -35,6 +36,15 @@ workflow ExpansionHunter {
         reference_fasta_index,
         reference_fasta + ".fai"])
 
+    String output_prefix_ =
+        if defined(output_prefix) then
+            select_first([output_prefix])
+        else
+            if is_bam then
+                basename(bam_or_cram, ".bam")
+            else
+                basename(bam_or_cram, ".cram")
+
     call RunExpansionHunter {
         input:
             bam_or_cram = bam_or_cram,
@@ -42,6 +52,7 @@ workflow ExpansionHunter {
             reference_fasta = reference_fasta,
             reference_fasta_index = reference_fasta_index_,
             variant_catalog = variant_catalog,
+            output_prefix = output_prefix_,
             docker_file = docker_file,
             runtime_attr_override = runtime_attr,
     }
@@ -60,11 +71,10 @@ task RunExpansionHunter {
         File reference_fasta
         File reference_fasta_index
         File variant_catalog
+        String output_prefix
         String docker_file
         RuntimeAttr? runtime_attr_override
     }
-
-    String output_prefix = "output"
 
     output {
         File json = "${output_prefix}.json"

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -1,0 +1,47 @@
+version 1.0
+
+import "Structs.wdl"
+import "ExpansionHunter.wdl" as ExpansionHunter
+
+workflow ExpansionHunterScatter {
+
+    input {
+        Array[File] bams_or_crams
+        Array[File]? bams_or_crams_indexes
+        File reference_fasta
+        File? reference_fasta_index
+        File variant_catalog
+        String eh_docker
+        RuntimeAttr? runtime_attr
+    }
+
+    scatter (i in range(length(bams_or_crams))) {
+        File bam_or_cram_ = bams_or_crams[i]
+        Boolean is_bam =
+            basename(bam_or_cram_, ".bam") + ".bam" == basename(bam_or_cram_)
+        File bam_or_cram_index_ =
+            if defined(bams_or_crams_indexes) then
+                select_first([bams_or_crams_indexes])[i]
+            else
+                bam_or_cram_ + if is_bam then ".bai" else ".crai"
+        File reference_fasta_index_ = select_first([
+            reference_fasta_index, reference_fasta + ".fai"])
+
+        call ExpansionHunter.ExpansionHunter as expanionHunter {
+            input:
+                bam_or_cram=bam_or_cram_,
+                bam_or_cram_index=bam_or_cram_index_,
+                reference_fasta=reference_fasta,
+                reference_fasta_index=reference_fasta_index_,
+                variant_catalog=variant_catalog,
+                docker_file=eh_docker,
+                runtime_attr=runtime_attr
+        }
+    }
+
+    output {
+        Array[File] jsons = expanionHunter.json
+        Array[File] vcfs = expanionHunter.vcf
+        Array[File] overlapping_reads = expanionHunter.overlapping_reads
+    }
+}


### PR DESCRIPTION
This PR adds `ExpansionHunterScatter.wdl` that takes multiple bam/cram as input and runs them on separate instances of ExpansionHunter in parallel.  