### PR TITLE
Compose an image tag in the same format as GATK docker images

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       base_sha: ${{ steps.commit_sha.outputs.BASE_SHA }}
       head_sha: ${{ steps.commit_sha.outputs.HEAD_SHA }}
+      image_tag: ${{ steps.image_tag.outputs.IMAGE_TAG }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -81,6 +82,32 @@ jobs:
           echo "::set-output name=BASE_SHA::$BASE_SHA"
           echo "::set-output name=HEAD_SHA::$HEAD_SHA"
 
+      - name: Compose Image Tag
+        id: image_tag
+        # This step composes a tag to be used for all the images created by
+        # the build_docker.py script. The tag follows the following template:
+        #
+        #   DATE-RELEAST_TAG-HEAD_SHA_8
+        #
+        # where 'DATE' is YYYY-MM-DD extracted from the time stamp of the last
+        # commit on the feature branch (HEAD), `RELEASE_TAG` is extracted from
+        # the latest [pre-]release on Github, and the 'HEAD_SHA_8' is the first
+        # eight letters of the SHA of the last commit on the feature branch (HEAD).
+        run: |          
+          # Extract the time stamp of COMMIT_SHA in YYYY-MM-DD format.
+          # See git-show documentation available at:
+          # http://schacon.github.io/git/git-show
+          DATE=$(git show -s --format=%ad --date=format:'%Y-%m-%d' $COMMIT_SHA)
+          
+          # Get latest [pre-]release tag.
+          RELEASE_TAG=$(jq -r '.[0] | .tag_name' <<< $(curl --silent https://api.github.com/repos/broadinstitute/gatk-sv/releases))
+          
+          COMMIT_SHA=${{ steps.commit_sha.outputs.HEAD_SHA }}
+          
+          IMAGE_TAG=$DATE-$RELEASE_TAG-${COMMIT_SHA::8}
+          echo "::debug::Image tag: $IMAGE_TAG"
+          echo "::set-output name=IMAGE_TAG::$IMAGE_TAG"
+
   build_job:
     runs-on: ubuntu-20.04
     name: Test Images Build
@@ -109,7 +136,10 @@ jobs:
       - name: Run build_docker.py
         run: |
           cd ./scripts/docker/
-          python build_docker.py --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} --current-git-commit ${{ needs.build_args_job.outputs.head_sha }}
+          python build_docker.py \
+            --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \
+            --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} \
+            --image-tag ${{ needs.build_args_job.outputs.image_tag }}
 
   publish_job:
     # This job first configures gcloud with the authentication of a
@@ -173,7 +203,11 @@ jobs:
       - name: Build and Publish Docker Images
         id: build_and_publish
         run: |
-          python ./scripts/docker/build_docker.py --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} --gcr-project ${{ secrets.GCP_PROJECT_ID }}/gatk-sv
+          python ./scripts/docker/build_docker.py \
+            --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \
+            --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} \
+            --gcr-project ${{ secrets.GCP_PROJECT_ID }}/gatk-sv \
+            --image-tag ${{ needs.build_args_job.outputs.image_tag }}
           CHANGED=$(git diff --quiet ./inputs/values/dockers.json || echo True)
           echo "::set-output name=CHANGED::$CHANGED"
 


### PR DESCRIPTION
The default image tag of `build_docker.py` is the first 8 chars of the commit SHA. Following @mwalker174's [suggestion](https://github.com/broadinstitute/gatk-sv/pull/313#pullrequestreview-918892810), this PR updates the `Docker Images` action by composing an image tag that follows a similar format to the GATK nightly builds; i.e., 

```
{date}-{release tag}-{first eight letters of the commit sha}
```

For instance: 

```
2022-03-25-v0.20.2-beta-658f92ce
```