### PR TITLE
remove bgzip for already-gzipped file in XfBatchEffect.GetFreqTable

### DIFF
--- a/wdl/Module07XfBatchEffect.wdl
+++ b/wdl/Module07XfBatchEffect.wdl
@@ -308,7 +308,6 @@ task GetFreqTable {
     | sed 's/^name/\#VID/g' \
     | gzip -c \
     > "~{prefix}.frequencies.allPops.txt.gz"
-    bgzip "~{prefix}.frequencies.txt"
   >>>
 
   output {


### PR DESCRIPTION
### Updates
Remove bgzip for an already-gzipped file in Module07XfBatchEffect.GetFreqTable. This bgzip line caused the task to fail because the un-zipped file did not exist as it had already been zipped.

### Testing
Tested in Terra in a beta tester's workspace. The workflow was successful and GetFreqTable outputted a gzipped file.