### PR TITLE
Update the link to the melt docker image.

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -8,7 +8,7 @@
   "genomes_in_the_cloud_docker" : "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker" : "marketplace.gcr.io/google/ubuntu1804",
   "manta_docker" : "us.gcr.io/broad-dsde-methods/manta:8645aa",
-  "melt_docker" : "us.gcr.io/broad-dsde-methods/vjalili/melt:lint-24b9cda",
+  "melt_docker" : "us.gcr.io/talkowski-sv-gnomad/melt:vj-4ff9de9f",
   "samtools_cloud_docker" : "us.gcr.io/broad-dsde-methods/gatk-sv/samtools-cloud:mw-gnomad-02-6a66c96",
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-base:mw-gnomad-0506-pr-087d4df",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-base-mini:mw-gnomad-0506-pr-087d4df",


### PR DESCRIPTION
Updates the link to the docker image of melt by replacing the image under `broad-dsde-methods` account with the one under `talkowski-sv-gnomad`. The image is built using the code in the current latest commit on the master branch (`Commit SHA: 4ff9de9f348084ad3b3966c0606a56d147fe05a1`). 