### PR TITLE
Expose runtime attributes in AnnotateVcf

### DIFF
--- a/wdl/AnnotateExternalAF.wdl
+++ b/wdl/AnnotateExternalAF.wdl
@@ -26,17 +26,23 @@ workflow AnnotateExternalAF {
         RuntimeAttr? runtime_attr_modify_vcf
         RuntimeAttr? runtime_override_combine_vcfs
         RuntimeAttr? runtime_override_split_vcf
+        RuntimeAttr? runtime_attr_split_ref_bed
+        RuntimeAttr? runtime_attr_split_query_vcf
+        RuntimeAttr? runtime_attr_bedtools_closest
+        RuntimeAttr? runtime_attr_select_matched_svs
 
     }
     call SplitBed as split_ref_bed{
         input:
             bed = ref_bed,
-            sv_base_mini_docker = sv_base_mini_docker
+            sv_base_mini_docker = sv_base_mini_docker,
+            runtime_attr_override = runtime_attr_split_ref_bed
     }
     call SplitVcf as split_query_vcf{
         input:
             vcf = vcf,
-            sv_pipeline_docker = sv_pipeline_docker
+            sv_pipeline_docker = sv_pipeline_docker,
+            runtime_attr_override = runtime_attr_split_query_vcf
     }
 
     Array[String] svtype_list = ["DEL","DUP","INS","INV_CPX","BND_CTX"]
@@ -60,13 +66,14 @@ workflow AnnotateExternalAF {
                 population = population,
                 contig = contig,
                 ref_prefix = ref_prefix,
-
                 max_shards_per_chrom_step1 = max_shards_per_chrom_step1,
                 min_records_per_shard_step1 = min_records_per_shard_step1,
                 sv_base_mini_docker = sv_base_mini_docker,
                 sv_pipeline_docker = sv_pipeline_docker,
                 runtime_override_split_vcf = runtime_override_split_vcf,
                 runtime_attr_modify_vcf = runtime_attr_modify_vcf
+                runtime_attr_select_matched_svs = runtime_attr_select_matched_svs,
+                runtime_attr_bedtools_closest = runtime_attr_bedtools_closest
         }
     }
 

--- a/wdl/AnnotateVcf.wdl
+++ b/wdl/AnnotateVcf.wdl
@@ -43,6 +43,10 @@ workflow AnnotateVcf {
     RuntimeAttr? runtime_attr_modify_vcf
     RuntimeAttr? runtime_override_combine_vcfs
     RuntimeAttr? runtime_override_split_vcf
+    RuntimeAttr? runtime_attr_split_ref_bed
+    RuntimeAttr? runtime_attr_split_query_vcf
+    RuntimeAttr? runtime_attr_bedtools_closest
+    RuntimeAttr? runtime_attr_select_matched_svs
   }
 
   call ann.ScatterAnnotateVcfByChrom as ScatterAnnotateVcfByChrom {
@@ -98,7 +102,11 @@ workflow AnnotateVcf {
         sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_modify_vcf = runtime_attr_modify_vcf,
         runtime_override_split_vcf = runtime_override_split_vcf,
-        runtime_override_combine_vcfs = runtime_override_combine_vcfs
+        runtime_override_combine_vcfs = runtime_override_combine_vcfs,
+        runtime_attr_split_ref_bed = runtime_attr_split_ref_bed,
+        runtime_attr_split_query_vcf = runtime_attr_split_query_vcf,
+        runtime_attr_bedtools_closest = runtime_attr_bedtools_closest,
+        runtime_attr_select_matched_svs = runtime_attr_select_matched_svs
     }
   }
 


### PR DESCRIPTION
### Updates
Expose runtime attributes in AnnotateVcf.wdl and subworkflows. Requested by an internal user who ran out of memory in `AnnotateVcf.AnnotateExternalAF.split_query_vcf` and was not able to increase the memory in Terra.

### Testing
* Validated AnnotateVcf.wdl with womtool. 
* Did not run a test because we lack test data for AnnotateVcf.wdl in the repo, but I have another PR coming soon that will hopefully address that, and the user can also test the fix and report back.