### PR TITLE
Add a link to PanGenie docker image in dockers.json file

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -20,5 +20,6 @@
   "igv_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/igv:mw-xz-fixes-2-b1be6a9",
   "duphold_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/duphold:mw-xz-fixes-2-b1be6a9",
   "vapor_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/vapor:mw-xz-fixes-2-b1be6a9",
-  "cloud_sdk_docker" : "google/cloud-sdk"
+  "cloud_sdk_docker" : "google/cloud-sdk",
+  "pangenie": "us.gcr.io/broad-dsde-methods/vjalili/pangenie:vj-127571f"
 }

--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -21,5 +21,5 @@
   "duphold_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/duphold:mw-xz-fixes-2-b1be6a9",
   "vapor_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/vapor:mw-xz-fixes-2-b1be6a9",
   "cloud_sdk_docker" : "google/cloud-sdk",
-  "pangenie": "us.gcr.io/broad-dsde-methods/vjalili/pangenie:vj-127571f"
+  "pangenie_docker": "us.gcr.io/broad-dsde-methods/vjalili/pangenie:vj-127571f"
 }


### PR DESCRIPTION
Following a suggestion in https://github.com/broadinstitute/gatk-sv/pull/252, this PR adds a link to a docker image of PanGenie in `dockers.json` file. The docker image is hosted on GCR. 