### PR TITLE
force tabix to overwrite file if it exists

### DIFF
--- a/wdl/AnnoRdPeSr.wdl
+++ b/wdl/AnnoRdPeSr.wdl
@@ -107,7 +107,7 @@ task RunRdPeSrAnnotation{
         zcat ~{rd_matrix} | grep -v '@' | grep -v CONTIG |bgzip >    bincov.tsv.gz
         Rscript /src/bincov_to_normCov.R -i bincov.tsv.gz
         bgzip normCov.tsv
-        tabix -b 2 -e 2 normCov.tsv.gz
+        tabix -f -b 2 -e 2 normCov.tsv.gz
 
         python3 /src/add_RD_to_SVs.py ~{bed} normCov.tsv.gz ~{filebase}.bed.Rd
         python3 /src/add_RD_to_SVs.py ~{bed_le_flank} normCov.tsv.gz ~{filebase}.le_flank.Rd

--- a/wdl/AnnotateChromosome.wdl
+++ b/wdl/AnnotateChromosome.wdl
@@ -173,7 +173,7 @@ task MergeAnnotations {
       ~{prefix}.annotated.vcf
 
     bgzip ~{prefix}.annotated.vcf
-    tabix ~{prefix}.annotated.vcf.gz
+    tabix -f ~{prefix}.annotated.vcf.gz
     
     orig=$( zcat ~{vcf} | cut -f1 | grep -cv "^#" || true)
     new=$( zcat ~{prefix}.annotated.vcf.gz | cut -f1 | grep -cv "^#" || true)

--- a/wdl/AnnotateCleanVcfWithFilteringResults.wdl
+++ b/wdl/AnnotateCleanVcfWithFilteringResults.wdl
@@ -121,7 +121,7 @@ task AnnotateFinalRecali{
         CODE
 
         bgzip annotated.vcf
-        tabix annotated.vcf.gz
+        tabix -f annotated.vcf.gz
     >>>
 
     output{
@@ -207,7 +207,7 @@ task AnnotateBatchEffect{
         CODE
 
         bgzip annotated.vcf
-        tabix annotated.vcf.gz
+        tabix -f annotated.vcf.gz
     >>>
 
     output{
@@ -293,7 +293,7 @@ task AnnotateOutlierFilter{
         CODE
 
         bgzip annotated.vcf
-        tabix annotated.vcf.gz
+        tabix -f annotated.vcf.gz
     >>>
 
     output{
@@ -381,7 +381,7 @@ task AnnotateMinGQ{
 
         bgzip annotated.vcf
         mv annotated.vcf.gz ~{prefix}.filter_annotated.vcf.gz
-        tabix ~{prefix}.filter_annotated.vcf.gz
+        tabix -f ~{prefix}.filter_annotated.vcf.gz
     >>>
 
     output{
@@ -468,7 +468,7 @@ task AnnotateWithFilterResults{
         CODE
 
         bgzip annotated.vcf
-        tabix annotated.vcf.gz
+        tabix -f annotated.vcf.gz
     >>>
 
     output{

--- a/wdl/AnnotateExternalAF.wdl
+++ b/wdl/AnnotateExternalAF.wdl
@@ -416,7 +416,7 @@ task ModifyVcf {
         CODE
 
         bgzip ~{prefix}.annotated.vcf
-        tabix ~{prefix}.annotated.vcf.gz
+        tabix -f ~{prefix}.annotated.vcf.gz
     >>>
 
     output {

--- a/wdl/AnnotateExternalAFperContig.wdl
+++ b/wdl/AnnotateExternalAFperContig.wdl
@@ -498,7 +498,7 @@ task ModifyVcf {
         CODE
 
         bgzip ~{prefix}.annotated.vcf
-        tabix ~{prefix}.annotated.vcf.gz
+        tabix -f ~{prefix}.annotated.vcf.gz
     >>>
 
     output {

--- a/wdl/AnnotateILFeatures.wdl
+++ b/wdl/AnnotateILFeatures.wdl
@@ -366,7 +366,7 @@ task vcf2bed{
         set -Eeuo pipefail
         
         gsutil cp ~{vcf} ./tmp.vcf.gz
-        tabix -p vcf ./tmp.vcf.gz
+        tabix -f -p vcf ./tmp.vcf.gz
         svtk vcf2bed -i SVTYPE -i SVLEN tmp.vcf.gz ~{prefix}.bed
         
     >>>
@@ -543,8 +543,8 @@ task ShiftVcfForDuphold{
         bgzip ~{prefix}.ri_flank.vcf
         bgzip ~{prefix}.le_flank.vcf
 
-        tabix -p vcf ~{prefix}.ri_flank.vcf.gz
-        tabix -p vcf ~{prefix}.le_flank.vcf.gz
+        tabix -f -p vcf ~{prefix}.ri_flank.vcf.gz
+        tabix -f -p vcf ~{prefix}.le_flank.vcf.gz
     >>>
 
     runtime {
@@ -714,7 +714,7 @@ task RunRdPeSrAnnotation{
         zcat ~{rd_matrix} | grep -v '@' | grep -v CONTIG |bgzip >    bincov.tsv.gz
         Rscript /src/bincov_to_normCov.R -i bincov.tsv.gz
         bgzip normCov.tsv
-        tabix -b 2 -e 2 normCov.tsv.gz
+        tabix -f -b 2 -e 2 normCov.tsv.gz
 
         python3 /src/add_RD_to_SVs.py ~{bed} normCov.tsv.gz ~{filebase}.bed.Rd
         python3 /src/add_RD_to_SVs.py ~{bed}.ri_flank normCov.tsv.gz ~{filebase}.ri_flank.Rd

--- a/wdl/BAFFromGVCFs.wdl
+++ b/wdl/BAFFromGVCFs.wdl
@@ -357,7 +357,7 @@ task GenerateBAF {
       | bgzip \
       > ~{batch}.~{shard}.txt.gz
 
-    tabix -s1 -b2 -e2 ~{batch}.~{shard}.txt.gz
+    tabix -f -s1 -b2 -e2 ~{batch}.~{shard}.txt.gz
   >>>
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
@@ -405,13 +405,13 @@ task MergeEvidenceFiles {
     mkdir data
     while read file; do
       filename=`basename $file`
-      tabix -h -R ~{inclusion_bed} $file > data/$filename.txt
+      tabix -f -h -R ~{inclusion_bed} $file > data/$filename.txt
       rm $file
     done < ~{write_lines(files)}
 
     mkdir tmp
     sort -m -k1,1V -k2,2n -T tmp data/*.txt | bgzip -c > ~{batch}.~{evidence}.txt.gz
-    tabix -s1 -b2 -e2 ~{batch}.~{evidence}.txt.gz
+    tabix -f -s1 -b2 -e2 ~{batch}.~{evidence}.txt.gz
 
   >>>
   runtime {

--- a/wdl/BAFFromShardedVCF.wdl
+++ b/wdl/BAFFromShardedVCF.wdl
@@ -85,7 +85,7 @@ task ScatterBAFBySample {
 
     set -euo pipefail
     zcat ~{BAF} | awk -F "\t" -v OFS="\t" '{if ($4=="~{sample}") print}' | bgzip -c > BAF.~{sample}.txt.gz
-    tabix -s 1 -b 2 -e 2 BAF.~{sample}.txt.gz
+    tabix -f -s 1 -b 2 -e 2 BAF.~{sample}.txt.gz
 
   >>>
   runtime {
@@ -125,7 +125,7 @@ task GatherBAF {
 
     set -euo pipefail
     cat ~{sep=" "  BAF} > ~{batch}.BAF.txt.gz
-    tabix -s1 -b2 -e2 ~{batch}.BAF.txt.gz
+    tabix -f -s1 -b2 -e2 ~{batch}.BAF.txt.gz
 
   >>>
   runtime {

--- a/wdl/BAFTestChromosome.wdl
+++ b/wdl/BAFTestChromosome.wdl
@@ -123,7 +123,7 @@ task BAFTest {
       bgzip local.BAF.txt
     fi
 
-    tabix -s1 -b2 -e2 local.BAF.txt.gz
+    tabix -f -s1 -b2 -e2 local.BAF.txt.gz
     svtk baf-test ~{bed} local.BAF.txt.gz --batch batch.key > ~{prefix}.metrics
   
   >>>
@@ -217,15 +217,15 @@ task SplitBafVcf {
   command <<<
 
     set -euo pipefail 
-    tabix -p vcf ~{vcf}
+    tabix -f -p vcf ~{vcf}
     #TODO : split -a parameter should be scaled properly (using suffix_len does not always work)
-    tabix -h ~{vcf} ~{chrom} \
+    tabix -f -h ~{vcf} ~{chrom} \
       | svtk vcf2bed --no-header stdin stdout \
       | fgrep -e "DEL" -e "DUP" \
       | awk -v OFS="\t" '{print $1, $2, $3, $4, $6, $5}' \
       | awk '($3-$2>=10000 && $3-$2<10000000)' \
       | split -a ~{suffix_len} -d -l 300 - ~{batch}.~{algorithm}.split.gt10kb.
-    tabix -h ~{vcf} ~{chrom} \
+    tabix -f -h ~{vcf} ~{chrom} \
       | svtk vcf2bed --no-header stdin stdout \
       | fgrep -e "DEL" -e "DUP" \
       | awk -v OFS="\t" '{print $1, $2, $3, $4, $6, $5}' \

--- a/wdl/BatchEvidenceMerging.wdl
+++ b/wdl/BatchEvidenceMerging.wdl
@@ -178,7 +178,7 @@ task SetSampleId {
 
     set -euo pipefail
     zcat ~{file} | awk -F "\t" -v OFS="\t" '$~{sample_column_index}="~{sample_id}"' | bgzip -c > ~{output_name}
-    tabix -s1 -b2 -e2 ~{output_name}
+    tabix -f -s1 -b2 -e2 ~{output_name}
 
   >>>
   runtime {
@@ -228,7 +228,7 @@ task MergeEvidenceFilesByContig {
     awk -F "\t" '{if ($1=="~{contig}") print}' ~{inclusion_bed} > regions.bed
     while read file; do
       filename=`basename $file`
-      tabix -h -R regions.bed $file > data/$filename.txt
+      tabix -f -h -R regions.bed $file > data/$filename.txt
     done < ~{write_lines(files)}
 
     mkdir tmp

--- a/wdl/CalcAF.wdl
+++ b/wdl/CalcAF.wdl
@@ -153,7 +153,7 @@ task CombineShardedVcfs {
     else
       cat merged.vcf | bgzip -c > "~{prefix}.wAFs.vcf.gz"
     fi
-    tabix -p vcf "~{prefix}.wAFs.vcf.gz"
+    tabix -f -p vcf "~{prefix}.wAFs.vcf.gz"
   }
 
 

--- a/wdl/ChromosomeAlleleFrequencies.wdl
+++ b/wdl/ChromosomeAlleleFrequencies.wdl
@@ -90,7 +90,7 @@ task ShardVcf {
     set -euo pipefail
 
     # Tabix chromosome of interest
-    tabix -h ~{vcf} ~{contig} | bgzip -c > ~{contig}.vcf.gz
+    tabix -f -h ~{vcf} ~{contig} | bgzip -c > ~{contig}.vcf.gz
     
     # Then shard VCF
     /opt/sv-pipeline/scripts/shard_VCF.sh \
@@ -213,7 +213,7 @@ task CombineShardedVcfs {
       | vcf-sort \
       | bgzip -c \
       > "~{prefix}.wAFs.vcf.gz";
-    tabix -p vcf "~{prefix}.wAFs.vcf.gz"
+    tabix -f -p vcf "~{prefix}.wAFs.vcf.gz"
   
   >>>
  

--- a/wdl/CleanVcf5.wdl
+++ b/wdl/CleanVcf5.wdl
@@ -139,7 +139,7 @@ task MakeCleanGQ {
             ~{prefix}
 
         bcftools view -G -O z ~{prefix}.multiallelic.vcf.gz > ~{prefix}.multiallelic.sites.vcf.gz
-        tabix ~{prefix}.cleanGQ.vcf.gz
+        tabix -f ~{prefix}.cleanGQ.vcf.gz
     >>>
 
     output {

--- a/wdl/CleanVcfChromosome.wdl
+++ b/wdl/CleanVcfChromosome.wdl
@@ -357,7 +357,7 @@ task CleanVcf1a {
       ~{prefix}.sexchr.revise.txt \
       | bgzip \
       > ~{prefix}.vcf.gz
-    tabix ~{prefix}.vcf.gz
+    tabix -f ~{prefix}.vcf.gz
   >>>
 
   output {
@@ -731,7 +731,7 @@ task FinalCleanup {
       | fgrep -v "##INFO=<ID=MEMBERS,Number=.,Type=String," \
       | bgzip -c \
       > ~{prefix}.vcf.gz
-    tabix ~{prefix}.vcf.gz
+    tabix -f ~{prefix}.vcf.gz
   >>>
 
   output {

--- a/wdl/CombineReassess.wdl
+++ b/wdl/CombineReassess.wdl
@@ -105,10 +105,10 @@ task MergeList {
     cut -f 4 ~{regeno_file} >regeno_variants.txt
     fgrep -f regeno_variants.txt ~{regeno_sample_ids_lookup} > cohort.regeno_var.combined.bed
     cat ~{sep=' ' nonempty_txt}|sort -k1,1V -k2,2n -k3,3n |bgzip -c > nonempty.bed.gz
-    tabix nonempty.bed.gz
+    tabix -f nonempty.bed.gz
     # For each variant in regeno_file, take variants across all batches
     while read chr start end var type;do
-        samplelist=$(tabix nonempty.bed.gz $chr:$start-$end |awk -v var="$var" '{if($4==var)print $6}' |tr "\n" ",")
+        samplelist=$(tabix -f nonempty.bed.gz $chr:$start-$end |awk -v var="$var" '{if($4==var)print $6}' |tr "\n" ",")
         printf "$chr\t$start\t$end\t$var\t$samplelist\n" 
     done<~{regeno_file} >regeno_variant_sample.txt
     # Use cohort cluster file, add samples that are clustered with the variant in question across whole cohort

--- a/wdl/Delly.wdl
+++ b/wdl/Delly.wdl
@@ -209,7 +209,7 @@ task GatherBCFs {
       | bgzip -c \
       > $VCF_OUT
     echo "Indexing $VCF_OUT"
-    tabix "$VCF_OUT"
+    tabix -f "$VCF_OUT"
     
   >>>
   runtime {

--- a/wdl/DepthClustering.wdl
+++ b/wdl/DepthClustering.wdl
@@ -211,7 +211,7 @@ task BedCluster {
   command <<<
 
     set -euo pipefail
-    tabix -p bed ~{bed};
+    tabix -f -p bed ~{bed};
     svtk bedcluster ~{bed} -r ~{chrom} \
       -p ~{batch}_depth_~{svtype}_~{chrom} \
       -f ~{frac} \

--- a/wdl/DepthPreprocessing.wdl
+++ b/wdl/DepthPreprocessing.wdl
@@ -110,7 +110,7 @@ task GcnvVcfToBed {
 
     set -e
     tar xzf ~{contig_ploidy_call_tar}
-    tabix ~{vcf}
+    tabix -f ~{vcf}
     python /opt/WGD/bin/convert_gcnv.py \
       --cutoff ~{qs_cutoff} \
       contig_ploidy.tsv \
@@ -216,7 +216,7 @@ task MergeSet {
       | awk -v OFS="\t" -v svtype=~{svtype} -v batch=~{batch} '{$4=batch"_"svtype"_"NR; print}' \
       | cat <(echo -e "#chr\\tstart\\tend\\tname\\tsample\\tsvtype\\tsources") - \
       | bgzip -c > ~{batch}.~{svtype}.bed.gz;
-    tabix -p bed ~{batch}.~{svtype}.bed.gz
+    tabix -f -p bed ~{batch}.~{svtype}.bed.gz
 		
   >>>
   runtime {

--- a/wdl/FilterCleanupQualRecalibration.wdl
+++ b/wdl/FilterCleanupQualRecalibration.wdl
@@ -87,11 +87,11 @@ task RemoveMCNVs{
   command <<<
     set -euo pipefail
     zcat ~{vcf} | awk '{if ($7!="MULTIALLELIC") print}' | bgzip > no_MCNV.vcf.gz
-    tabix no_MCNV.vcf.gz
+    tabix -f no_MCNV.vcf.gz
     zcat ~{vcf} | grep '#' > MCNV.vcf
     zcat ~{vcf} | awk '{if ($7=="MULTIALLELIC") print}' >> MCNV.vcf
     bgzip MCNV.vcf
-    tabix MCNV.vcf.gz
+    tabix -f MCNV.vcf.gz
   >>>
 
   output{
@@ -134,9 +134,9 @@ task MergeMCNV{
   command <<<
     set -euo pipefail
     #zcat ~{mcnv} |uniq | bgzip > mcnv.vcf.gz
-    #tabix mcnv.vcf.gz
+    #tabix -f mcnv.vcf.gz
     vcf-concat ~{vcf} ~{mcnv} | vcf-sort | bgzip > ~{prefix}.cleaned_filters_qual_recali.vcf.gz
-    tabix ~{prefix}.cleaned_filters_qual_recali.vcf.gz
+    tabix -f ~{prefix}.cleaned_filters_qual_recali.vcf.gz
   >>>
 
   output{
@@ -182,9 +182,9 @@ task Cleanup {
     
     set -euo pipefail
     #Subset to chromosome of interest
-    tabix -h ~{vcf} ~{contig} | bgzip -c > input.vcf.gz
+    tabix -f -h ~{vcf} ~{contig} | bgzip -c > input.vcf.gz
     #Get list of PCR- samples
-    tabix -H ~{vcf} | fgrep -v "##" | cut -f10- | sed 's/\t/\n/g' \
+    tabix -f -H ~{vcf} | fgrep -v "##" | cut -f10- | sed 's/\t/\n/g' \
     > all.samples.list
     if [ ! -z "~{pcrplus_samples_list}" ];then
       fgrep -wvf ~{pcrplus_samples_list} all.samples.list \
@@ -220,7 +220,7 @@ task Cleanup {
       stdout \
     | bgzip -c \
     > "~{prefix}.~{contig}.cleaned_filters_qual_recalibrated.vcf.gz"
-    # tabix -p vcf -f "~{prefix}.cleaned_filters_qual_recalibrated.vcf.gz"
+    # tabix -f -p vcf -f "~{prefix}.cleaned_filters_qual_recalibrated.vcf.gz"
   >>>
 
   output {

--- a/wdl/FilterOutlierSamplesPostMinGQ.wdl
+++ b/wdl/FilterOutlierSamplesPostMinGQ.wdl
@@ -124,7 +124,7 @@ task WriteSamplesList {
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
   command <<<
     set -euo pipefail
-    tabix -H ~{vcf} | fgrep -v "##" \
+    tabix -f -f -H ~{vcf} | fgrep -v "##" \
     | cut -f10- | sed 's/\t/\n/g' > "~{prefix}.samples.list"
     if [ ! -z "~{pcrplus_samples_list}" ];then
       fgrep -wf ~{pcrplus_samples_list} "~{prefix}.samples.list" \
@@ -176,7 +176,7 @@ task CountSvtypes {
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
   command <<<
     set -euo pipefail
-    tabix --print-header "~{vcf}" "~{contig}" \
+    tabix -f --print-header "~{vcf}" "~{contig}" \
     | fgrep -v "MULTIALLELIC" \
     | fgrep -v "PESR_GT_OVERDISPERSION" \
     | svtk count-svtypes --no-header stdin \
@@ -327,7 +327,7 @@ task ExcludeOutliers {
     cat ~{plus_outliers_list} ~{minus_outliers_list} \
       | sort -Vk1,1 | uniq \
       > "~{prefix}.SV_count_outliers.samples.list" || true
-    tabix -H ~{vcf} | fgrep -v "##" | \
+    tabix -f -H ~{vcf} | fgrep -v "##" | \
       sed 's/\t/\n/g' | awk -v OFS="\t" '{ print $1, NR }' | \
       fgrep -wf "~{prefix}.SV_count_outliers.samples.list" | cut -f2 > \
       indexes_to_exclude.txt || true
@@ -343,7 +343,7 @@ task ExcludeOutliers {
     else
       cp ~{vcf} ~{outfile}
     fi
-    tabix -p vcf -f "~{outfile}"
+    tabix -f -p vcf -f "~{outfile}"
   >>>
 
   output {

--- a/wdl/GenotypeCpxCnvs.wdl
+++ b/wdl/GenotypeCpxCnvs.wdl
@@ -208,7 +208,7 @@ task ParseGenotypes {
       ~{genotypes} \
       ~{ped_file} \
       ~{prefix}.postCPXregenotyping.~{contig}.vcf.gz
-    tabix ~{prefix}.postCPXregenotyping.~{contig}.vcf.gz
+    tabix -f ~{prefix}.postCPXregenotyping.~{contig}.vcf.gz
   >>>
 
   output {

--- a/wdl/GenotypeCpxCnvsPerBatch.wdl
+++ b/wdl/GenotypeCpxCnvsPerBatch.wdl
@@ -252,8 +252,8 @@ task RdTestGenotype {
       bgzip local.RD.txt
     fi
 
-    tabix -p bed local.RD.txt.gz
-    tabix -p bed ~{bin_exclude}
+    tabix -f -p bed local.RD.txt.gz
+    tabix -f -p bed ~{bin_exclude}
 
     Rscript /opt/RdTest/RdTest.R \
       -b ~{bed} \

--- a/wdl/Genotype_2.wdl
+++ b/wdl/Genotype_2.wdl
@@ -299,7 +299,7 @@ task ConcatReGenotypedVcfs {
     vcf-concat ~{batch}.regeno.vcf.gz no_variant.vcf.gz \
       | vcf-sort -c \
       | bgzip -c > ~{batch}.depth.regeno.vcf.gz
-    tabix ~{batch}.depth.regeno.vcf.gz
+    tabix -f ~{batch}.depth.regeno.vcf.gz
   
   >>>
   runtime {

--- a/wdl/Genotype_3.wdl
+++ b/wdl/Genotype_3.wdl
@@ -50,7 +50,7 @@ task ConcatRegenotypedVcfs {
     vcf-concat regeno.vcf.gz no_variant.vcf.gz \
       | vcf-sort -c \
       | bgzip -c > ~{batch}.depth.regeno_final.vcf.gz
-    tabix ~{batch}.depth.regeno_final.vcf.gz
+    tabix -f ~{batch}.depth.regeno_final.vcf.gz
        >>>
   output {
     File genotyped_vcf = "~{batch}.depth.regeno_final.vcf.gz"

--- a/wdl/HailMerge.wdl
+++ b/wdl/HailMerge.wdl
@@ -128,7 +128,7 @@ finally:
 CODE
 
   mv merged.vcf.bgz ~{prefix}.vcf.gz
-  tabix ~{prefix}.vcf.gz
+  tabix -f ~{prefix}.vcf.gz
   >>>
 
   output {
@@ -176,7 +176,7 @@ task FixHeader {
     bcftools reheader -h header ~{merged_vcf} \
       ~{if reset_cnv_gts then "| gunzip | python /opt/sv-pipeline/04_variant_resolution/scripts/reset_cnv_gts.py stdin stdout | bgzip" else ""} \
       > ~{prefix}.vcf.gz
-    tabix ~{prefix}.vcf.gz
+    tabix -f ~{prefix}.vcf.gz
   >>>
 
   output {

--- a/wdl/MELT.wdl
+++ b/wdl/MELT.wdl
@@ -670,7 +670,7 @@ task RunMELT {
     rm temp.vcf.gz
     
     # index vcf
-    tabix -p vcf "~{sample_id}.melt.vcf.gz"
+    tabix -f -p vcf "~{sample_id}.melt.vcf.gz"
     
   >>>
   runtime {

--- a/wdl/MakeBincovMatrix.wdl
+++ b/wdl/MakeBincovMatrix.wdl
@@ -265,7 +265,7 @@ task ZPaste {
 
     # paste unzipped files and compress
     paste column_file_fifos/* | bgzip -c > "~{matrix_file_name}"
-    tabix -p bed "~{matrix_file_name}"
+    tabix -f -p bed "~{matrix_file_name}"
   >>>
 
   runtime {

--- a/wdl/Manta.wdl
+++ b/wdl/Manta.wdl
@@ -161,7 +161,7 @@ task RunManta {
       > diploidSV.vcf
 
     bgzip -c diploidSV.vcf > ~{sample_id}.manta.vcf.gz
-    tabix -p vcf ~{sample_id}.manta.vcf.gz
+    tabix -f -p vcf ~{sample_id}.manta.vcf.gz
     
   >>>
   runtime {

--- a/wdl/MatrixQC.wdl
+++ b/wdl/MatrixQC.wdl
@@ -157,7 +157,7 @@ task PESRBAF_QC {
       bgzip local.RD.txt
     fi
 
-    tabix -s 1 -b 2 -e 2 local.RD.txt.gz
+    tabix -f -s 1 -b 2 -e 2 local.RD.txt.gz
 
     /opt/sv-pipeline/00_preprocessing/misc_scripts/nonRD_matrix_QC.sh \
       -d ~{distance} \
@@ -234,7 +234,7 @@ task RD_QC {
       bgzip local.RD.txt
     fi
 
-    tabix -p bed local.RD.txt.gz
+    tabix -f -p bed local.RD.txt.gz
 
     /opt/sv-pipeline/00_preprocessing/misc_scripts/RD_matrix_QC.sh \
       -d ~{distance} \

--- a/wdl/Module07FilterCleanupQualRecalibration.wdl
+++ b/wdl/Module07FilterCleanupQualRecalibration.wdl
@@ -81,9 +81,9 @@ task Cleanup {
     
     set -euo pipefail
     #Subset to chromosome of interest
-    tabix -h ~{vcf} ~{contig} | bgzip -c > input.vcf.gz
+    tabix -f -h ~{vcf} ~{contig} | bgzip -c > input.vcf.gz
     #Get list of PCR- samples
-    tabix -H ~{vcf} | fgrep -v "##" | cut -f10- | sed 's/\t/\n/g' \
+    tabix -f -H ~{vcf} | fgrep -v "##" | cut -f10- | sed 's/\t/\n/g' \
     > all.samples.list
     if [ ! -z "~{pcrplus_samples_list}" ];then
       fgrep -wvf ~{pcrplus_samples_list} all.samples.list \

--- a/wdl/Module07MinGQ.wdl
+++ b/wdl/Module07MinGQ.wdl
@@ -337,7 +337,7 @@ task SplitPcrVcf {
     awk 'ARGIND==1{inFileA[$1]; next} !($1 in inFileA)' ~{pcrplus_samples_list} all_samples.list \
       > pcrminus_samples.list
     bcftools reheader -s pcrminus_samples.list -Oz -o ~{prefix}.PCRMINUS.vcf.gz
-    tabix ~{prefix}.PCRMINUS.vcf.gz
+    tabix -f ~{prefix}.PCRMINUS.vcf.gz
   >>>
 
   output {
@@ -457,7 +457,7 @@ task SplitFamfile {
   command <<<
     set -euo pipefail
     #Get list of sample IDs & column numbers from VCF header
-    tabix -H ~{vcf} | fgrep -v "##" | sed 's/\t/\n/g' \
+    tabix -f -H ~{vcf} | fgrep -v "##" | sed 's/\t/\n/g' \
       | awk -v OFS="\t" '{ print $1, NR }' > vcf_header_columns.txt
     #Iterate over families & subset VCF
     while read famID pro fa mo prosex pheno; do

--- a/wdl/Module07MinGQStep2MergePCRStatus.wdl
+++ b/wdl/Module07MinGQStep2MergePCRStatus.wdl
@@ -120,7 +120,7 @@ task get_sample_lists {
 
   command <<<
     set -euo pipefail
-    tabix -H ~{vcf} | fgrep -v "##" | cut -f10- | sed 's/\t/\n/g' > all_samples.list
+    tabix -f -H ~{vcf} | fgrep -v "##" | cut -f10- | sed 's/\t/\n/g' > all_samples.list
     fgrep -wf ~{PCRPLUS_samples_list} all_samples.list > "~{prefix}.PCRPLUS.samples.list" || true
     fgrep -wvf ~{PCRPLUS_samples_list} all_samples.list > "~{prefix}.PCRMINUS.samples.list" || true
     cat \
@@ -209,8 +209,8 @@ task Split_Vcf_by_contig {
   command <<<
       set -euo pipefail
       #Tabix chromosome of interest
-      tabix -h ~{vcf} ~{contig} | bgzip -c > ~{contig}.vcf.gz
-      tabix -p vcf ~{contig}.vcf.gz
+      tabix -f -h ~{vcf} ~{contig} | bgzip -c > ~{contig}.vcf.gz
+      tabix -f -p vcf ~{contig}.vcf.gz
   >>>
 
   output {
@@ -289,7 +289,7 @@ task combine_vcfs {
   
   command <<<
     vcf-concat ~{sep=" " vcfs} | vcf-sort | bgzip -c > ~{prefix}.minGQ_filtered.vcf.gz;
-    tabix -p vcf ~{prefix}.minGQ_filtered.vcf.gz
+    tabix -f -p vcf ~{prefix}.minGQ_filtered.vcf.gz
   >>>
 
   runtime {

--- a/wdl/Module07XfBatchEffect.wdl
+++ b/wdl/Module07XfBatchEffect.wdl
@@ -220,7 +220,7 @@ task GetBatchSamplesList {
   command <<<
     set -euo pipefail
     # Get list of all samples present in VCF header
-    tabix -H ~{vcf} | fgrep -v "##" | cut -f10- | sed 's/\t/\n/g' | sort -Vk1,1 \
+    tabix -f -H ~{vcf} | fgrep -v "##" | cut -f10- | sed 's/\t/\n/g' | sort -Vk1,1 \
     > all_samples.list
     # Get list of samples in batch
     fgrep -w ~{batch} ~{sample_batch_assignments} | cut -f1 \
@@ -661,7 +661,7 @@ task ApplyBatchEffectLabels {
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
   command <<<
     set -euo pipefail
-    tabix -h ~{vcf} ~{contig} \
+    tabix -f -h ~{vcf} ~{contig} \
     | /opt/sv-pipeline/scripts/downstream_analysis_and_filtering/label_batch_effects.PCRMinus_only.py \
         --unstable-af-pcrminus ~{mingq_prePost_pcrminus_fails} \
         stdin \

--- a/wdl/Module10AnnotateILFeatures.wdl
+++ b/wdl/Module10AnnotateILFeatures.wdl
@@ -154,7 +154,7 @@ task split_per_sample_vcf{
         set -Eeuo pipefail
         
         bcftools view -s ~{sample} ~{vcf} | grep -v "0/0" | bgzip > ~{sample}.vcf.gz
-        tabix -p vcf ~{sample}.vcf.gz
+        tabix -f -p vcf ~{sample}.vcf.gz
 
     >>>
     runtime {

--- a/wdl/Module10Benchmark.wdl
+++ b/wdl/Module10Benchmark.wdl
@@ -534,7 +534,7 @@ task RunRdPeSrAnnotation{
     zcat ~{rd_metrics} | grep -v '@' | grep -v CONTIG |bgzip >  bincov.tsv.gz
     Rscript /bincov_to_normCov.R -i bincov.tsv.gz
     bgzip normCov.tsv
-    tabix normCov.tsv.gz
+    tabix -f normCov.tsv.gz
 
     python /add_RD_to_SVs.py ~{bed} normCov.tsv.gz
     python /add_RD_to_SVs.py ~{filename}.ri_flank normCov.tsv.gz

--- a/wdl/MosaicDepth.wdl
+++ b/wdl/MosaicDepth.wdl
@@ -79,7 +79,7 @@ task GetPotential{
     awk -v dupp="$dupp" -v dupmed="$dupmed" '{if ($3=="DUP" && $5<dupmed && $6>dupp) print}' phase3-1_7.depth.metrics> dup.potentialmosaic.txt
     cat del.potentialmosaic.txt dup.potentialmosaic.txt |cut -f1 > potentialmosaic.txt
     tabix -f ~{depth_vcf}
-    tabix -H ~{depth_vcf} > head.txt
+    tabix -f -H ~{depth_vcf} > head.txt
     zcat ~{depth_vcf} |fgrep -w -f potentialmosaic.txt >body.txt
     cat head.txt body.txt |bgzip -c > test.vcf.gz
     bash /opt/sv-pipeline/04_variant_resolution/scripts/stitch_fragmented_calls.sh -x 1 test.vcf.gz test1.vcf.gz

--- a/wdl/MosaicPesrPart1.wdl
+++ b/wdl/MosaicPesrPart1.wdl
@@ -111,7 +111,7 @@ task GetPotential{
     awk -v dupp="$dupp" -v dupmed="$dupmed" -v pe_p="$pe_p" -v sr_p="$sr_p" -v pesr_p="$pesr_p" '{if ($3=="DUP" && $8<dupmed && $9>dupp ) print}' ~{name}.depth.metrics> dup.potentialmosaic.txt
     cat del.potentialmosaic.txt dup.potentialmosaic.txt |cut -f1 > potentialmosaic.txt
     tabix -f ~{depth_vcf}
-    tabix -H ~{depth_vcf} > head.txt
+    tabix -f -H ~{depth_vcf} > head.txt
     zcat ~{depth_vcf} |fgrep -w -f potentialmosaic.txt >body.txt
     cat head.txt body.txt |bgzip -c > test.vcf.gz
     bash /opt/sv-pipeline/04_variant_resolution/scripts/stitch_fragmented_calls.sh -x 1 test.vcf.gz test1.vcf.gz

--- a/wdl/PESRClustering.wdl
+++ b/wdl/PESRClustering.wdl
@@ -87,8 +87,8 @@ task VCFCluster {
   command <<<
 
     set -euo pipefail
-    for f in ~{sep=" "  vcfs}; do tabix -p vcf -f $f; done;
-    tabix -p bed ~{exclude_list};
+    for f in ~{sep=" "  vcfs}; do tabix -f -p vcf -f $f; done;
+    tabix -f -p bed ~{exclude_list};
 
     svtk vcfcluster ~{write_lines(vcfs)} stdout \
       -r ~{chrom} \
@@ -142,7 +142,7 @@ task ConcatVCFs {
 
     set -euo pipefail
     vcf-concat ~{sep=" "  vcfs} | vcf-sort -c | bgzip -c > ~{batch}.~{algorithm}.vcf.gz;
-    tabix -p vcf ~{batch}.~{algorithm}.vcf.gz;
+    tabix -f -p vcf ~{batch}.~{algorithm}.vcf.gz;
   
   >>>
   runtime {

--- a/wdl/PETestChromosome.wdl
+++ b/wdl/PETestChromosome.wdl
@@ -227,7 +227,7 @@ task PETest {
       bgzip local.PE.txt
     fi
 
-    tabix -s1 -b2 -e2 local.PE.txt.gz
+    tabix -f -s1 -b2 -e2 local.PE.txt.gz
     svtk pe-test -o ~{window} ~{common_arg} --medianfile ~{medianfile} --samples ~{include_list} ~{vcf} local.PE.txt.gz ~{prefix}.stats
   >>>
   runtime {

--- a/wdl/PruneAndAddVafs.wdl
+++ b/wdl/PruneAndAddVafs.wdl
@@ -109,7 +109,7 @@ task PruneVcf {
     set -euo pipefail
     
     # Tabix chromosome of interest
-    tabix -h ~{vcf} ~{contig} | bgzip -c > ~{contig}.vcf.gz
+    tabix -f -h ~{vcf} ~{contig} | bgzip -c > ~{contig}.vcf.gz
     
     # Get column indexes corresponding to samples to drop, if any exist
     if ~{defined(prune_list)}; then

--- a/wdl/RDTestChromosome.wdl
+++ b/wdl/RDTestChromosome.wdl
@@ -179,7 +179,7 @@ task RDTest {
       bgzip local.RD.txt
     fi
 
-    tabix -p bed local.RD.txt.gz
+    tabix -f -p bed local.RD.txt.gz
 
     Rscript /opt/RdTest/RdTest.R \
       -b ~{bed} \
@@ -231,14 +231,14 @@ task SplitRDVcf {
   command <<<
 
     set -euo pipefail
-    tabix -p vcf ~{vcf};
-    tabix -h ~{vcf} ~{chrom} \
+    tabix -f -p vcf ~{vcf};
+    tabix -f -h ~{vcf} ~{chrom} \
       | svtk vcf2bed --no-header stdin stdout \
       | fgrep -e "DEL" -e "DUP" \
       | awk -v OFS="\t" '{print $1, $2, $3, $4, $6, $5}' \
       | awk '($3-$2>=10000)' \
       > ~{batch}.~{algorithm}.split.gt10kb;
-    tabix -h ~{vcf} ~{chrom} \
+    tabix -f -h ~{vcf} ~{chrom} \
       | svtk vcf2bed --no-header stdin stdout \
       | fgrep -e "DEL" -e "DUP" \
       | awk -v OFS="\t" '{print $1, $2, $3, $4, $6, $5}' \

--- a/wdl/RdPeSrAnno.wdl
+++ b/wdl/RdPeSrAnno.wdl
@@ -165,7 +165,7 @@ task RunRdPeSrAnnotation{
     zcat ~{rd_metrics} | grep -v '@' | grep -v CONTIG |bgzip >  bincov.tsv.gz
     Rscript /src/bincov_to_normCov.R -i bincov.tsv.gz
     bgzip normCov.tsv
-    tabix normCov.tsv.gz
+    tabix -f normCov.tsv.gz
 
     python3 /src/add_RD_to_SVs.py ~{bed} normCov.tsv.gz
     python3 /src/add_RD_to_SVs.py ~{filename}.ri_flank normCov.tsv.gz

--- a/wdl/RdTestVisualization.wdl
+++ b/wdl/RdTestVisualization.wdl
@@ -70,16 +70,16 @@ task rdtest {
             if [ $i -gt 1 ]
             then
                 export GCS_OAUTH_TOKEN=`gcloud auth application-default print-access-token`
-                tabix -h $bincov -R test.merged.bed|cut -f4->covfile.$i.bed 
+                tabix -f -h $bincov -R test.merged.bed|cut -f4->covfile.$i.bed 
             else
                 export GCS_OAUTH_TOKEN=`gcloud auth application-default print-access-token`
-                tabix -h $bincov -R test.merged.bed>covfile.$i.bed 
+                tabix -f -h $bincov -R test.merged.bed>covfile.$i.bed 
 
         fi
         done<bincovlist.txt
 
         paste covfile.*.bed |tr ' ' '\t' |bgzip >allcovfile.bed.gz 
-        tabix allcovfile.bed.gz
+        tabix -f allcovfile.bed.gz
         rm covfile.*.bed
         zcat allcovfile.bed.gz |head -n 1|cut -f 4-|tr '\t' '\n'>samples.txt
         Rscript /opt/RdTest/RdTest.R \

--- a/wdl/RegenotypeCNVs.wdl
+++ b/wdl/RegenotypeCNVs.wdl
@@ -768,7 +768,7 @@ task ConcatRegenotypedVcfs {
     vcf-concat regeno.vcf.gz no_variant.vcf.gz \
       | vcf-sort -c \
       | bgzip -c > ~{batch}.depth.regeno_final.vcf.gz
-    tabix ~{batch}.depth.regeno_final.vcf.gz
+    tabix -f ~{batch}.depth.regeno_final.vcf.gz
   >>>
   output {
     File genotyped_vcf = "~{batch}.depth.regeno_final.vcf.gz"

--- a/wdl/RenameVcfSamples.wdl
+++ b/wdl/RenameVcfSamples.wdl
@@ -64,7 +64,7 @@ task RenameVcfSamplesTask {
     paste ~{current_sample_list} ~{new_sample_list} > dict.tsv
     /opt/sv-pipeline/scripts/vcf_replacement_samples.py --vcf ~{vcf} --dict dict.tsv > reheader.list
     bcftools reheader --samples reheader.list -o ~{prefix}.vcf.gz ~{vcf}
-    tabix ~{prefix}.vcf.gz
+    tabix -f ~{prefix}.vcf.gz
   >>>
 
   output {

--- a/wdl/ResolveComplexVariants.wdl
+++ b/wdl/ResolveComplexVariants.wdl
@@ -297,7 +297,7 @@ task IntegrateResolvedVcfs {
       |bcftools sort - -O z -T temp \
       > ~{prefix}.vcf.gz
 
-    tabix ~{prefix}.vcf.gz
+    tabix -f ~{prefix}.vcf.gz
   >>>
 
   output {
@@ -349,8 +349,8 @@ task BreakpointOverlap {
       ~{prefix}.dropped_records.vcf.gz \
       | bgzip \
       > ~{prefix}.vcf.gz
-    tabix ~{prefix}.vcf.gz
-    tabix ~{prefix}.dropped_records.vcf.gz
+    tabix -f ~{prefix}.vcf.gz
+    tabix -f ~{prefix}.dropped_records.vcf.gz
   >>>
 
   output {
@@ -399,7 +399,7 @@ task RenameVariants {
     /opt/sv-pipeline/04_variant_resolution/scripts/rename.py --chrom ~{chrom} --prefix ~{vid_prefix} ~{vcf} - \
       | bgzip \
       > ~{prefix}.vcf.gz
-    tabix ~{prefix}.vcf.gz
+    tabix -f ~{prefix}.vcf.gz
   >>>
 
   output {

--- a/wdl/ResolveCpxSv.wdl
+++ b/wdl/ResolveCpxSv.wdl
@@ -385,7 +385,7 @@ task ResolvePrep {
         > discfile.PE.txt.gz
     fi
 
-    tabix -s 1 -b 2 -e 2 -f discfile.PE.txt.gz
+    tabix -f -s 1 -b 2 -e 2 -f discfile.PE.txt.gz
   >>>
 
   output {
@@ -542,7 +542,7 @@ task RestoreUnresolvedCnv {
         /dev/stdin /dev/stdout \
       | bgzip \
       > ~{resolved_plus_cnv}
-    tabix ~{resolved_plus_cnv}
+    tabix -f ~{resolved_plus_cnv}
   >>>
 
   output {

--- a/wdl/ReviseSVtypeINStoMEIperContig.wdl
+++ b/wdl/ReviseSVtypeINStoMEIperContig.wdl
@@ -87,7 +87,7 @@ task ReviseSVtypeMEI{
     zcat ~{vcf} | grep -v '#' | grep -v "INS:ME"  >> ~{prefix}.vcf
     mkdir tmp
     vcf-sort -t tmp/ ~{prefix}.vcf | bgzip > ~{prefix}.vcf.gz
-    tabix -p vcf ~{prefix}.vcf.gz
+    tabix -f -p vcf ~{prefix}.vcf.gz
   >>>
 
   output{

--- a/wdl/SRTestChromosome.wdl
+++ b/wdl/SRTestChromosome.wdl
@@ -228,7 +228,7 @@ task SRTest {
       bgzip local.SR.txt
     fi
 
-    tabix -s1 -b2 -e2 local.SR.txt.gz
+    tabix -f -s1 -b2 -e2 local.SR.txt.gz
     svtk sr-test -w 50 --log ~{common_arg} --medianfile ~{medianfile} --samples ~{include_list} ~{vcf} local.SR.txt.gz ~{prefix}.stats
   >>>
   runtime {

--- a/wdl/ShardedCluster.wdl
+++ b/wdl/ShardedCluster.wdl
@@ -210,7 +210,7 @@ task GetVcfHeaderWithMembersInfoLine {
     echo "##INFO=<ID=MEMBERS,Number=.,Type=String,Description=\"IDs of cluster's constituent records.\">" >> ~{prefix}.vcf
     zgrep "^#CHROM" ~{vcf_gz} >> ~{prefix}.vcf
     bgzip ~{prefix}.vcf
-    tabix ~{prefix}.vcf.gz
+    tabix -f ~{prefix}.vcf.gz
   >>>
 
   output {
@@ -258,7 +258,7 @@ task ShardClusters {
 
   command <<<
     set -euo pipefail
-    ~{if defined(exclude_list) && !defined(exclude_list_idx) then "tabix -p bed ~{exclude_list}" else ""}
+    ~{if defined(exclude_list) && !defined(exclude_list_idx) then "tabix -f -p bed ~{exclude_list}" else ""}
 
     #Run clustering
     svtk vcfcluster <(echo "~{vcf}") ~{prefix}.vcf.gz \
@@ -319,7 +319,7 @@ task SvtkVcfCluster {
 
   command <<<
     set -euo pipefail
-    ~{if defined(exclude_list) && !defined(exclude_list_idx) then "tabix -p bed ~{exclude_list}" else ""}
+    ~{if defined(exclude_list) && !defined(exclude_list_idx) then "tabix -f -p bed ~{exclude_list}" else ""}
 
     #Run clustering
     svtk vcfcluster <(echo "~{vcf}") - \

--- a/wdl/SingleSampleFiltering.wdl
+++ b/wdl/SingleSampleFiltering.wdl
@@ -33,7 +33,7 @@ task FilterVcfBySampleGenotypeAndAddEvidenceAnnotation {
     sampleIndex=`gzip -cd ~{vcf_gz} | grep '^#CHROM' | cut -f10- | tr "\t" "\n" | awk '$1 == "~{sample_id}" {found=1; print NR - 1} END { if (found != 1) { print "sample not found"; exit 1; }}'`
 
     bcftools query -f "%CHROM\t%POS\t%REF\t%ALT\t~{evidence}\n" ~{vcf_gz} | bgzip -c > evidence_annotations.tab.gz
-    tabix -s1 -b2 -e2 evidence_annotations.tab.gz
+    tabix -f -s1 -b2 -e2 evidence_annotations.tab.gz
 
     echo '##INFO=<ID=EVIDENCE,Number=.,Type=String,Description="Classes of random forest support.">' > header_line.txt
 
@@ -91,7 +91,7 @@ task FilterVcfForShortDepthCalls {
       -s ~{filter_name} |
          bgzip -c > ~{outfile}
 
-    tabix ~{outfile}
+    tabix -f ~{outfile}
 
   >>>
   runtime {
@@ -150,7 +150,7 @@ task GetUniqueNonGenotypedDepthCalls {
 
     cat header.txt unique_depth_records.txt | bgzip -c > ~{outfile}
 
-    tabix ~{outfile}
+    tabix -f ~{outfile}
   >>>
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
@@ -197,7 +197,7 @@ task FilterVcfForCaseSampleGenotype {
         -i "FILTER ~ \"MULTIALLELIC\" || GT[${sampleIndex}]=\"alt\"" \
         ~{vcf_gz} | bgzip -c > ~{outfile}
 
-    tabix ~{outfile}
+    tabix -f ~{outfile}
   >>>
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
@@ -260,7 +260,7 @@ task FilterLargePESRCallsWithoutRawDepthSupport {
        | bgzip -c \
        > ~{outfile}
 
-    tabix ~{outfile}
+    tabix -f ~{outfile}
   >>>
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
@@ -374,7 +374,7 @@ task FilterVcfWithReferencePanelCalls {
       -s REF_PANEL_GENOTYPES \
       -m + \
       del_dup_cpx_inv_filtered.vcf.gz | bgzip -c > ~{outfile}
-  tabix ~{outfile}
+  tabix -f ~{outfile}
   >>>
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
@@ -422,7 +422,7 @@ task ResetFilter {
   echo '~{info_header_line}' > header.txt
 
   bcftools filter -i 'FILTER ~ "~{filter_to_reset}"' ~{single_sample_vcf} | bgzip -c > sites.vcf.gz
-  tabix sites.vcf.gz
+  tabix -f sites.vcf.gz
 
   bcftools annotate \
     -k \
@@ -432,7 +432,7 @@ task ResetFilter {
     -x FILTER/~{filter_to_reset} \
     ~{single_sample_vcf} | bgzip -c > ~{outfile}
 
-  tabix ~{outfile}
+  tabix -f ~{outfile}
   >>>
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
@@ -480,7 +480,7 @@ task FinalVCFCleanup {
      # clean up bad END tags
      bcftools query -f '%CHROM\t%POS\t%REF\t%ALT\t%INFO/END\n' \
         ~{single_sample_vcf} | awk '$5 < $2 {OFS="\t"; $5 = $2 + 1; print}' | bgzip -c > bad_ends.txt.gz
-     tabix -s1 -b2 -e2 bad_ends.txt.gz
+     tabix -f -s1 -b2 -e2 bad_ends.txt.gz
      bcftools annotate \
         -a bad_ends.txt.gz \
         -c CHROM,POS,REF,ALT,END \
@@ -490,7 +490,7 @@ task FinalVCFCleanup {
         | vcf-sort -c \
         | bgzip -c > ~{outfile}
 
-     tabix ~{outfile}
+     tabix -f ~{outfile}
   >>>
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
@@ -588,7 +588,7 @@ task ConvertCNVsWithoutDepthSupportToBNDs {
         ~{default="1000" min_length} \
         -o ~{outfile}
 
-    tabix ~{outfile}
+    tabix -f ~{outfile}
 
   >>>
   runtime {
@@ -691,7 +691,7 @@ task SampleQC {
       cp wgd_filtered.vcf.gz ~{outfile}
     fi
 
-    tabix ~{outfile}
+    tabix -f ~{outfile}
 
   >>>
   runtime {

--- a/wdl/TasksBenchmark.wdl
+++ b/wdl/TasksBenchmark.wdl
@@ -252,13 +252,13 @@ task SplitVcf{
   command <<<
     if [[ ~{vcf_file} == *.gz ]] ;  then
       tabix -f -p vcf ~{vcf_file}
-      tabix -h ~{vcf_file} ~{contig} | bgzip > ~{contig}.vcf.gz
-      tabix -p vcf ~{contig}.vcf.gz
+      tabix -f -h ~{vcf_file} ~{contig} | bgzip > ~{contig}.vcf.gz
+      tabix -f -p vcf ~{contig}.vcf.gz
     else
       bgzip ~{vcf_file}
       tabix -f -p vcf ~{vcf_file}.gz
-      tabix -h ~{vcf_file}.gz ~{contig} | bgzip > ~{contig}.vcf.gz
-      tabix -p vcf ~{contig}.vcf.gz
+      tabix -f -h ~{vcf_file}.gz ~{contig} | bgzip > ~{contig}.vcf.gz
+      tabix -f -p vcf ~{contig}.vcf.gz
     fi
   >>>
 

--- a/wdl/TasksGenerateBatchMetrics.wdl
+++ b/wdl/TasksGenerateBatchMetrics.wdl
@@ -30,9 +30,9 @@ task SplitVCF {
   command <<<
 
     set -euo pipefail
-    tabix -p vcf ~{vcf}
+    tabix -f -p vcf ~{vcf}
     mkdir splits
-    tabix ~{vcf} ~{chrom} | split -a ~{suffix_len} -d -l ~{split_size} - splits/~{batch}.~{algorithm}.split.
+    tabix -f ~{vcf} ~{chrom} | split -a ~{suffix_len} -d -l ~{split_size} - splits/~{batch}.~{algorithm}.split.
 
     if [ ! -f splits/~{batch}.~{algorithm}.split.`printf '%0~{suffix_len}d' 0` ]; then
       touch splits/~{batch}.~{algorithm}.split.`printf '%0~{suffix_len}d' 0`
@@ -100,7 +100,7 @@ task GetCommonVCF {
     /usr/local/bin/bcftools filter -i 'ID=@common_SVID' ~{vcf} > common_SVs.vcf
 
     vcf-sort common_SVs.vcf | bgzip > common_SVs.vcf.gz
-    tabix common_SVs.vcf.gz
+    tabix -f common_SVs.vcf.gz
   >>>
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])

--- a/wdl/TasksGenotypeBatch.wdl
+++ b/wdl/TasksGenotypeBatch.wdl
@@ -227,7 +227,7 @@ task ConcatGenotypedVcfs {
     vcf-concat ~{sep=" " lt5kb_vcfs} ~{sep=" " gt5kb_vcfs} ~{sep=" " bca_vcfs} \
       | vcf-sort -c \
       | bgzip -c > ~{batch}.~{evidence_type}.vcf.gz
-    tabix -p vcf ~{batch}.~{evidence_type}.vcf.gz
+    tabix -f -p vcf ~{batch}.~{evidence_type}.vcf.gz
 
   >>>
   runtime {
@@ -347,7 +347,7 @@ task RDTestGenotype {
       bgzip local.RD.txt
     fi
 
-    tabix -p bed local.RD.txt.gz
+    tabix -f -p bed local.RD.txt.gz
 
     Rscript /opt/RdTest/RdTest.R \
       -b ~{bed} \
@@ -438,7 +438,7 @@ task CountPE {
       bgzip local.PE.txt
     fi
 
-    tabix -s1 -b2 -e2 local.PE.txt.gz
+    tabix -f -s1 -b2 -e2 local.PE.txt.gz
     svtk count-pe -s ~{write_lines(samples)} --medianfile ~{medianfile} ~{vcf} local.PE.txt.gz ~{prefix}.pe_counts.txt
     gzip ~{prefix}.pe_counts.txt
 
@@ -514,7 +514,7 @@ task CountSR {
       bgzip local.SR.txt
     fi
 
-    tabix -s1 -b2 -e2 local.SR.txt.gz
+    tabix -f -s1 -b2 -e2 local.SR.txt.gz
     svtk count-sr -s ~{write_lines(samples)} --medianfile ~{medianfile} ~{vcf} local.SR.txt.gz ~{prefix}.sr_counts.txt
     /opt/sv-pipeline/04_variant_resolution/scripts/sum_SR.sh ~{prefix}.sr_counts.txt ~{prefix}.sr_sum.txt.gz
     gzip ~{prefix}.sr_counts.txt

--- a/wdl/TasksMakeCohortVcf.wdl
+++ b/wdl/TasksMakeCohortVcf.wdl
@@ -150,7 +150,7 @@ task SortVcf {
         --output-type z \
         --output-file ~{outfile_name} \
         ~{vcf}
-    tabix ~{outfile_name}
+    tabix -f ~{outfile_name}
   >>>
 
   output {
@@ -209,7 +209,7 @@ task ConcatVcfs {
   String naive_flag = if naive then "--naive" else ""
   String concat_output_type = if (sites_only) then "v" else "z"
   String sites_only_command = if (sites_only) then "| bcftools view --no-version -G -Oz" else ""
-  String generate_index_command = if (generate_index) then "tabix ~{outfile_name}" else "touch ~{outfile_name}.tbi"
+  String generate_index_command = if (generate_index) then "tabix -f ~{outfile_name}" else "touch ~{outfile_name}.tbi"
 
   command <<<
     set -euo pipefail
@@ -289,7 +289,7 @@ task ConcatBeds {
       > ~{output_file}
 
     if ~{call_tabix}; then
-      tabix -p bed ~{output_file}
+      tabix -f -p bed ~{output_file}
     else
       touch ~{output_file}.tbi
     fi
@@ -440,7 +440,7 @@ task FilterVcf {
   command <<<
     set -eu
     bcftools view --no-version --no-update -i '~{records_filter}' -O z -o ~{outfile_name} ~{vcf}
-    tabix ~{outfile_name}
+    tabix -f ~{outfile_name}
   >>>
 
   output {
@@ -568,7 +568,7 @@ task SplitVcf {
     set -eu -o pipefail
 
     # Uncompress vcf. If index is present and contig is specified, use tabix to extract desired contig
-    ~{if defined(vcf_idx) && defined(contig) then "tabix -h ~{vcf} ~{contig}" else "zcat ~{vcf}"} \
+    ~{if defined(vcf_idx) && defined(contig) then "tabix -f -h ~{vcf} ~{contig}" else "zcat ~{vcf}"} \
       > uncompressed.vcf
 
     # Extract vcf header:
@@ -820,7 +820,7 @@ task MakeSitesOnlyVcf {
   command <<<
     set -euxo pipefail
     bcftools view --no-version -G ~{vcf} -Oz -o ~{prefix}.vcf.gz
-    tabix ~{prefix}.vcf.gz
+    tabix -f ~{prefix}.vcf.gz
   >>>
 
   output {
@@ -862,7 +862,7 @@ task ReheaderVcf {
   command <<<
     set -euxo pipefail
     bcftools reheader -h ~{header} ~{vcf} > ~{prefix}.vcf.gz
-    tabix ~{prefix}.vcf.gz
+    tabix -f ~{prefix}.vcf.gz
   >>>
 
   output {
@@ -903,7 +903,7 @@ task PullVcfShard {
   command <<<
     set -euo pipefail
     bcftools view --no-version --include ID=@~{vids} ~{vcf} -O z -o ~{output_prefix}.vcf.gz
-    tabix ~{output_prefix}.vcf.gz
+    tabix -f ~{output_prefix}.vcf.gz
     wc -l < ~{vids} > count.txt
   >>>
 
@@ -953,7 +953,7 @@ task RenameVariantIds {
       | bgzip \
       > ~{file_prefix}.vcf.gz
     if ~{defined(vcf_index)}; then
-      tabix ~{file_prefix}.vcf.gz
+      tabix -f ~{file_prefix}.vcf.gz
     else
       touch ~{file_prefix}.vcf.gz
     fi

--- a/wdl/TinyResolve.wdl
+++ b/wdl/TinyResolve.wdl
@@ -111,7 +111,7 @@ task ResolveManta {
     for (( i=0; i<~{num_samples}; i++ ));
     do
       vcf=${vcfs[$i]}
-      tabix -p vcf $vcf
+      tabix -f -p vcf $vcf
       sample_id=${sample_ids[$i]}
       pe=${discfiles[$i]}
       sample_no=`printf %03d $i`

--- a/wdl/VcfClusterSingleChromsome.wdl
+++ b/wdl/VcfClusterSingleChromsome.wdl
@@ -220,12 +220,12 @@ task LocalizeContigVcfs {
     # See Issue #52 "Use GATK to retrieve VCF records in JoinContigFromRemoteVcfs"
     # https://github.com/broadinstitute/gatk-sv/issues/52
 
-    tabix -h "~{vcf}" "~{contig}" \
+    tabix -f -h "~{vcf}" "~{contig}" \
       | sed "s/AN=[0-9]*;//g" \
       | sed "s/AC=[0-9]*;//g" \
       | bgzip \
       > contig.vcf.gz
-    tabix contig.vcf.gz
+    tabix -f contig.vcf.gz
 
     python3 <<CODE
     import pysam
@@ -313,7 +313,7 @@ task JoinVcfs {
           sys.stdout.write("\t".join(out_lines))
         sys.stdout.write('\n')
     CODE
-    tabix ~{prefix}.~{contig}.joined.vcf.gz
+    tabix -f ~{prefix}.~{contig}.joined.vcf.gz
   >>>
 
   output {
@@ -362,7 +362,7 @@ task FixMultiallelicRecords {
       ~{joined_vcf} \
       ~{write_lines(batch_contig_vcfs)} \
       ~{prefix}.~{contig}.fixed_multiallelics.vcf.gz
-    tabix ~{prefix}.~{contig}.fixed_multiallelics.vcf.gz
+    tabix -f ~{prefix}.~{contig}.fixed_multiallelics.vcf.gz
   >>>
 
   output {
@@ -415,7 +415,7 @@ task FixEvidenceTags {
       | sed -e 's/ID=EV,Number=.,Type=String/ID=EV,Number=1,Type=Integer/g' \
       | bgzip \
       > ~{prefix}.~{contig}.unclustered.vcf.gz
-    tabix ~{prefix}.~{contig}.unclustered.vcf.gz
+    tabix -f ~{prefix}.~{contig}.unclustered.vcf.gz
   >>>
 
   output {

--- a/wdl/Whamg.wdl
+++ b/wdl/Whamg.wdl
@@ -186,14 +186,14 @@ task RunWhamg {
 
     whamg -c "~{sep=","  chr_list}" -x ~{num_cpu} -a ~{reference_fasta} -f ~{bam_file} \
       | bgzip -c > "$VCF_FILE_BAD_TAGS"
-    tabix -p vcf "$VCF_FILE_BAD_TAGS"
+    tabix -f -p vcf "$VCF_FILE_BAD_TAGS"
 
     # write out a an annotation table with the new sample ID for each variant record.
     bcftools query -f '%CHROM\t%POS\t%REF\t%ALT\t~{sample_id}\n' $VCF_FILE_BAD_TAGS | bgzip -c > tags_annotation_file.tsv.gz
     tabix -f -s1 -b2 -e2 tags_annotation_file.tsv.gz
     # Use bcftools annotate to re-write the TAGS field in each variant based on the annotation table.
     bcftools annotate -a tags_annotation_file.tsv.gz -c CHROM,POS,REF,ALT,INFO/TAGS  $VCF_FILE_BAD_TAGS | bgzip -c > $VCF_FILE_BAD_HEADER
-    tabix -p vcf "$VCF_FILE_BAD_HEADER"
+    tabix -f -p vcf "$VCF_FILE_BAD_HEADER"
 
     echo "Adding contigs with length to vcf header"
     # get the existing header
@@ -213,7 +213,7 @@ task RunWhamg {
         "$VCF_FILE_BAD_HEADER" > $VCF_FILE_FIXED_HEADER
     
     echo "Indexing vcf"
-    tabix "$VCF_FILE_FIXED_HEADER"
+    tabix -f "$VCF_FILE_FIXED_HEADER"
     
     echo "finished RunWhamg"
     
@@ -326,7 +326,7 @@ task RunWhamgIncludelist {
         -r "$GOOD_INTERVAL" \
         | bgzip -c > "$NEW_VCF"
       # index results vcf
-      tabix "$NEW_VCF"
+      tabix -f "$NEW_VCF"
       # add vcf file name to list of vcfs, separated by spaces
       if [ -z "$VCFS" ]; then
         VCFS="$NEW_VCF"
@@ -347,14 +347,14 @@ task RunWhamgIncludelist {
     # concatenate resulting vcfs into final vcf
     echo "Concatenating results"
     bcftools concat -a -O z -o "$VCF_FILE_BAD_TAGS" $VCFS
-    tabix -p vcf "$VCF_FILE_BAD_TAGS"
+    tabix -f -p vcf "$VCF_FILE_BAD_TAGS"
 
     # write out a an annotation table with the new sample ID for each variant record.
     bcftools query -f '%CHROM\t%POS\t%REF\t%ALT\t~{sample_id}\n' $VCF_FILE_BAD_TAGS | bgzip -c > tags_annotation_file.tsv.gz
     tabix -f -s1 -b2 -e2 tags_annotation_file.tsv.gz
     # Use bcftools annotate to re-write the TAGS field in each variant based on the annotation table.
     bcftools annotate -a tags_annotation_file.tsv.gz -c CHROM,POS,REF,ALT,INFO/TAGS  $VCF_FILE_BAD_TAGS | bgzip -c > $VCF_FILE_BAD_HEADER
-    tabix -p vcf "$VCF_FILE_BAD_HEADER"
+    tabix -f -p vcf "$VCF_FILE_BAD_HEADER"
 
     echo "Getting existing header"
     # get the existing header
@@ -380,7 +380,7 @@ task RunWhamgIncludelist {
       > "$VCF_FILE_FIXED_HEADER"
     
     echo "Indexing vcf"
-    tabix "$VCF_FILE_FIXED_HEADER"
+    tabix -f "$VCF_FILE_FIXED_HEADER"
     
     echo "finished RunWhamg"
     

--- a/wdl/XfBatchEffect.wdl
+++ b/wdl/XfBatchEffect.wdl
@@ -215,7 +215,7 @@ task GetBatchSamplesList {
   command <<<
     set -euo pipefail
     # Get list of all samples present in VCF header
-    tabix -H ~{vcf} | fgrep -v "##" | cut -f10- | sed 's/\t/\n/g' | sort -Vk1,1 \
+    tabix -f -H ~{vcf} | fgrep -v "##" | cut -f10- | sed 's/\t/\n/g' | sort -Vk1,1 \
     > all_samples.list
     # Get list of samples in batch
     fgrep -w ~{batch} ~{sample_batch_assignments} | cut -f1 \
@@ -646,7 +646,7 @@ task ApplyBatchEffectLabels {
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
   command <<<
     set -euo pipefail
-    tabix -h ~{vcf} ~{contig} \
+    tabix -f -h ~{vcf} ~{contig} \
     | /opt/sv-pipeline/scripts/downstream_analysis_and_filtering/label_batch_effects.PCRMinus_only.py \
         --unstable-af-pcrminus ~{mingq_prePost_pcrminus_fails} \
         stdin \

--- a/wdl/prune_add_af.wdl
+++ b/wdl/prune_add_af.wdl
@@ -88,7 +88,7 @@ task PruneVcf {
   command <<<
     set -euo pipefail
     #Tabix chromosome of interest
-    tabix -h ~{vcf} ~{contig} | bgzip -c > ~{contig}.vcf.gz
+    tabix -f -h ~{vcf} ~{contig} | bgzip -c > ~{contig}.vcf.gz
     #Get column indexes corresponding to samples to drop, if any exist
     if ~{defined(prune_list)}; then
       dropidx=$( zfgrep "#" ~{contig}.vcf.gz | fgrep -v "##" \


### PR DESCRIPTION
When running the pipeline in local or shared filesystems, the pipeline sometimes fail because the index files are already there. With that in mind, I'm suggesting to add the `-f` flag to all `tabix` commands. 

Let me know if this make sense or if you would prefer to do it in some other way. 

Thanks