### PR TITLE
External AF SVID INFO key is String type

### DIFF
--- a/wdl/AnnotateExternalAF.wdl
+++ b/wdl/AnnotateExternalAF.wdl
@@ -32,13 +32,13 @@ workflow AnnotateExternalAF {
         RuntimeAttr? runtime_attr_select_matched_svs
 
     }
-    call SplitBed as split_ref_bed{
+    call SplitBed as split_ref_bed {
         input:
             bed = ref_bed,
             sv_base_mini_docker = sv_base_mini_docker,
             runtime_attr_override = runtime_attr_split_ref_bed
     }
-    call SplitVcf as split_query_vcf{
+    call SplitVcf as split_query_vcf {
         input:
             vcf = vcf,
             sv_pipeline_docker = sv_pipeline_docker,
@@ -82,20 +82,20 @@ workflow AnnotateExternalAF {
         vcfs = AnnotateExternalAFperContig.annotated_vcf,
         vcfs_idx = AnnotateExternalAFperContig.annotated_vcf_tbi,
         naive = true,
-        outfile_prefix = "~{prefix}.annotated.vcf",
+        outfile_prefix = "~{prefix}.annotated",
         sv_base_mini_docker = sv_base_mini_docker,
         runtime_attr_override = runtime_override_combine_vcfs
     }
 
-     output{
+     output {
         File annotated_vcf = CombineVcfStep2.concat_vcf
         File annotated_vcf_tbi = CombineVcfStep2.concat_vcf_idx
     }
 
 }
 
-task SplitBed{
-    input{
+task SplitBed {
+    input {
         File bed
         String sv_base_mini_docker
         RuntimeAttr? runtime_attr_override
@@ -133,7 +133,7 @@ task SplitBed{
         cat header <(zcat ~{bed} | awk '{if ($6=="BND" || $6=="CTX") print}' ) > ~{prefix}.BND_CTX.bed
     >>>
 
-    output{
+    output {
         File del = "~{prefix}.DEL.bed"
         File dup = "~{prefix}.DUP.bed"
         File ins = "~{prefix}.INS.bed"
@@ -142,8 +142,8 @@ task SplitBed{
     }    
 }
 
-task SplitVcf{
-    input{
+task SplitVcf {
+    input {
         File vcf
         String sv_pipeline_docker
         RuntimeAttr? runtime_attr_override
@@ -187,7 +187,7 @@ task SplitVcf{
         cat header <(awk '{if ($5=="BND" || $5=="CTX") print}' ~{prefix}.bed )> ~{prefix}.BND_CTX.bed
     >>>
 
-    output{
+    output {
         File bed = "~{prefix}.bed"
         File del = "~{prefix}.DEL.bed"
         File dup = "~{prefix}.DUP.bed"
@@ -197,8 +197,8 @@ task SplitVcf{
     }
 }
 
-task BedtoolsClosest{
-    input{
+task BedtoolsClosest {
+    input {
         File bed_a
         File bed_b
         String svtype
@@ -237,13 +237,13 @@ task BedtoolsClosest{
         bedtools closest -wo -a <(sort -k1,1 -k2,2n filea.bed) -b <(sort -k1,1 -k2,2n fileb.bed) >> ~{svtype}.bed
     >>>
 
-    output{
+    output {
         File output_bed = "~{svtype}.bed"
     }
 }
 
-task SelectMatchedSVs{
-    input{
+task SelectMatchedSVs {
+    input {
         File input_bed
         String svtype
         Array[String] population
@@ -282,13 +282,13 @@ task SelectMatchedSVs{
             -p ~{pop_list}
     >>>
 
-    output{
+    output {
         File output_comp = "~{prefix}.comparison"
     }    
 }
 
-task SelectMatchedINSs{
-    input{
+task SelectMatchedINSs {
+    input {
         File input_bed
         String svtype
         Array[String] population
@@ -327,13 +327,13 @@ task SelectMatchedINSs{
             -p ~{pop_list}
     >>>
 
-    output{
+    output {
         File output_comp = "~{prefix}.comparison"
     }
 }
 
-task ModifyVcf{
-    input{
+task ModifyVcf {
+    input {
         Array[File] labeled_del
         Array[File] labeled_dup
         Array[File] labeled_ins
@@ -387,7 +387,7 @@ task ModifyVcf{
             else:
                 body[pin[2]]=pin
                 SVID_key.append(pin[2])
-        header.append(['##INFO=<ID='+"~{ref_prefix}"+'_SVID'+',Number=1,Type=Float,Description="Allele frequency (for biallelic sites) or copy-state frequency (for multiallelic sites) of an overlapping event in gnomad.">'])
+        header.append(['##INFO=<ID='+"~{ref_prefix}"+'_SVID'+',Number=1,Type=String,Description="SVID of an overlapping event in gnomad used for external allele frequency annotation.">'])
 
         fin.close()
         fin=open('labeled.bed')
@@ -419,7 +419,7 @@ task ModifyVcf{
         tabix ~{prefix}.annotated.vcf.gz
     >>>
 
-    output{
+    output {
         File annotated_vcf = "~{prefix}.annotated.vcf.gz"
         File annotated_vcf_tbi = "~{prefix}.annotated.vcf.gz.tbi"
     }        

--- a/wdl/AnnotateExternalAFperContig.wdl
+++ b/wdl/AnnotateExternalAFperContig.wdl
@@ -6,7 +6,7 @@ import "Structs.wdl"
 import "TasksMakeCohortVcf.wdl" as MiniTasks
 
 workflow AnnotateExternalAFperContig {
-    input{
+    input {
         File vcf
         File vcf_idx
         File ref_bed
@@ -148,7 +148,7 @@ workflow AnnotateExternalAFperContig {
 
 
     scatter (vcf_shard in SplitVcf.vcf_shards) {
-        call ModifyVcf{
+        call ModifyVcf {
             input:
                 labeled_del = calcu_del.output_comp,
                 labeled_dup = calcu_dup.output_comp,
@@ -468,7 +468,7 @@ task ModifyVcf {
             else:
                 body[pin[2]]=pin
                 SVID_key.append(pin[2])
-        header.append(['##INFO=<ID='+"~{ref_prefix}"+'_SVID'+',Number=1,Type=Float,Description="Allele frequency (for biallelic sites) or copy-state frequency (for multiallelic sites) of an overlapping event in gnomad.">'])
+        header.append(['##INFO=<ID='+"~{ref_prefix}"+'_SVID'+',Number=1,Type=String,Description="SVID of an overlapping event in gnomad used for external allele frequency annotation.">'])
 
         fin.close()
         fin=open('labeled.bed')


### PR DESCRIPTION
### Updates
Tweaks to AnnotateVcf workflow:
* SVID INFO key from AnnotateExternalAF should be a String type, not Float. This was causing issues with Hail
  * There are two ModifyVcf tasks, one in AnnotateExternalAF and one in AnnotateExternalAFPerContig. It appears that only the one in the per-contig WDL is used, but I updated both because they aren't identical so I was wary of deleting the other 
* Output name of annotated VCF was `{prefix}.annotated.vcf.vcf.gz`; removed extra `.vcf` 
* Spacing

### Testing
* Validated all WDLs and JSONs with womtool
* Tested AnnotateVcf and verified that the output VCF name had one `.vcf` and the header reflected that the SVID INFO key is of type String