### PR TITLE
Get male-only var IDs from ped file and GTs not log p-value

### DIFF
--- a/wdl/GATKSVPipelinePhase1.wdl
+++ b/wdl/GATKSVPipelinePhase1.wdl
@@ -223,6 +223,7 @@ workflow GATKSVPipelinePhase1 {
     RuntimeAttr? runtime_attr_exclude_outliers
     RuntimeAttr? runtime_attr_cat_outliers
     RuntimeAttr? runtime_attr_filter_samples
+    RuntimeAttr? runtime_attr_get_male_only
 
     ############################################################
     ## Module metrics parameters for GatherBatchEvidence, ClusterBatch, GenerateBatchMetrics, FilterBatch metrics

--- a/wdl/PETest.wdl
+++ b/wdl/PETest.wdl
@@ -17,6 +17,7 @@ workflow PETest {
     File ped_file
     File male_samples
     File female_samples
+    File male_only_variant_ids
     File samples
     Int common_cnv_size_cutoff
 
@@ -47,6 +48,7 @@ workflow PETest {
         samples = samples,
         male_samples = male_samples,
         female_samples = female_samples,
+        male_only_variant_ids = male_only_variant_ids,
         allosome = false,
         ref_dict = ref_dict,
         common_cnv_size_cutoff = common_cnv_size_cutoff,
@@ -75,6 +77,7 @@ workflow PETest {
         samples = samples,
         male_samples = male_samples,
         female_samples = female_samples,
+        male_only_variant_ids = male_only_variant_ids,
         allosome = true,
         ref_dict = ref_dict,
         common_cnv_size_cutoff = common_cnv_size_cutoff,

--- a/wdl/PETestChromosome.wdl
+++ b/wdl/PETestChromosome.wdl
@@ -16,6 +16,7 @@ workflow PETestChromosome {
     Int? suffix_len
     File male_samples
     File female_samples
+    File male_only_variant_ids
     File samples
     Boolean allosome
     Int common_cnv_size_cutoff
@@ -77,10 +78,11 @@ workflow PETestChromosome {
         input:
           male_test = PETestMale.stats,
           female_test = PETestFemale.stats,
+          male_only_ids_list = male_only_variant_ids,
           chrom = chrom,
           sv_pipeline_docker = sv_pipeline_docker,
           runtime_attr_override = runtime_attr_merge_allo,
-          male_only_expr = "females.log_pval == 0"
+          male_only_expr = "females.name.isin(male_only_ids)"
       }
     }
     if (!allosome) {

--- a/wdl/RDTest.wdl
+++ b/wdl/RDTest.wdl
@@ -17,6 +17,7 @@ workflow RDTest {
     File ped_file
     File male_samples
     File female_samples
+    File male_only_variant_ids
     File samples
     File ref_dict
 
@@ -47,6 +48,7 @@ workflow RDTest {
         samples = samples,
         male_samples = male_samples,
         female_samples = female_samples,
+        male_only_variant_ids = male_only_variant_ids,
         allosome = false,
         ref_dict = ref_dict,
         sv_pipeline_docker = sv_pipeline_docker,
@@ -74,6 +76,7 @@ workflow RDTest {
         samples = samples,
         male_samples = male_samples,
         female_samples = female_samples,
+        male_only_variant_ids = male_only_variant_ids,
         allosome = true,
         ref_dict = ref_dict,
         sv_pipeline_docker = sv_pipeline_docker,

--- a/wdl/RDTestChromosome.wdl
+++ b/wdl/RDTestChromosome.wdl
@@ -16,6 +16,7 @@ workflow RDTestChromosome {
     Int? suffix_len
     File male_samples
     File female_samples
+    File male_only_variant_ids
     File samples
     Boolean allosome
     File ref_dict
@@ -79,10 +80,11 @@ workflow RDTestChromosome {
         input:
           male_test = RDTestMale.stats,
           female_test = RDTestFemale.stats,
+          male_only_ids_list = male_only_variant_ids,
           chrom = chrom,
           sv_pipeline_docker = sv_pipeline_docker,
           runtime_attr_override = runtime_attr_merge_allo,
-          male_only_expr = "females.P.astype(str) == 'No_samples_for_analysis'"
+          male_only_expr = "females.CNVID.isin(male_only_ids)"
       }
     }
 

--- a/wdl/SRTest.wdl
+++ b/wdl/SRTest.wdl
@@ -16,6 +16,7 @@ workflow SRTest {
     String algorithm
     File male_samples
     File female_samples
+    File male_only_variant_ids
     File samples
     Boolean run_common
     Int? common_cnv_size_cutoff  # Required if run_common is true
@@ -49,6 +50,7 @@ workflow SRTest {
         samples = samples,
         male_samples = male_samples,
         female_samples = female_samples,
+        male_only_variant_ids = male_only_variant_ids,
         allosome = false,
         run_common = run_common,
         common_cnv_size_cutoff = common_cnv_size_cutoff,
@@ -78,6 +80,7 @@ workflow SRTest {
         samples = samples,
         male_samples = male_samples,
         female_samples = female_samples,
+        male_only_variant_ids = male_only_variant_ids,
         allosome = true,
         run_common = run_common,
         common_cnv_size_cutoff = common_cnv_size_cutoff,

--- a/wdl/SRTestChromosome.wdl
+++ b/wdl/SRTestChromosome.wdl
@@ -15,6 +15,7 @@ workflow SRTestChromosome {
     Int? suffix_len
     File male_samples
     File female_samples
+    File male_only_variant_ids
     File samples
     File ref_dict
     Boolean allosome
@@ -78,10 +79,11 @@ workflow SRTestChromosome {
         input:
           male_test = SRTestMale.stats,
           female_test = SRTestFemale.stats,
+          male_only_ids_list = male_only_variant_ids,
           chrom = chrom,
           runtime_attr_override = runtime_attr_merge_allo,
           sv_pipeline_docker = sv_pipeline_docker,
-          male_only_expr = "females.log_pval == 0"
+          male_only_expr = "females.name.isin(male_only_ids)"
       }
     } 
 

--- a/wdl/TasksGenerateBatchMetrics.wdl
+++ b/wdl/TasksGenerateBatchMetrics.wdl
@@ -117,6 +117,7 @@ task MergeAllosomes {
   input {
     File male_test
     File female_test
+    File male_only_ids_list
     String chrom
     String male_only_expr
     String sv_pipeline_docker
@@ -143,6 +144,10 @@ task MergeAllosomes {
     import pandas as pd
     males = pd.read_table("~{male_test}")
     females = pd.read_table("~{female_test}")
+    male_only_ids = set()
+    with open("~{male_only_ids_list}", 'r') as male_only_file:
+      for line in male_only_file:
+        male_only_ids.add(line.strip())
     if "~{chrom}" == 'Y' or "~{chrom}" == 'chrY':
       males.to_csv("~{basename(male_test)}.merged.csv", sep='\t', index=False, na_rep='NA')
     else:


### PR DESCRIPTION
### Updates
Issue: Previous method of determining which variants on chrX appeared only in males and should use evidence from males instead of (preferentially, by default) females caused issues with some variants in SRTest that had a log p-value of 0 for one position (start or end) but not the other, resulting in mixing and matching SR coordinates.

Fix: Determine male-only variant IDs for each caller VCF from GTs and ped file and supply the list to SRTest, PETest, and RDTest. Use male evidence only for variant IDs appearing in the male-only list.

### Testing
Tested with one full-genome gnomAD batch and spot-checked that one variant was properly rescued (compared to original gnomAD run) and one variant had the correct matched SR coordinates (compared to previous master). Also confirmed no changes other than on chrX.