### PR TITLE
Adjust VM disk size w.r.t the input files size.

### DIFF
--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -200,7 +200,12 @@ task ConcatEHOutputs {
         boot_disk_gb: 10,
         preemptible_tries: 3,
         max_retries: 1,
-        disk_gb: 10
+        disk_gb: 10 +
+            (2 * ceil(
+                size(vcfs_gz, "GiB") +
+                size(jsons, "GiB") +
+                size(overlapping_reads, "GiB") +
+                size(timings, "GiB")))
     }
     RuntimeAttr runtime_attr = select_first([
         runtime_attr_override,


### PR DESCRIPTION
This PR sets the disk size of the VM of the task that combines the results of the scattered ExpansionHunter runs to the sum of input files size multiplied by two, in order to fit the input files and their merged versions. 