### PR TITLE
Determine the docker images to be built using build_docker.py script

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -25,8 +25,9 @@ jobs:
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     outputs:
-      target_images: ${{ steps.target_images.outputs.TARGETS }}
       images_tag: ${{ steps.image_tag.outputs.IMAGE_TAG }}
+      base_sha: ${{ steps.commit_sha.outputs.BASE_SHA }}
+      head_sha: ${{ steps.commit_sha.outputs.HEAD_SHA }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -128,7 +129,7 @@ jobs:
       - name: Run build_docker.py
         run: |
           cd ./scripts/docker/
-          python build_docker.py --base-git-commit ${{ steps.commit_sha.outputs.BASE_SHA }} --current-git-commit ${{ steps.commit_sha.outputs.HEAD_SHA }} --image-tag ${{ needs.build_args_job.outputs.images_tag }}
+          python build_docker.py --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} --image-tag ${{ needs.build_args_job.outputs.images_tag }}
 
   publish_job:
     # This job first configures gcloud with the authentication of a
@@ -189,4 +190,4 @@ jobs:
       - name: Build and Publish Docker Images
         run: |
           cd ./scripts/docker/
-          python build_docker.py --base-git-commit ${{ steps.commit_sha.outputs.BASE_SHA }} --current-git-commit ${{ steps.commit_sha.outputs.HEAD_SHA }} --image-tag ${{ needs.build_args_job.outputs.images_tag }} --gcr-project ${{ secrets.GCP_PROJECT_ID }}/gatk-sv
+          python build_docker.py --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} --image-tag ${{ needs.build_args_job.outputs.images_tag }} --gcr-project ${{ secrets.GCP_PROJECT_ID }}/gatk-sv

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -103,83 +103,6 @@ jobs:
           echo "::debug::Image tag: $IMAGE_TAG"
           echo "::set-output name=IMAGE_TAG::$IMAGE_TAG"
 
-      - name: Determine Target Images
-        id: target_images
-        # This step determines the target images to be rebuilt based on the
-        # files changed between the HEAD and BASE commits (see the
-        # 'Determine Commit SHAs' step). For instance, if the commit changes
-        # the `dockerfiles/sv-base/Dockerfile`, then the `sv-base` docker
-        # image and all its dependencies are rebuilt.
-        #
-        # This step first gets the HEAD and BASE commit SHAs from the
-        # 'commit_sha' step. Then uses `git diff` to determine the files
-        # changed between the commits. Based on the changed files, it
-        # determines a list of docker images to be rebuilt. Finally, it
-        # stores the determined docker images in $TARGETS variable that can
-        # be accessed in other steps.
-        run: |
-          BASE_SHA=${{ steps.commit_sha.outputs.BASE_SHA }}
-          HEAD_SHA=${{ steps.commit_sha.outputs.HEAD_SHA }}
-
-          # A list of all the files changed in HEAD commit w.r.t BASE commit.
-          CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
-
-          # Add a given target image name to the TARGETS
-          # array if it is not already in the array.
-          TARGETS=()
-          try_add_target() {
-            if [[ ! " ${TARGETS[*]} " =~ $1 ]]; then
-              TARGETS+=($1)
-            fi
-          }
-
-          for i in "${CHANGED_FILES[@]}"
-          do
-            if [[ $i == *".github/workflows/sv_pipeline_docker.yml"* ]]; then
-              # A change to this file may impact how images are built,
-              # hence, if this file is changed, all the images are rebuilt.
-              TARGETS=("all")
-              break
-            elif [[ $i == *"src/svtk"* ||
-                  $i == *"src/sv-pipeline"* ||
-                  $i == *"src/svtest"* ||
-                  $i == *"src/svqc"* ]]; then
-              try_add_target "sv-pipeline"
-              try_add_target "sv-pipeline-base"
-              try_add_target "sv-pipeline-children-r"
-            elif [[ $i == *"src/RdTest"* ]]; then
-              try_add_target "sv-pipeline-rdtest"
-            elif [[ $i == *"src/WGD"* ]]; then
-              try_add_target "sv-pipeline-qc"
-              try_add_target "cnmops"
-            fi
-
-            # Rebuild the docker image of the Dockerfiles specified in
-            # the `D` array. Use regular expression to extract the target
-            # image from the file path. For instance, if
-            # i = dockerfiles/delly/Dockerfile, then M="delly".
-            if [[ $i =~ (dockerfiles/)([^,]*)(/Dockerfile) ]]; then
-              M="${BASH_REMATCH[2]}"
-              D=("delly" "manta" "wham" "sv-base-mini" "sv-base" "samtools-cloud")
-              if [[ " ${D[*]} " =~ $M ]]; then
-                try_add_target $M
-              fi
-            fi
-          done
-
-          # Join the determined targets in a space-delimited string.
-          TARGETS=$(IFS=' '; echo "${TARGETS[*]}")
-
-          # Print some debugging information.
-          echo "::debug::Docker images to rebuild: $TARGETS"
-          echo "::debug::Changed files:"
-          for f in "${CHANGED_FILES[@]}"; do
-            echo "::debug:: - $f"
-          done
-
-          # Set the output of this step so it can be accessed in other steps.
-          echo "::set-output name=TARGETS::$TARGETS"
-
   build_job:
     runs-on: ubuntu-20.04
     name: Test Images Build
@@ -205,7 +128,7 @@ jobs:
       - name: Run build_docker.py
         run: |
           cd ./scripts/docker/
-          python build_docker.py --targets ${{ needs.build_args_job.outputs.target_images }} --image-tag ${{ needs.build_args_job.outputs.images_tag }}
+          python build_docker.py --base-git-commit ${{ steps.commit_sha.outputs.BASE_SHA }} --current-git-commit ${{ steps.commit_sha.outputs.HEAD_SHA }} --image-tag ${{ needs.build_args_job.outputs.images_tag }}
 
   publish_job:
     # This job first configures gcloud with the authentication of a
@@ -266,4 +189,4 @@ jobs:
       - name: Build and Publish Docker Images
         run: |
           cd ./scripts/docker/
-          python build_docker.py --targets ${{ needs.build_args_job.outputs.target_images }} --image-tag ${{ needs.build_args_job.outputs.images_tag }} --gcr-project ${{ secrets.GCP_PROJECT_ID }}/gatk-sv
+          python build_docker.py --base-git-commit ${{ steps.commit_sha.outputs.BASE_SHA }} --current-git-commit ${{ steps.commit_sha.outputs.HEAD_SHA }} --image-tag ${{ needs.build_args_job.outputs.images_tag }} --gcr-project ${{ secrets.GCP_PROJECT_ID }}/gatk-sv

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -25,7 +25,6 @@ jobs:
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     outputs:
-      images_tag: ${{ steps.image_tag.outputs.IMAGE_TAG }}
       base_sha: ${{ steps.commit_sha.outputs.BASE_SHA }}
       head_sha: ${{ steps.commit_sha.outputs.HEAD_SHA }}
     steps:
@@ -82,28 +81,6 @@ jobs:
           echo "::set-output name=BASE_SHA::$BASE_SHA"
           echo "::set-output name=HEAD_SHA::$HEAD_SHA"
 
-      - name: Compose Image Tag
-        id: image_tag
-        # This step composes a tag to be used for all the images created by
-        # the build_docker.py script. The tag follows the following template:
-        #
-        #   DATE-HEAD_SHA_8
-        #
-        # where 'DATE' is YYYYMMDD extracted from the time stamp of the last
-        # commit on the feature branch (HEAD), and 'HEAD_SHA_8' is the first
-        # eight letters of its commit SHA.
-        run: |
-          COMMIT_SHA=${{ steps.commit_sha.outputs.HEAD_SHA }}
-
-          # Extract the time stamp of COMMIT_SHA in YYYYMMDD format.
-          # See git-show documentation available at:
-          # http://schacon.github.io/git/git-show
-          DATE=$(git show -s --format=%ad --date=format:'%Y%m%d' $COMMIT_SHA)
-
-          IMAGE_TAG=$DATE-${COMMIT_SHA::8}
-          echo "::debug::Image tag: $IMAGE_TAG"
-          echo "::set-output name=IMAGE_TAG::$IMAGE_TAG"
-
   build_job:
     runs-on: ubuntu-20.04
     name: Test Images Build
@@ -132,7 +109,7 @@ jobs:
       - name: Run build_docker.py
         run: |
           cd ./scripts/docker/
-          python build_docker.py --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} --image-tag ${{ needs.build_args_job.outputs.images_tag }}
+          python build_docker.py --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} --current-git-commit ${{ needs.build_args_job.outputs.head_sha }}
 
   publish_job:
     # This job first configures gcloud with the authentication of a
@@ -196,4 +173,4 @@ jobs:
       - name: Build and Publish Docker Images
         run: |
           cd ./scripts/docker/
-          python build_docker.py --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} --image-tag ${{ needs.build_args_job.outputs.images_tag }} --gcr-project ${{ secrets.GCP_PROJECT_ID }}/gatk-sv
+          python build_docker.py --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} --gcr-project ${{ secrets.GCP_PROJECT_ID }}/gatk-sv

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -115,6 +115,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          # See the comment on build_args_job.
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -147,6 +150,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          # See the comment on build_args_job.
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Currently, the `workflows/sv_pipeline_docker.yml` uses two git commits to determine the files changed between the commits, and uses the list of changed files to determine which docker images should be rebuilt. This functionality is now available in `build_docker.py`; hence, in order to simplify the workflow, this PR implements changes to leverage `build_docker.py` to decide which docker images should be rebuilt. 