### PR TITLE
Filter sites with NA score

### DIFF
--- a/wdl/FilterBatchSites.wdl
+++ b/wdl/FilterBatchSites.wdl
@@ -186,8 +186,8 @@ task FilterAnnotateVcf {
 
     set -euo pipefail
     cat \
-      <(sed -e '1d' ~{scores} | fgrep -e DEL -e DUP | awk '($3>=0.5)' | cut -f1 | fgrep -w -f - <(zcat ~{vcf})) \
-      <(sed -e '1d' ~{scores} | fgrep -e INV -e BND -e INS | awk '($3>=0.5)' | cut -f1 | fgrep -w -f - <(zcat ~{vcf}) | sed -e 's/SVTYPE=DEL/SVTYPE=BND/' -e 's/SVTYPE=DUP/SVTYPE=BND/' -e 's/<DEL>/<BND>/' -e 's/<DUP>/<BND>/') \
+    <(sed -e '1d' ~{scores} | fgrep -e DEL -e DUP | awk '($3!="NA" && $3>=0.5)' | cut -f1 | fgrep -w -f - <(zcat ~{vcf})) \
+    <(sed -e '1d' ~{scores} | fgrep -e INV -e BND -e INS | awk '($3!="NA" && $3>=0.5)' | cut -f1 | fgrep -w -f - <(zcat ~{vcf}) | sed -e 's/SVTYPE=DEL/SVTYPE=BND/' -e 's/SVTYPE=DUP/SVTYPE=BND/' -e 's/<DEL>/<BND>/' -e 's/<DUP>/<BND>/') \
       | cat <(sed -n -e '/^#/p' <(zcat ~{vcf})) - \
       | vcf-sort -c \
       | bgzip -c \


### PR DESCRIPTION
Fixes an issue in `FilterBatch` where variants with a score of `NA` were not being filtered. This case seems to only affect depth-only calls and occurs for one of three reasons:

1. all samples are non-ref, 
2. all samples are ref,
3. or insufficient read count bins

The cause in most cases is (2). In our 1KGP panel (batch 1), this eliminates 1518 sites, 1488 of which are on chrY. We currently allow raw calls on chrY in female samples, but `GenerateBatchMetrics` only considers males. Therefore there are many depth-only / female-only CNVs with all-ref genotypes when subsetted to male samples.