### PR TITLE
Update single-sample WDL to GetMaleOnlyVariantIDs before SRTest

### DIFF
--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -304,6 +304,7 @@ workflow GATKSVPipelineSingleSample {
     RuntimeAttr? runtime_attr_rewritesrcoords
 
     RuntimeAttr? runtime_attr_merge_pesr_vcfs
+    RuntimeAttr? runtime_attr_get_male_only
 
     ############################################################
     ## GenotypeBatch
@@ -773,6 +774,15 @@ workflow GATKSVPipelineSingleSample {
       sv_base_docker = sv_base_docker
   }
 
+  call batchmetrics.GetMaleOnlyVariantIDs {
+    input:
+      vcf = ClusterBatch.depth_vcf,
+      female_samples = SamplesList.female_samples,
+      male_samples = SamplesList.male_samples,
+      sv_pipeline_docker = sv_pipeline_docker,
+      runtime_attr_override = runtime_attr_get_male_only
+  }
+
   call SRTest.SRTest as SRTest {
     input:
       splitfile = GatherBatchEvidence.merged_SR,
@@ -788,6 +798,7 @@ workflow GATKSVPipelineSingleSample {
       samples = SamplesList.samples_file,
       male_samples = SamplesList.male_samples,
       female_samples = SamplesList.female_samples,
+      male_only_variant_ids = GetMaleOnlyVariantIDs.male_only_variant_ids,
       run_common = false,
       sv_base_mini_docker = sv_base_mini_docker,
       linux_docker = linux_docker,


### PR DESCRIPTION
### Updates
Add GetMaleOnlyVariantIDs before standalone SRTest task in single-sample WDL, to bring the single-sample pipeline up to date with #254. 

### Testing
* Validated all WDLs and JSONs
* Ran GATKSVPipelineSingleSampleTest.wdl successfully with changes