### PR TITLE
Add minGQ_NCR INFO field

### DIFF
--- a/dockerfiles/sv-pipeline-rdtest/Dockerfile
+++ b/dockerfiles/sv-pipeline-rdtest/Dockerfile
@@ -15,7 +15,7 @@ ARG SV_PIPELINE_R_PKGS="BSDA caret fpc hash metap perm plyr pwr reshape ROCR zoo
 ARG SLIM_R_LIB_CMD="find . -type d \\( -name \"help\" -o -name \"doc\" -o -name \"html\" -o -name \"htmlwidgets\" -o -name \"demo\" -o -name \"demodata\" -o -name \"examples\" -o -name \"exampleData\" -o -name \"unitTests\" -o -name \"tests\" -o -name \"testdata\" -o -name \"shiny\" \\) | xargs rm -rf"
 RUN apt-get -qqy update --fix-missing && \
     apt-get -qqy install --no-upgrade --no-install-recommends \
-                 make cmake automake fftw3 pkg-config \
+                 make cmake automake fftw3 fftw3-dev pkg-config \
                  libssh2-1-dev \
                  libssl-dev && \
     /opt/install_deprecated_R_package.sh "https://cran.r-project.org/src/contrib/Archive/data.table/data.table_1.12.8.tar.gz" && \

--- a/dockerfiles/sv-pipeline-rdtest/Dockerfile
+++ b/dockerfiles/sv-pipeline-rdtest/Dockerfile
@@ -15,7 +15,7 @@ ARG SV_PIPELINE_R_PKGS="BSDA caret fpc hash metap perm plyr pwr reshape ROCR zoo
 ARG SLIM_R_LIB_CMD="find . -type d \\( -name \"help\" -o -name \"doc\" -o -name \"html\" -o -name \"htmlwidgets\" -o -name \"demo\" -o -name \"demodata\" -o -name \"examples\" -o -name \"exampleData\" -o -name \"unitTests\" -o -name \"tests\" -o -name \"testdata\" -o -name \"shiny\" \\) | xargs rm -rf"
 RUN apt-get -qqy update --fix-missing && \
     apt-get -qqy install --no-upgrade --no-install-recommends \
-                 make cmake automake \
+                 make cmake automake pkg-config \
                  libssh2-1-dev \
                  libssl-dev && \
     /opt/install_deprecated_R_package.sh "https://cran.r-project.org/src/contrib/Archive/data.table/data.table_1.12.8.tar.gz" && \
@@ -29,7 +29,7 @@ RUN apt-get -qqy update --fix-missing && \
     Rscript --vanilla install_R_packages.R ${SV_PIPELINE_R_PKGS} && \
     cd "/usr/local/lib/R/site-library" && eval ${SLIM_R_LIB_CMD} && \
     cd "/usr/lib/R/site-library" && eval ${SLIM_R_LIB_CMD} && \
-    apt-get -qqy purge make cmake automake && \
+    apt-get -qqy purge make cmake automake pkg-config && \
     apt-get -qqy clean && \
     rm -rf /tmp/* \
            /var/tmp/* \

--- a/dockerfiles/sv-pipeline-rdtest/Dockerfile
+++ b/dockerfiles/sv-pipeline-rdtest/Dockerfile
@@ -15,7 +15,7 @@ ARG SV_PIPELINE_R_PKGS="BSDA caret fpc hash metap perm plyr pwr reshape ROCR zoo
 ARG SLIM_R_LIB_CMD="find . -type d \\( -name \"help\" -o -name \"doc\" -o -name \"html\" -o -name \"htmlwidgets\" -o -name \"demo\" -o -name \"demodata\" -o -name \"examples\" -o -name \"exampleData\" -o -name \"unitTests\" -o -name \"tests\" -o -name \"testdata\" -o -name \"shiny\" \\) | xargs rm -rf"
 RUN apt-get -qqy update --fix-missing && \
     apt-get -qqy install --no-upgrade --no-install-recommends \
-                 make cmake automake pkg-config \
+                 make cmake automake fftw3 pkg-config \
                  libssh2-1-dev \
                  libssl-dev && \
     /opt/install_deprecated_R_package.sh "https://cran.r-project.org/src/contrib/Archive/data.table/data.table_1.12.8.tar.gz" && \

--- a/src/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py
+++ b/src/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py
@@ -330,7 +330,8 @@ def apply_minGQ_filter(record, minGQ_dict, SVLEN_table, AF_table, SVTYPE_table,
                 bl += 1
 
     if n_samples > 0:
-        frac_bl = bl / n_samples
+        frac_bl = bl / float(n_samples)
+        record.info['minGQ_NCR'] = round(frac_bl, 2)
         if frac_bl > maxNCR:
             record.filter.add(highNCR_filter)
 
@@ -382,13 +383,16 @@ def main():
     else:
         vcf = pysam.VariantFile(args.vcf)
 
-    # Add HIGH_NOCALL_RATE filter to vcf header
+    # Add HIGH_NOCALL_RATE filter and info field to vcf header
     NEW_FILTER = '##FILTER=<ID=HIGH_{0}_NOCALL_RATE,Description="More than '.format(args.prefix) + \
                  '{:.2%}'.format(args.maxNCR) + ' of {0} sample GTs were '.format(args.prefix) + \
                  'masked as no-call GTs due to low GQ. Indicates a possibly noisy locus ' + \
                  'in {0} samples.>'.format(args.prefix)
+    NEW_INFO = '##INFO=<ID=minGQ_NCR,Number=1,Type=Float,Description="Fraction of sample GTs that were ' \
+               'masked as no-call GTs due to low GQ during minGQ filtering.>'
     header = vcf.header
     header.add_line(NEW_FILTER)
+    header.add_line(NEW_INFO)
     filter_text = 'HIGH_{0}_NOCALL_RATE'.format(args.prefix)
 
     if args.fout in '- stdout'.split():


### PR DESCRIPTION
Adds a new INFO field `minGQ_NCR` to all non-multiallelic sites during minGQ filtering giving the fraction of no-call genotypes, in addition to the `HIGH_X_NOCALL_RATE` filter status.