### PR TITLE
Subset to chrX for GetMaleOnlyVariantIDs

### DIFF
--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -292,6 +292,7 @@ workflow GATKSVPipelineSingleSample {
 
     File rmsk
     File segdups
+    String? chr_x
 
     Int? min_large_pesr_call_size_for_filtering
     Float? min_large_pesr_depth_overlap_fraction
@@ -779,6 +780,7 @@ workflow GATKSVPipelineSingleSample {
       vcf = ClusterBatch.depth_vcf,
       female_samples = SamplesList.female_samples,
       male_samples = SamplesList.male_samples,
+      contig = select_first([chr_x, "chrX"]),
       sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_get_male_only
   }

--- a/wdl/GenerateBatchMetrics.wdl
+++ b/wdl/GenerateBatchMetrics.wdl
@@ -36,6 +36,7 @@ workflow GenerateBatchMetrics {
     File autosome_contigs
     File allosome_contigs
     File ref_dict
+    String? chr_x
 
     # Module metrics parameters
     # Run module metrics workflow at the end - on by default
@@ -107,6 +108,7 @@ workflow GenerateBatchMetrics {
           vcf = vcf,
           female_samples = GetSampleLists.female_samples,
           male_samples = GetSampleLists.male_samples,
+          contig = select_first([chr_x, "chrX"]),
           sv_pipeline_docker = sv_pipeline_docker,
           runtime_attr_override = runtime_attr_get_male_only
       }
@@ -349,6 +351,7 @@ task GetMaleOnlyVariantIDs {
     File vcf
     File female_samples
     File male_samples
+    String contig
     String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
@@ -367,8 +370,8 @@ task GetMaleOnlyVariantIDs {
     File male_only_variant_ids = "male_only_variant_ids.txt"
   }
   command <<<
-    bcftools view -t chrX -S ~{male_samples} ~{vcf} | bcftools view --min-ac 1 | bcftools query -f '%ID\n' > variant_ids_in_males.txt
-    bcftools view -t chrX -S ~{female_samples} ~{vcf} | bcftools view --min-ac 1 | bcftools query -f '%ID\n' > variant_ids_in_females.txt
+    bcftools view -t ~{contig} -S ~{male_samples} ~{vcf} | bcftools view --min-ac 1 | bcftools query -f '%ID\n' > variant_ids_in_males.txt
+    bcftools view -t ~{contig} -S ~{female_samples} ~{vcf} | bcftools view --min-ac 1 | bcftools query -f '%ID\n' > variant_ids_in_females.txt
     awk 'NR==FNR{a[$0];next} !($0 in a)' variant_ids_in_females.txt variant_ids_in_males.txt > male_only_variant_ids.txt
     
   >>>

--- a/wdl/GenerateBatchMetrics.wdl
+++ b/wdl/GenerateBatchMetrics.wdl
@@ -367,8 +367,8 @@ task GetMaleOnlyVariantIDs {
     File male_only_variant_ids = "male_only_variant_ids.txt"
   }
   command <<<
-    bcftools view -S ~{male_samples} ~{vcf} | bcftools view --min-ac 1 | bcftools query -f '%ID\n' > variant_ids_in_males.txt
-    bcftools view -S ~{female_samples} ~{vcf} | bcftools view --min-ac 1 | bcftools query -f '%ID\n' > variant_ids_in_females.txt
+    bcftools view -t chrX -S ~{male_samples} ~{vcf} | bcftools view --min-ac 1 | bcftools query -f '%ID\n' > variant_ids_in_males.txt
+    bcftools view -t chrX -S ~{female_samples} ~{vcf} | bcftools view --min-ac 1 | bcftools query -f '%ID\n' > variant_ids_in_females.txt
     awk 'NR==FNR{a[$0];next} !($0 in a)' variant_ids_in_females.txt variant_ids_in_males.txt > male_only_variant_ids.txt
     
   >>>


### PR DESCRIPTION
### Updates
Subset to chrX for GetMaleOnlyVariantIDs for space and memory efficiency, as the only variants for which the male-only status matters are on chrX. 
Note: bcftools view -t was used in place of -r because the input VCFs do not appear to be indexed. It is still highly efficient.

### Testing
* Validated all WDLs and JSONs with womtool
* Tested one gnomAD batch - it finished successfully, and all of the GetMaleOnlyVariantIDs outputs were identical to the chrX portion of the previous master outputs. Note that I did not compare the final module outputs directly because the gnomAD processing was done on a branch with other changes to enable processing chrX only.