### PR TITLE
Scatter expansion hunter on batches of variant catalogs

### DIFF
--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -3,6 +3,7 @@
 version 1.0
 
 import "Structs.wdl"
+import "TasksMakeCohortVcf.wdl" as MiniTasks
 
 struct FilenamePostfixes {
     String locus
@@ -22,8 +23,10 @@ workflow ExpansionHunter {
         File variant_catalog
         File? output_prefix
         String expansion_hunter_docker
+        String sv_base_mini_docker
         Int variant_catalog_batch_size
         RuntimeAttr? runtime_attr
+        RuntimeAttr? runtime_override_concat
     }
 
     Boolean is_bam = basename(bam_or_cram, ".bam") + ".bam" == basename(bam_or_cram)

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -183,7 +183,7 @@ task ConcatEHOutputs {
         jq -s 'reduce .[] as $item ({}; . * $item)' ~{sep=" " jsons} > ~{output_prefix}.json
 
         VCFS="~{write_lines(vcfs_gz)}"
-        bcftools concat --no-version --naive --naive-force --output-type z --file-list ${VCFS} --output "~{output_prefix}.vcf.gz"
+        bcftools concat --no-version --naive-force --output-type z --file-list ${VCFS} --output "~{output_prefix}.vcf.gz"
 
         BAMS="~{write_lines(overlapping_reads)}"
         samtools merge ~{output_prefix}.bam -b ${BAMS}

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -22,6 +22,7 @@ workflow ExpansionHunter {
         File variant_catalog
         File? output_prefix
         String expansion_hunter_docker
+        Int variant_catalog_batch_size
         RuntimeAttr? runtime_attr
     }
 
@@ -45,23 +46,32 @@ workflow ExpansionHunter {
             else
                 basename(bam_or_cram, ".cram")
 
-    call RunExpansionHunter {
+    call SplitVariantCatalog {
         input:
-            bam_or_cram = bam_or_cram,
-            bam_or_cram_index = bam_or_cram_index_,
-            reference_fasta = reference_fasta,
-            reference_fasta_index = reference_fasta_index_,
             variant_catalog = variant_catalog,
-            output_prefix = output_prefix_,
-            expansion_hunter_docker = expansion_hunter_docker,
-            runtime_attr_override = runtime_attr,
+            batch_size = variant_catalog_batch_size
+    }
+
+    scatter(i in range(length(SplitVariantCatalog.catalogs_json))) {
+        File variant_catalog_split = SplitVariantCatalog.catalogs_json[i]
+        call RunExpansionHunter {
+            input:
+                bam_or_cram = bam_or_cram,
+                bam_or_cram_index = bam_or_cram_index_,
+                reference_fasta = reference_fasta,
+                reference_fasta_index = reference_fasta_index_,
+                variant_catalog = variant_catalog_split,
+                output_prefix = output_prefix_,
+                expansion_hunter_docker = expansion_hunter_docker,
+                runtime_attr_override = runtime_attr,
+        }
     }
 
     output {
-        File json = RunExpansionHunter.json
-        File vcf = RunExpansionHunter.vcf
-        File overlapping_reads = RunExpansionHunter.overlapping_reads
-        File timing = RunExpansionHunter.timing
+        Array[File] json = RunExpansionHunter.json
+        Array[File] vcf = RunExpansionHunter.vcf
+        Array[File] overlapping_reads = RunExpansionHunter.overlapping_reads
+        Array[File] timing = RunExpansionHunter.timing
     }
 }
 
@@ -114,6 +124,90 @@ task RunExpansionHunter {
 
     runtime {
         docker: expansion_hunter_docker
+        cpu: runtime_attr.cpu_cores
+        memory: runtime_attr.mem_gb + " GiB"
+        disks: "local-disk " + runtime_attr.disk_gb + " HDD"
+        bootDiskSizeGb: runtime_attr.boot_disk_gb
+        preemptible: runtime_attr.preemptible_tries
+        maxRetries: runtime_attr.max_retries
+    }
+}
+
+task SplitVariantCatalog {
+    input {
+        File variant_catalog
+        Int batch_size
+        String? split_variant_catalog_docker
+        String? output_prefix
+        RuntimeAttr? runtime_attr_override
+    }
+
+    output {
+        Array[File] catalogs_json = glob("${output_prefix_}*.json")
+    }
+
+    String output_prefix_ =
+        if defined(output_prefix) then
+            select_first([output_prefix])
+        else
+            "output_"
+
+    String split_variant_catalog_docker_ =
+        if defined(split_variant_catalog_docker) then
+            select_first([split_variant_catalog_docker])
+        else
+            "python:slim-buster"
+
+    command <<<
+        set -euxo pipefail
+
+        python <<CODE
+        import json
+        import sys
+        import os
+        from pathlib import Path
+
+        filename = "~{variant_catalog}"
+        filename_without_ext = Path(filename).stem
+        output_prefix = "~{output_prefix_}"
+        i = 0
+        subset_counter = 0
+
+        def serialize():
+            print(f"subset counter: {subset_counter}")
+            with open(f"{output_prefix}{filename_without_ext}_{subset_counter}.json", "w") as f_out:
+                json.dump(subset_catalogs, f_out, indent=4)
+
+        with open(filename, "r") as f_in:
+            catalogs = json.load(f_in)
+
+            subset_catalogs = []
+            for catalog in catalogs:
+                subset_catalogs.append(catalog)
+                i += 1
+                if i == ~{batch_size}:
+                    serialize()
+                    i = 0
+                    subset_counter += 1
+                    subset_catalogs = []
+            serialize()
+        CODE
+    >>>
+
+    RuntimeAttr runtime_attr_str_profile_default = object {
+        cpu_cores: 1,
+        mem_gb: 4,
+        boot_disk_gb: 10,
+        preemptible_tries: 3,
+        max_retries: 1,
+        disk_gb: 10
+    }
+    RuntimeAttr runtime_attr = select_first([
+        runtime_attr_override,
+        runtime_attr_str_profile_default])
+
+    runtime {
+        docker: split_variant_catalog_docker_
         cpu: runtime_attr.cpu_cores
         memory: runtime_attr.mem_gb + " GiB"
         disks: "local-disk " + runtime_attr.disk_gb + " HDD"

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -19,12 +19,11 @@ workflow ExpansionHunter {
         File? bam_or_cram_index
         File reference_fasta
         File? reference_fasta_index
-        File variant_catalog
+        Array[File] split_variant_catalogs
         String sample_id
         File? ped_file
         String expansion_hunter_docker
         String python_docker
-        Int variant_catalog_batch_size
         RuntimeAttr? runtime_attr
         RuntimeAttr? runtime_override_concat
     }
@@ -45,36 +44,27 @@ workflow ExpansionHunter {
         reference_fasta_index,
         reference_fasta + ".fai"])
 
-    call SplitVariantCatalog {
-        input:
-            variant_catalog = variant_catalog,
-            batch_size = variant_catalog_batch_size,
-            output_prefix = sample_id,
-            python_docker = python_docker
-    }
-
-    scatter(i in range(length(SplitVariantCatalog.catalogs_json))) {
-        File variant_catalog_split = SplitVariantCatalog.catalogs_json[i]
-        call RunExpansionHunter {
+    scatter (i in range(length(split_variant_catalogs))) {
+        call RunExpansionHunter as expanionHunter {
             input:
                 bam_or_cram = bam_or_cram,
                 bam_or_cram_index = bam_or_cram_index_,
                 reference_fasta = reference_fasta,
                 reference_fasta_index = reference_fasta_index_,
-                variant_catalog = variant_catalog_split,
+                variant_catalog = split_variant_catalogs[i],
                 sample_id = sample_id,
                 ped_file = ped_file,
                 expansion_hunter_docker = expansion_hunter_docker,
-                runtime_attr_override = runtime_attr,
+                runtime_attr_override = runtime_attr
         }
     }
 
     call ConcatEHOutputs {
         input:
-            vcfs_gz = RunExpansionHunter.vcf_gz,
-            jsons = RunExpansionHunter.json,
-            overlapping_reads = RunExpansionHunter.overlapping_reads,
-            timings = RunExpansionHunter.timing,
+            vcfs_gz = expanionHunter.vcf_gz,
+            jsons = expanionHunter.json,
+            overlapping_reads = expanionHunter.overlapping_reads,
+            timings = expanionHunter.timing,
             output_prefix = sample_id,
             expansion_hunter_docker = expansion_hunter_docker
     }
@@ -160,78 +150,6 @@ task RunExpansionHunter {
 
     runtime {
         docker: expansion_hunter_docker
-        cpu: runtime_attr.cpu_cores
-        memory: runtime_attr.mem_gb + " GiB"
-        disks: "local-disk " + runtime_attr.disk_gb + " HDD"
-        bootDiskSizeGb: runtime_attr.boot_disk_gb
-        preemptible: runtime_attr.preemptible_tries
-        maxRetries: runtime_attr.max_retries
-    }
-}
-
-task SplitVariantCatalog {
-    input {
-        File variant_catalog
-        Int batch_size
-        String output_prefix
-        String python_docker
-        RuntimeAttr? runtime_attr_override
-    }
-
-    output {
-        Array[File] catalogs_json = glob("${output_prefix}*.json")
-    }
-
-    command <<<
-        set -euxo pipefail
-
-        python <<CODE
-        import json
-        import sys
-        import os
-        from pathlib import Path
-
-        filename = "~{variant_catalog}"
-        filename_without_ext = Path(filename).stem
-        output_prefix = "~{output_prefix}"
-        i = 0
-        subset_counter = 0
-
-        def serialize():
-            print(f"subset counter: {subset_counter}")
-            with open(f"{output_prefix}{filename_without_ext}_{subset_counter}.json", "w") as f_out:
-                json.dump(subset_catalogs, f_out, indent=4)
-
-        with open(filename, "r") as f_in:
-            catalogs = json.load(f_in)
-
-            subset_catalogs = []
-            for catalog in catalogs:
-                subset_catalogs.append(catalog)
-                i += 1
-                if i == ~{batch_size}:
-                    serialize()
-                    i = 0
-                    subset_counter += 1
-                    subset_catalogs = []
-            serialize()
-        CODE
-    >>>
-
-    RuntimeAttr runtime_attr_str_profile_default = object {
-        cpu_cores: 1,
-        mem_gb: 4,
-        boot_disk_gb: 10,
-        preemptible_tries: 3,
-        max_retries: 1,
-        disk_gb: 10
-    }
-    RuntimeAttr runtime_attr = select_first([
-        runtime_attr_override,
-        runtime_attr_str_profile_default])
-
-    runtime {
-        docker: python_docker
         cpu: runtime_attr.cpu_cores
         memory: runtime_attr.mem_gb + " GiB"
         disks: "local-disk " + runtime_attr.disk_gb + " HDD"

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -22,7 +22,6 @@ workflow ExpansionHunter {
         File variant_catalog
         File? output_prefix
         String expansion_hunter_docker
-        String sv_base_mini_docker
         Int variant_catalog_batch_size
         RuntimeAttr? runtime_attr
         RuntimeAttr? runtime_override_concat

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -191,7 +191,7 @@ task ConcatEHOutputs {
         TIMINGS=(~{sep=" " timings})
         FIRST_TIMING=${TIMINGS[0]}
         head -1 ${FIRST_TIMING} > ~{output_prefix}_timing.tsv
-        tail -n +2 -q ~{sep=" " timings} >> ~{output_prefix}_timing.tsv
+        awk FNR!=1 ~{sep=" " timings} >> ~{output_prefix}_timing.tsv
     >>>
 
     RuntimeAttr runtime_attr_str_profile_default = object {

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -49,6 +49,7 @@ workflow ExpansionHunter {
         input:
             variant_catalog = variant_catalog,
             batch_size = variant_catalog_batch_size,
+            output_prefix = sample_id,
             python_docker = python_docker
     }
 
@@ -172,20 +173,14 @@ task SplitVariantCatalog {
     input {
         File variant_catalog
         Int batch_size
+        String output_prefix
         String python_docker
-        String? output_prefix
         RuntimeAttr? runtime_attr_override
     }
 
     output {
-        Array[File] catalogs_json = glob("${output_prefix_}*.json")
+        Array[File] catalogs_json = glob("${output_prefix}*.json")
     }
-
-    String output_prefix_ =
-        if defined(output_prefix) then
-            select_first([output_prefix])
-        else
-            "output_"
 
     command <<<
         set -euxo pipefail
@@ -198,7 +193,7 @@ task SplitVariantCatalog {
 
         filename = "~{variant_catalog}"
         filename_without_ext = Path(filename).stem
-        output_prefix = "~{output_prefix_}"
+        output_prefix = "~{output_prefix}"
         i = 0
         subset_counter = 0
 

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -14,7 +14,6 @@ workflow ExpansionHunterScatter {
         File variant_catalog
         Int? variant_catalog_batch_size
         String expansion_hunter_docker
-        String sv_base_mini_docker
         RuntimeAttr? runtime_attr
     }
 
@@ -53,7 +52,6 @@ workflow ExpansionHunterScatter {
                 reference_fasta_index=reference_fasta_index_,
                 variant_catalog=variant_catalog,
                 output_prefix=output_prefix,
-                sv_base_mini_docker=sv_base_mini_docker,
                 expansion_hunter_docker=expansion_hunter_docker,
                 variant_catalog_batch_size=variant_catalog_batch_size_
         }

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -12,8 +12,21 @@ workflow ExpansionHunterScatter {
         File reference_fasta
         File? reference_fasta_index
         File variant_catalog
+        Int? variant_catalog_batch_size
         String expansion_hunter_docker
         RuntimeAttr? runtime_attr
+    }
+
+    String variant_catalog_batch_size_ =
+        if defined(variant_catalog_batch_size) then
+            select_first([variant_catalog_batch_size])
+        else
+            10000
+
+    call SplitVariantCatalog {
+        input:
+            variant_catalog = variant_catalog,
+            batch_size = variant_catalog_batch_size_
     }
 
     scatter (i in range(length(bams_or_crams))) {
@@ -37,23 +50,109 @@ workflow ExpansionHunterScatter {
                 else
                     basename(bam_or_cram_, ".cram")
 
-        call ExpansionHunter.ExpansionHunter as expanionHunter {
-            input:
-                bam_or_cram=bam_or_cram_,
-                bam_or_cram_index=bam_or_cram_index_,
-                reference_fasta=reference_fasta,
-                reference_fasta_index=reference_fasta_index_,
-                variant_catalog=variant_catalog,
-                output_prefix=output_prefix,
-                expansion_hunter_docker=expansion_hunter_docker,
-                runtime_attr=runtime_attr
+        scatter (j in range(length(SplitVariantCatalog.catalogs_json))) {
+            File variant_catalog_split = SplitVariantCatalog.catalogs_json[j]
+            call ExpansionHunter.ExpansionHunter as expanionHunter {
+                input:
+                    bam_or_cram=bam_or_cram_,
+                    bam_or_cram_index=bam_or_cram_index_,
+                    reference_fasta=reference_fasta,
+                    reference_fasta_index=reference_fasta_index_,
+                    variant_catalog=variant_catalog_split,
+                    output_prefix=output_prefix,
+                    expansion_hunter_docker=expansion_hunter_docker
+            }
         }
     }
 
     output {
-        Array[File] jsons = expanionHunter.json
-        Array[File] vcfs = expanionHunter.vcf
-        Array[File] overlapping_reads = expanionHunter.overlapping_reads
-        Array[File] timing = expanionHunter.timing
+        Array[Array[File]] jsons = expanionHunter.json
+        Array[Array[File]] vcfs = expanionHunter.vcf
+        Array[Array[File]] overlapping_reads = expanionHunter.overlapping_reads
+        Array[Array[File]] timing = expanionHunter.timing
+    }
+}
+
+task SplitVariantCatalog {
+    input {
+        File variant_catalog
+        Int batch_size
+        String? split_variant_catalog_docker
+        String? output_prefix
+        RuntimeAttr? runtime_attr_override
+    }
+
+    output {
+        Array[File] catalogs_json = glob("${output_prefix_}*.json")
+    }
+
+    String output_prefix_ =
+        if defined(output_prefix) then
+            select_first([output_prefix])
+        else
+            "output_"
+
+    String split_variant_catalog_docker_ =
+        if defined(split_variant_catalog_docker) then
+            select_first([split_variant_catalog_docker])
+        else
+            "python:slim-buster"
+
+    command <<<
+        set -euxo pipefail
+
+        python <<CODE
+        import json
+        import sys
+        import os
+        from pathlib import Path
+
+        filename = "~{variant_catalog}"
+        filename_without_ext = Path(filename).stem
+        output_prefix = "~{output_prefix_}"
+        i = 0
+        subset_counter = 0
+
+        def serialize():
+            print(f"subset counter: {subset_counter}")
+            with open(f"{output_prefix}{filename_without_ext}_{subset_counter}.json", "w") as f_out:
+                json.dump(subset_catalogs, f_out, indent=4)
+
+        with open(filename, "r") as f_in:
+            catalogs = json.load(f_in)
+
+            subset_catalogs = []
+            for catalog in catalogs:
+                subset_catalogs.append(catalog)
+                i += 1
+                if i == ~{batch_size}:
+                    serialize()
+                    i = 0
+                    subset_counter += 1
+                    subset_catalogs = []
+            serialize()
+        CODE
+    >>>
+
+    RuntimeAttr runtime_attr_str_profile_default = object {
+        cpu_cores: 1,
+        mem_gb: 4,
+        boot_disk_gb: 10,
+        preemptible_tries: 3,
+        max_retries: 1,
+        disk_gb: 10
+    }
+    RuntimeAttr runtime_attr = select_first([
+        runtime_attr_override,
+        runtime_attr_str_profile_default])
+
+    runtime {
+        docker: split_variant_catalog_docker_
+        cpu: runtime_attr.cpu_cores
+        memory: runtime_attr.mem_gb + " GiB"
+        disks: "local-disk " + runtime_attr.disk_gb + " HDD"
+        bootDiskSizeGb: runtime_attr.boot_disk_gb
+        preemptible: runtime_attr.preemptible_tries
+        maxRetries: runtime_attr.max_retries
     }
 }

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -98,7 +98,6 @@ task SplitVariantCatalog {
 
 
         def serialize():
-            print(f"subset counter: {subset_counter}")
             with open(f"{output_prefix}{filename_without_ext}_{subset_counter:06}.json", "w") as f_out:
                 json.dump(subset_catalogs, f_out, indent=4)
 

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -92,8 +92,6 @@ task SplitVariantCatalog {
 
         python <<CODE
         import json
-        import sys
-        import os
         from pathlib import Path
 
         filename = "~{variant_catalog}"
@@ -102,10 +100,12 @@ task SplitVariantCatalog {
         i = 0
         subset_counter = 0
 
+
         def serialize():
             print(f"subset counter: {subset_counter}")
             with open(f"{output_prefix}{filename_without_ext}_{subset_counter}.json", "w") as f_out:
                 json.dump(subset_catalogs, f_out, indent=4)
+
 
         with open(filename, "r") as f_in:
             catalogs = json.load(f_in)

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -119,7 +119,8 @@ task SplitVariantCatalog {
                     i = 0
                     subset_counter += 1
                     subset_catalogs = []
-            serialize()
+            if len(subset_catalogs) > 0:
+                serialize()
         CODE
     >>>
 

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -41,16 +41,18 @@ workflow ExpansionHunterScatter {
         File reference_fasta_index_ = select_first([
             reference_fasta_index, reference_fasta + ".fai"])
 
-        String output_prefix =
-            if defined(sample_ids) then
-                select_first([sample_ids])[i]
-            else
-                if is_bam then
-                    basename(bam_or_cram_, ".bam")
-                else
-                    basename(bam_or_cram_, ".cram")
-
         scatter (j in range(length(SplitVariantCatalog.catalogs_json))) {
+            String output_prefix_ =
+                if defined(sample_ids) then
+                    select_first([sample_ids])[i]
+                else
+                    if is_bam then
+                        basename(bam_or_cram_, ".bam")
+                    else
+                        basename(bam_or_cram_, ".cram")
+
+            String output_prefix = output_prefix_ + "_catalog_shard_" + j
+
             File variant_catalog_split = SplitVariantCatalog.catalogs_json[j]
             call ExpansionHunter.ExpansionHunter as expanionHunter {
                 input:

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -23,12 +23,6 @@ workflow ExpansionHunterScatter {
         else
             10000
 
-    call SplitVariantCatalog {
-        input:
-            variant_catalog = variant_catalog,
-            batch_size = variant_catalog_batch_size_
-    }
-
     scatter (i in range(length(bams_or_crams))) {
         File bam_or_cram_ = bams_or_crams[i]
         Boolean is_bam =
@@ -41,29 +35,25 @@ workflow ExpansionHunterScatter {
         File reference_fasta_index_ = select_first([
             reference_fasta_index, reference_fasta + ".fai"])
 
-        scatter (j in range(length(SplitVariantCatalog.catalogs_json))) {
-            String output_prefix_ =
-                if defined(sample_ids) then
-                    select_first([sample_ids])[i]
+        String output_prefix =
+            if defined(sample_ids) then
+                select_first([sample_ids])[i]
+            else
+                if is_bam then
+                    basename(bam_or_cram_, ".bam")
                 else
-                    if is_bam then
-                        basename(bam_or_cram_, ".bam")
-                    else
-                        basename(bam_or_cram_, ".cram")
+                    basename(bam_or_cram_, ".cram")
 
-            String output_prefix = output_prefix_ + "_catalog_shard_" + j
-
-            File variant_catalog_split = SplitVariantCatalog.catalogs_json[j]
-            call ExpansionHunter.ExpansionHunter as expanionHunter {
-                input:
-                    bam_or_cram=bam_or_cram_,
-                    bam_or_cram_index=bam_or_cram_index_,
-                    reference_fasta=reference_fasta,
-                    reference_fasta_index=reference_fasta_index_,
-                    variant_catalog=variant_catalog_split,
-                    output_prefix=output_prefix,
-                    expansion_hunter_docker=expansion_hunter_docker
-            }
+        call ExpansionHunter.ExpansionHunter as expanionHunter {
+            input:
+                bam_or_cram=bam_or_cram_,
+                bam_or_cram_index=bam_or_cram_index_,
+                reference_fasta=reference_fasta,
+                reference_fasta_index=reference_fasta_index_,
+                variant_catalog=variant_catalog,
+                output_prefix=output_prefix,
+                expansion_hunter_docker=expansion_hunter_docker,
+                variant_catalog_batch_size=variant_catalog_batch_size_
         }
     }
 
@@ -72,89 +62,5 @@ workflow ExpansionHunterScatter {
         Array[Array[File]] vcfs = expanionHunter.vcf
         Array[Array[File]] overlapping_reads = expanionHunter.overlapping_reads
         Array[Array[File]] timing = expanionHunter.timing
-    }
-}
-
-task SplitVariantCatalog {
-    input {
-        File variant_catalog
-        Int batch_size
-        String? split_variant_catalog_docker
-        String? output_prefix
-        RuntimeAttr? runtime_attr_override
-    }
-
-    output {
-        Array[File] catalogs_json = glob("${output_prefix_}*.json")
-    }
-
-    String output_prefix_ =
-        if defined(output_prefix) then
-            select_first([output_prefix])
-        else
-            "output_"
-
-    String split_variant_catalog_docker_ =
-        if defined(split_variant_catalog_docker) then
-            select_first([split_variant_catalog_docker])
-        else
-            "python:slim-buster"
-
-    command <<<
-        set -euxo pipefail
-
-        python <<CODE
-        import json
-        import sys
-        import os
-        from pathlib import Path
-
-        filename = "~{variant_catalog}"
-        filename_without_ext = Path(filename).stem
-        output_prefix = "~{output_prefix_}"
-        i = 0
-        subset_counter = 0
-
-        def serialize():
-            print(f"subset counter: {subset_counter}")
-            with open(f"{output_prefix}{filename_without_ext}_{subset_counter}.json", "w") as f_out:
-                json.dump(subset_catalogs, f_out, indent=4)
-
-        with open(filename, "r") as f_in:
-            catalogs = json.load(f_in)
-
-            subset_catalogs = []
-            for catalog in catalogs:
-                subset_catalogs.append(catalog)
-                i += 1
-                if i == ~{batch_size}:
-                    serialize()
-                    i = 0
-                    subset_counter += 1
-                    subset_catalogs = []
-            serialize()
-        CODE
-    >>>
-
-    RuntimeAttr runtime_attr_str_profile_default = object {
-        cpu_cores: 1,
-        mem_gb: 4,
-        boot_disk_gb: 10,
-        preemptible_tries: 3,
-        max_retries: 1,
-        disk_gb: 10
-    }
-    RuntimeAttr runtime_attr = select_first([
-        runtime_attr_override,
-        runtime_attr_str_profile_default])
-
-    runtime {
-        docker: split_variant_catalog_docker_
-        cpu: runtime_attr.cpu_cores
-        memory: runtime_attr.mem_gb + " GiB"
-        disks: "local-disk " + runtime_attr.disk_gb + " HDD"
-        bootDiskSizeGb: runtime_attr.boot_disk_gb
-        preemptible: runtime_attr.preemptible_tries
-        maxRetries: runtime_attr.max_retries
     }
 }

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -60,9 +60,9 @@ workflow ExpansionHunterScatter {
     }
 
     output {
-        Array[Array[File]] jsons = expanionHunter.json
-        Array[Array[File]] vcfs = expanionHunter.vcf
-        Array[Array[File]] overlapping_reads = expanionHunter.overlapping_reads
-        Array[Array[File]] timing = expanionHunter.timing
+        Array[File] jsons = expanionHunter.json
+        Array[File] vcfs_gz = expanionHunter.vcf_gz
+        Array[File] overlapping_reads = expanionHunter.overlapping_reads
+        Array[File] timing = expanionHunter.timing
     }
 }

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -24,11 +24,7 @@ workflow ExpansionHunterScatter {
         sample_ids: "One ID per sample, in the same order as the files in bams_or_crams. These IDs must match the ID given in the second column (`Individual ID` column) of the given PED file. These IDs will also be used as an output prefix."
     }
 
-    String variant_catalog_batch_size_ =
-        if defined(variant_catalog_batch_size) then
-            select_first([variant_catalog_batch_size])
-        else
-            10000
+    String variant_catalog_batch_size_ = select_first([variant_catalog_batch_size, 1000])
 
     call SplitVariantCatalog as svc {
         input:

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -99,7 +99,7 @@ task SplitVariantCatalog {
 
         def serialize():
             print(f"subset counter: {subset_counter}")
-            with open(f"{output_prefix}{filename_without_ext}_{subset_counter}.json", "w") as f_out:
+            with open(f"{output_prefix}{filename_without_ext}_{subset_counter:06}.json", "w") as f_out:
                 json.dump(subset_catalogs, f_out, indent=4)
 
 

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -12,7 +12,7 @@ workflow ExpansionHunterScatter {
         File? ped_file
         File reference_fasta
         File? reference_fasta_index
-        File variant_catalog
+        File variant_catalog_json
         Int? variant_catalog_batch_size
         String expansion_hunter_docker
         String python_docker

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -28,9 +28,9 @@ workflow ExpansionHunterScatter {
 
     call SplitVariantCatalog as svc {
         input:
-            variant_catalog = variant_catalog,
+            variant_catalog = variant_catalog_json,
             batch_size = variant_catalog_batch_size_,
-            output_prefix = basename(variant_catalog, ".json"),
+            output_prefix = basename(variant_catalog_json, ".json"),
             python_docker = python_docker
     }
 

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -30,7 +30,7 @@ workflow ExpansionHunterScatter {
         input:
             variant_catalog = variant_catalog,
             batch_size = variant_catalog_batch_size_,
-            output_prefix = basename(variant_catalog),
+            output_prefix = basename(variant_catalog, ".json"),
             python_docker = python_docker
     }
 

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -15,6 +15,7 @@ workflow ExpansionHunterScatter {
         File variant_catalog
         Int? variant_catalog_batch_size
         String expansion_hunter_docker
+        String python_docker
         RuntimeAttr? runtime_attr
     }
 
@@ -53,6 +54,7 @@ workflow ExpansionHunterScatter {
                 sample_id=sample_id,
                 ped_file=ped_file,
                 expansion_hunter_docker=expansion_hunter_docker,
+                python_docker=python_docker,
                 variant_catalog_batch_size=variant_catalog_batch_size_
         }
     }

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -119,7 +119,7 @@ task SplitVariantCatalog {
         CODE
     >>>
 
-    RuntimeAttr runtime_attr_str_profile_default = object {
+    RuntimeAttr default_attr = object {
         cpu_cores: 1,
         mem_gb: 4,
         boot_disk_gb: 10,
@@ -127,17 +127,14 @@ task SplitVariantCatalog {
         max_retries: 1,
         disk_gb: 10
     }
-    RuntimeAttr runtime_attr = select_first([
-        runtime_attr_override,
-        runtime_attr_str_profile_default])
 
     runtime {
         docker: python_docker
-        cpu: runtime_attr.cpu_cores
-        memory: runtime_attr.mem_gb + " GiB"
-        disks: "local-disk " + runtime_attr.disk_gb + " HDD"
-        bootDiskSizeGb: runtime_attr.boot_disk_gb
-        preemptible: runtime_attr.preemptible_tries
-        maxRetries: runtime_attr.max_retries
+        cpu: select_first([runtime_attr_override.cpu_cores, default_attr.cpu_cores])
+        memory: select_first([runtime_attr_override.mem_gb, default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " + select_first([runtime_attr_override.disk_gb, default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb: select_first([runtime_attr_override.boot_disk_gb, default_attr.boot_disk_gb])
+        preemptible: select_first([runtime_attr_override.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries: select_first([runtime_attr_override.max_retries, default_attr.max_retries])
     }
 }

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -14,6 +14,7 @@ workflow ExpansionHunterScatter {
         File variant_catalog
         Int? variant_catalog_batch_size
         String expansion_hunter_docker
+        String sv_base_mini_docker
         RuntimeAttr? runtime_attr
     }
 
@@ -52,6 +53,7 @@ workflow ExpansionHunterScatter {
                 reference_fasta_index=reference_fasta_index_,
                 variant_catalog=variant_catalog,
                 output_prefix=output_prefix,
+                sv_base_mini_docker=sv_base_mini_docker,
                 expansion_hunter_docker=expansion_hunter_docker,
                 variant_catalog_batch_size=variant_catalog_batch_size_
         }

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -34,7 +34,7 @@ workflow ExpansionHunterScatter {
         input:
             variant_catalog = variant_catalog,
             batch_size = variant_catalog_batch_size_,
-            output_prefix = sample_id,
+            output_prefix = basename(variant_catalog),
             python_docker = python_docker
     }
 
@@ -84,7 +84,7 @@ task SplitVariantCatalog {
     }
 
     output {
-        Array[File] catalogs_json = glob("${output_prefix}*.json")
+        Array[File] catalogs_json = glob("~{output_prefix}*.json")
     }
 
     command <<<

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -30,6 +30,14 @@ workflow ExpansionHunterScatter {
         else
             10000
 
+    call SplitVariantCatalog as svc {
+        input:
+            variant_catalog = variant_catalog,
+            batch_size = variant_catalog_batch_size_,
+            output_prefix = sample_id,
+            python_docker = python_docker
+    }
+
     scatter (i in range(length(bams_or_crams))) {
         File bam_or_cram_ = bams_or_crams[i]
         Boolean is_bam =
@@ -50,12 +58,11 @@ workflow ExpansionHunterScatter {
                 bam_or_cram_index=bam_or_cram_index_,
                 reference_fasta=reference_fasta,
                 reference_fasta_index=reference_fasta_index_,
-                variant_catalog=variant_catalog,
+                split_variant_catalogs=svc.catalogs_json,
                 sample_id=sample_id,
                 ped_file=ped_file,
                 expansion_hunter_docker=expansion_hunter_docker,
-                python_docker=python_docker,
-                variant_catalog_batch_size=variant_catalog_batch_size_
+                python_docker=python_docker
         }
     }
 
@@ -64,5 +71,77 @@ workflow ExpansionHunterScatter {
         Array[File] vcfs_gz = expanionHunter.vcf_gz
         Array[File] overlapping_reads = expanionHunter.overlapping_reads
         Array[File] timing = expanionHunter.timing
+    }
+}
+
+task SplitVariantCatalog {
+    input {
+        File variant_catalog
+        Int batch_size
+        String output_prefix
+        String python_docker
+        RuntimeAttr? runtime_attr_override
+    }
+
+    output {
+        Array[File] catalogs_json = glob("${output_prefix}*.json")
+    }
+
+    command <<<
+        set -euxo pipefail
+
+        python <<CODE
+        import json
+        import sys
+        import os
+        from pathlib import Path
+
+        filename = "~{variant_catalog}"
+        filename_without_ext = Path(filename).stem
+        output_prefix = "~{output_prefix}"
+        i = 0
+        subset_counter = 0
+
+        def serialize():
+            print(f"subset counter: {subset_counter}")
+            with open(f"{output_prefix}{filename_without_ext}_{subset_counter}.json", "w") as f_out:
+                json.dump(subset_catalogs, f_out, indent=4)
+
+        with open(filename, "r") as f_in:
+            catalogs = json.load(f_in)
+
+            subset_catalogs = []
+            for catalog in catalogs:
+                subset_catalogs.append(catalog)
+                i += 1
+                if i == ~{batch_size}:
+                    serialize()
+                    i = 0
+                    subset_counter += 1
+                    subset_catalogs = []
+            serialize()
+        CODE
+    >>>
+
+    RuntimeAttr runtime_attr_str_profile_default = object {
+        cpu_cores: 1,
+        mem_gb: 4,
+        boot_disk_gb: 10,
+        preemptible_tries: 3,
+        max_retries: 1,
+        disk_gb: 10
+    }
+    RuntimeAttr runtime_attr = select_first([
+        runtime_attr_override,
+        runtime_attr_str_profile_default])
+
+    runtime {
+        docker: python_docker
+        cpu: runtime_attr.cpu_cores
+        memory: runtime_attr.mem_gb + " GiB"
+        disks: "local-disk " + runtime_attr.disk_gb + " HDD"
+        bootDiskSizeGb: runtime_attr.boot_disk_gb
+        preemptible: runtime_attr.preemptible_tries
+        maxRetries: runtime_attr.max_retries
     }
 }

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -127,14 +127,15 @@ task SplitVariantCatalog {
         max_retries: 1,
         disk_gb: 10
     }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 
     runtime {
         docker: python_docker
-        cpu: select_first([runtime_attr_override.cpu_cores, default_attr.cpu_cores])
-        memory: select_first([runtime_attr_override.mem_gb, default_attr.mem_gb]) + " GiB"
-        disks: "local-disk " + select_first([runtime_attr_override.disk_gb, default_attr.disk_gb]) + " HDD"
-        bootDiskSizeGb: select_first([runtime_attr_override.boot_disk_gb, default_attr.boot_disk_gb])
-        preemptible: select_first([runtime_attr_override.preemptible_tries, default_attr.preemptible_tries])
-        maxRetries: select_first([runtime_attr_override.max_retries, default_attr.max_retries])
+        cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+        memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+        preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
     }
 }

--- a/wdl/TasksMakeCohortVcf.wdl
+++ b/wdl/TasksMakeCohortVcf.wdl
@@ -175,7 +175,6 @@ task ConcatVcfs {
     Array[File]? vcfs_idx
     Boolean allow_overlaps = false
     Boolean naive = false
-    Boolean force_naive = false
     Boolean generate_index = true
     String? outfile_prefix
     String sv_base_mini_docker
@@ -185,7 +184,6 @@ task ConcatVcfs {
   String outfile_name = outfile_prefix + ".vcf.gz"
   String allow_overlaps_flag = if allow_overlaps then "--allow-overlaps" else ""
   String naive_flag = if naive then "--naive" else ""
-  String force_naive_flag = if force_naive then "--naive-force" else ""
 
   # when filtering/sorting/etc, memory usage will likely go up (much of the data will have to
   # be held in memory or disk while working, potentially in a form that takes up more space)
@@ -214,7 +212,7 @@ task ConcatVcfs {
     if ~{!defined(vcfs_idx)}; then
       cat ${VCFS} | xargs -n1 tabix
     fi
-    bcftools concat --no-version ~{allow_overlaps_flag} ~{naive_flag} ~{force_naive_flag} --output-type z --file-list ${VCFS} --output "~{outfile_name}"
+    bcftools concat --no-version ~{allow_overlaps_flag} ~{naive_flag} --output-type z --file-list ${VCFS} --output "~{outfile_name}"
     if ~{generate_index}; then
       tabix "~{outfile_name}"
     else

--- a/wdl/TasksMakeCohortVcf.wdl
+++ b/wdl/TasksMakeCohortVcf.wdl
@@ -175,6 +175,7 @@ task ConcatVcfs {
     Array[File]? vcfs_idx
     Boolean allow_overlaps = false
     Boolean naive = false
+    Boolean force_naive = false
     Boolean generate_index = true
     String? outfile_prefix
     String sv_base_mini_docker
@@ -184,6 +185,7 @@ task ConcatVcfs {
   String outfile_name = outfile_prefix + ".vcf.gz"
   String allow_overlaps_flag = if allow_overlaps then "--allow-overlaps" else ""
   String naive_flag = if naive then "--naive" else ""
+  String force_naive_flag = if force_naive then "--naive-force" else ""
 
   # when filtering/sorting/etc, memory usage will likely go up (much of the data will have to
   # be held in memory or disk while working, potentially in a form that takes up more space)
@@ -212,7 +214,7 @@ task ConcatVcfs {
     if ~{!defined(vcfs_idx)}; then
       cat ${VCFS} | xargs -n1 tabix
     fi
-    bcftools concat --no-version ~{allow_overlaps_flag} ~{naive_flag} --output-type z --file-list ${VCFS} --output "~{outfile_name}"
+    bcftools concat --no-version ~{allow_overlaps_flag} ~{naive_flag} ~{force_naive_flag} --output-type z --file-list ${VCFS} --output "~{outfile_name}"
     if ~{generate_index}; then
       tabix "~{outfile_name}"
     else


### PR DESCRIPTION
This PR splits a given JSON file containing a catalog of variants into smaller JSON files each containing a maximum of  `variant_catalog_batch_size` variants (defaults to `10,000`). Then calls expansion hunter on each of the input samples using the split variant catalogs separately. Hence, running expansion hunter for `n * m` times where `n` and `m` are respectively the number of input samples and the number of split JSON files. 