### PR TITLE
Incorporate timing and optimization flags of EH

### DIFF
--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -61,6 +61,7 @@ workflow ExpansionHunter {
         File json = RunExpansionHunter.json
         File vcf = RunExpansionHunter.vcf
         File overlapping_reads = RunExpansionHunter.overlapping_reads
+        File timing = RunExpansionHunter.timing
     }
 }
 
@@ -80,6 +81,7 @@ task RunExpansionHunter {
         File json = "${output_prefix}.json"
         File vcf = "${output_prefix}.vcf"
         File overlapping_reads = "${output_prefix}_realigned.bam"
+        File timing = "${output_prefix}_timing.tsv"
     }
 
     command <<<
@@ -89,7 +91,9 @@ task RunExpansionHunter {
             --reads ~{bam_or_cram} \
             --reference ~{reference_fasta} \
             --variant-catalog ~{variant_catalog} \
-            --output-prefix ~{output_prefix}
+            --output-prefix ~{output_prefix} \
+            --cache-mates \
+            --record-timing
     >>>
 
     RuntimeAttr runtime_attr_str_profile_default = object {

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -54,5 +54,6 @@ workflow ExpansionHunterScatter {
         Array[File] jsons = expanionHunter.json
         Array[File] vcfs = expanionHunter.vcf
         Array[File] overlapping_reads = expanionHunter.overlapping_reads
+        Array[File] timing = expanionHunter.timing
     }
 }


### PR DESCRIPTION
EH v.5 has two new flags, `--record-timing` and `--cache-mates`, which respectively report a breakdown on the runtime of every EH step per target STR site, and make caching optimizations. We use both of these flags for EH dev. 