### PR TITLE
Adding -k -f parameters to gunzip to avoid failures of GermlineCNV processes

### DIFF
--- a/wdl/GermlineCNVCase.wdl
+++ b/wdl/GermlineCNVCase.wdl
@@ -245,7 +245,7 @@ task DetermineGermlineContigPloidyCaseMode {
         tar xzf ~{contig_ploidy_model_tar} -C input-contig-ploidy-model
 
         read_count_files_list=~{write_lines(read_count_files)}
-        grep gz$ $read_count_files_list | xargs -l1 -P0 gunzip
+        grep gz$ $read_count_files_list | xargs -l1 -P0 gunzip -k -f
         sed 's/\.gz$//' $read_count_files_list | \
             awk '{print "--input "$0}' > read_count_files.args
 
@@ -362,7 +362,7 @@ task GermlineCNVCallerCaseMode {
         tar xzf ~{gcnv_model_tar} -C gcnv-model
 
         read_count_files_list=~{write_lines(read_count_files)}
-        grep gz$ "$read_count_files_list" | xargs -l1 -P0 gunzip
+        grep gz$ "$read_count_files_list" | xargs -l1 -P0 gunzip -k -f
         sed 's/\.gz$//' "$read_count_files_list" \
             | awk '{print "--input "$0}' \
             > read_count_files.args

--- a/wdl/GermlineCNVCohort.wdl
+++ b/wdl/GermlineCNVCohort.wdl
@@ -364,7 +364,7 @@ task DetermineGermlineContigPloidyCohortMode {
         export OMP_NUM_THREADS=~{cpu}
 
         read_count_files_list=~{write_lines(read_count_files)}
-        grep gz$ $read_count_files_list | xargs -l1 -P0 gunzip
+        grep gz$ $read_count_files_list | xargs -l1 -P0 gunzip -k -f
         sed 's/\.gz$//' $read_count_files_list | \
             awk '{print "--input "$0}' > read_count_files.args
 
@@ -489,7 +489,7 @@ task GermlineCNVCallerCohortMode {
 
         # prepare read-count files and compose gatk argument file
         read_count_files_list=~{write_lines(read_count_files)}
-        grep gz$ $read_count_files_list | xargs -l1 -P0 gunzip
+        grep gz$ $read_count_files_list | xargs -l1 -P0 gunzip -k -f
         sed 's/\.gz$//' $read_count_files_list | \
             awk '{print "--input "$0}' > read_count_files.args
 

--- a/wdl/GermlineCNVTasks.wdl
+++ b/wdl/GermlineCNVTasks.wdl
@@ -105,7 +105,7 @@ task FilterIntervals {
         export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk4_jar_override}
 
         read_count_files_list=~{write_lines(read_count_files)}
-        grep gz$ $read_count_files_list | xargs -l1 -P0 gunzip
+        grep gz$ $read_count_files_list | xargs -l1 -P0 gunzip -k -f
         sed 's/\.gz$//' $read_count_files_list | \
             awk '{print "--input "$0}' > read_count_files.args
 


### PR DESCRIPTION
Adding -k -f flag to gunzip command as on local the file overwriting fails. 
So -k will keep the original gz files and -f will force the unzipping of files and will overwrite the files on local so the process won't fail.

Error :
gzip: /gfb-v2-dev-sv-fsx-results-us-east-2/cromwell-execution/GATKSVPipelineBatch/2b6de38e-b3eb-47b8-8f9c-b935dc1c741f/call-GATKSVPipelinePhase1/GATKSVPipelinePhase1/01429d16-a31c-48c9-b374-0e856d5e9c81/call-GatherBatchEvidence/GatherBatchEvidence/4eb237c7-ddc3-4f2b-b1ed-8272eb49715b/call-CondenseReadCounts/shard-1/condensed_counts.HG00129.tsv already exists;	not overwritten