### PR TITLE
Fix build_dockers.py error updating dockers.json

### DIFF
--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -198,7 +198,10 @@ class ProjectBuilder:
         if output_json is None or not output_json or output_json == Paths.dev_null:
             return  # no update is desired
         new_dockers_json = {
-            json_key: self.get_current_image(ProjectBuilder.get_target_from_image(docker_image))
+            json_key: (self.get_current_image(ProjectBuilder.get_target_from_image(docker_image))
+                       if ProjectBuilder.get_target_from_image(docker_image) in self.dependencies
+                       else docker_image)
+
             for json_key, docker_image in self.dockers_json.items()
         }
         # if a new image has been added that is not used by dockers json, store it as a distinct value to have a record


### PR DESCRIPTION
Previously build_dockers.py would erroneously update the gatk dockers, which it is not supposed to update.

build_dockers.py would erroneously update the gatk dockers, which it was
not supposed to maintain. This caused one of the images to clobber the
other. Now build_dockers.py only updates images it maintains.