### PR TITLE
Single sample pipeline fixes for MakeCohortVcf

### DIFF
--- a/input_values/dockers.json
+++ b/input_values/dockers.json
@@ -13,7 +13,7 @@
   "sv_base_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-base:mw-gnomad-0506-pr-2-6d104d7",
   "sv_base_mini_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-base-mini:mw-gnomad-0506-pr-087d4df",
   "sv_pipeline_base_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-base:mw-gnomad-0506-pr-2-6d104d7",
-  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:mw-gnomad-0506-pr-2-6d104d7",
+  "sv_pipeline_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:mw-merge-pesr-depth-empty-4376a69",
   "sv_pipeline_hail_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-hail:mw-gnomad-0506-pr-2-b7988f0",
   "sv_pipeline_updates_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-updates:mw-gnomad-0506-superscale-dev-304ffa1",
   "sv_pipeline_qc_docker" : "us.gcr.io/broad-dsde-methods/markw/sv-pipeline-qc:mw-gnomad-0506-pr-087d4df",

--- a/wdl/ResolveComplexVariants.wdl
+++ b/wdl/ResolveComplexVariants.wdl
@@ -277,8 +277,7 @@ task IntegrateResolvedVcfs {
 
     ##get unresolved variants from full vcf that are resolved in inversion resolved vcf###
     zcat ~{inv_res_vcf} \
-      |fgrep -v "#" \
-      |awk '{if ($8!~"UNRESOLVED") print}' \
+      |awk '{if ($8!~"UNRESOLVED" && $1!~"#") print}' \
       |awk -F'\t' -v OFS='\t' 'ARGIND==1{inFileA[$1]; next} {if (!($3 in inFileA)) print }' \
         <(awk '{if ($NF!="MEMBERS") print $NF}' all.resolved.inv.bed | tr ',' '\n') - \
       >add.vcf.lines.txt


### PR DESCRIPTION
Addresses two bugs introduced in #288 that occur in the single sample pipeline:
- Deleted function in merge_pesr_depth.py that "cleaned" depth-only call records by basing them on PESR records. This was causing an error when there were no PESR records, and turns out to be unnecessary anymore.
- Fixed a `grep` error caused by empty files in IntegrateResolvedVcfs.

Tested `MakeCohortVcf` and `GATKSVSingleSamplePipeline` for correctness. Metrics for the latter (blue) compared to the current featured workspace (orange): [mw-merge-pesr-depth-empty.single_sample_metrics_comparison.pdf](https://github.com/broadinstitute/gatk-sv/files/8082701/mw-merge-pesr-depth-empty.single_sample_metrics_comparison.pdf)