### PR TITLE
Fix ENDs and rescale GQ to [0,99] at end of CleanVcf

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ Apply downstream filtering steps to the cleaned vcf to further control the false
 
 Filterings methods include:
 * minGQ - remove variants based on the genotype quality across populations.
-Note: Trio families are required to build the minGQ filtering model in this step. We provide tables pre-trained with the 1000 genomes samples at different FDR thresholds for projects that lack family structures, and they can be found here: 
+Note: Trio families are required to build the minGQ filtering model in this step. We provide tables pre-trained with the 1000 genomes samples at different FDR thresholds for projects that lack family structures, and they can be found at the paths below.  These tables assume that GQ has a scale of [0,999], so they will not work with newer VCFs where GQ has a scale of [0,99].
 ```
 gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/mingq/1KGP_2504_and_698_with_GIAB.10perc_fdr.PCRMINUS.minGQ.filter_lookup_table.txt
 gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/mingq/1KGP_2504_and_698_with_GIAB.1perc_fdr.PCRMINUS.minGQ.filter_lookup_table.txt

--- a/inputs/templates/test/MakeCohortVcf/MasterVcfQc.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/MasterVcfQc.json.tmpl
@@ -1,0 +1,20 @@
+{
+  "MasterVcfQc.primary_contigs_fai": {{ reference_resources.primary_contigs_fai | tojson }},
+  
+  "MasterVcfQc.thousand_genomes_benchmark_calls": {{ reference_resources.thousand_genomes_benchmark_calls | tojson }},
+
+  "MasterVcfQc.random_seed": 0,
+
+  "MasterVcfQc.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
+  "MasterVcfQc.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
+  "MasterVcfQc.sv_pipeline_qc_docker": {{ dockers.sv_pipeline_qc_docker | tojson }},
+
+  "MasterVcfQc.prefix": {{ test_batch.name | tojson }},
+  "MasterVcfQc.ped_file": {{ test_batch.ped_file | tojson }},
+  
+  "MasterVcfQc.vcf": {{ test_batch.clean_vcf| tojson }},
+
+  "MasterVcfQc.sv_per_shard": 10000,
+  "MasterVcfQc.samples_per_shard": 100
+  
+}

--- a/src/sv-pipeline/java/org/broadinstitute/svpipeline/VCFParserUnitTest.java
+++ b/src/sv-pipeline/java/org/broadinstitute/svpipeline/VCFParserUnitTest.java
@@ -116,8 +116,8 @@ public final class VCFParserUnitTest {
     public static void testRecord() {
         final String line = "chr1\t10000\tna19240_DUP_chr1_1\tN\t<DUP>\t999\tPASS;BUT_FUNKY\t" +
                 "END=16000;SVTYPE=DUP;FLAG1;CHR2=chr1;SVLEN=6000;ALGORITHMS=depth;EVIDENCE=RD;FLAG2\t" +
-                "GT:GQ:RD_CN:RD_GQ:PE_GT:PE_GQ:SR_GT:SR_GQ:EV\t0/1:142:3:142:.:.:.:.:RD\t" +
-                "0/0:999:2:999:.:.:.:.:RD";
+                "GT:GQ:RD_CN:RD_GQ:PE_GT:PE_GQ:SR_GT:SR_GQ:EV\t0/1:14:3:14:.:.:.:.:RD\t" +
+                "0/0:99:2:99:.:.:.:.:RD";
         final byte[] bytes = (line + "\n").getBytes();
         final VCFParser parser = new VCFParser(new ByteArrayInputStream(bytes));
         assert(!parser.hasMetadata());
@@ -223,10 +223,10 @@ public final class VCFParserUnitTest {
         final List<CompoundField> genotypes = record.getGenotypes();
         assert(genotypes.size() == 2);
         final ByteSequence geno1 = genotypes.get(0).getValue();
-        final ByteSequence geno1Value = new ByteSequence("0/1:142:3:142:.:.:.:.:RD");
+        final ByteSequence geno1Value = new ByteSequence("0/1:14:3:14:.:.:.:.:RD");
         assert(geno1.equals(geno1Value));
         final ByteSequence geno2 = genotypes.get(1).getValue();
-        final ByteSequence geno2Value = new ByteSequence("0/0:999:2:999:.:.:.:.:RD");
+        final ByteSequence geno2Value = new ByteSequence("0/0:99:2:99:.:.:.:.:RD");
         assert(geno2.equals(geno2Value));
         record.setGenotypes(Collections.singletonList(geno2Value));
         final List<CompoundField> newGenotypes = record.getGenotypes();
@@ -262,6 +262,6 @@ public final class VCFParserUnitTest {
         sb.append("N\t").append("<DUP>\t").append("999\t").append("PASS\t");
         sb.append("END=").append(pos+999).append('\t');
         sb.append("SVTYPE=DUP;CHR2=chr1;SVLEN=1000;ALGORITHMS=depth;EVIDENCE=RD\t");
-        sb.append("GT:GQ:RD_CN\t").append("0/1:999:2\t").append("0/0:999:1\n");
+        sb.append("GT:GQ:RD_CN\t").append("0/1:99:2\t").append("0/0:99:1\n");
     }
 }

--- a/src/sv-pipeline/scripts/downstream_analysis_and_filtering/after_process_step1.revise_filter_Large_SR_only.py
+++ b/src/sv-pipeline/scripts/downstream_analysis_and_filtering/after_process_step1.revise_filter_Large_SR_only.py
@@ -12,7 +12,7 @@ def revise_filter_Large_SR_only(vcf, fout, size_cutoff=500, sample_proportion_cu
                 SR_only_list = []
                 gt_list = []
                 for sample in record.samples.values():
-                    if sample['RD_CN'] == 2 and sample['PE_GT'] == 0 and sample['PE_GQ'] == 999 and sample['SR_GT'] != 0:
+                    if sample['RD_CN'] == 2 and sample['PE_GT'] == 0 and sample['PE_GQ'] == 99 and sample['SR_GT'] != 0:
                         SR_only_list.append(1)
                         gt_list.append(sample['GT'])
                     else:

--- a/src/sv-pipeline/scripts/downstream_analysis_and_filtering/filter_cleanup_and_QUAL_recalibration.PCRMinus_only.py
+++ b/src/sv-pipeline/scripts/downstream_analysis_and_filtering/filter_cleanup_and_QUAL_recalibration.PCRMinus_only.py
@@ -67,7 +67,7 @@ def recal_qual_score(record):
         elif GT in HET_GTs:
             quals.append(record.samples[s]['GQ'])
         else:
-            quals.append(999)
+            quals.append(99)
 
     if len(quals) > 0:
         return int(median(quals))

--- a/src/sv-pipeline/scripts/downstream_analysis_and_filtering/filter_cleanup_and_QUAL_recalibration.py
+++ b/src/sv-pipeline/scripts/downstream_analysis_and_filtering/filter_cleanup_and_QUAL_recalibration.py
@@ -66,7 +66,7 @@ def recal_qual_score(record):
         elif GT in HET_GTs:
             quals.append(record.samples[s]['GQ'])
         else:
-            quals.append(999)
+            quals.append(99)
 
     if len(quals) > 0:
         return int(median(quals))

--- a/src/sv-pipeline/scripts/downstream_analysis_and_filtering/optimize_minGQ_ROC_v2.R
+++ b/src/sv-pipeline/scripts/downstream_analysis_and_filtering/optimize_minGQ_ROC_v2.R
@@ -176,7 +176,7 @@ option_list <- list(
   make_option(c("--minGQ"), type="integer", default=0,
               help="minimum GQ in window to test [default %default]",
               metavar="integer"),
-  make_option(c("--maxGQ"), type="integer", default=999,
+  make_option(c("--maxGQ"), type="integer", default=99,
               help="maximum GQ in window to test [default %default]",
               metavar="integer"),
   make_option(c("--step"), type="integer", default=1,

--- a/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R
+++ b/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R
@@ -84,7 +84,7 @@ subsetDat <- function(dat,vlist,biallelic=T,
   return(x)
 }
 #Gather matrix of SVs in any member of a family with information on allele counts in child & parent(s)
-getFamDat <- function(dat,proband,father=NA,mother=NA,biallelic=T,nocall.placeholder=9999){
+getFamDat <- function(dat,proband,father=NA,mother=NA,biallelic=T,nocall.placeholder=9999,max.GQ=99){
   #Clean parent IDs
   if(is.na(father)){
     father <- NULL
@@ -183,7 +183,7 @@ getFamDat <- function(dat,proband,father=NA,mother=NA,biallelic=T,nocall.placeho
                        "pro.GQ","fa.GQ","mo.GQ")
   
   #Subset data & add transmission data
-  dat.fam <- subsetDat(dat=dat,vlist=trans,biallelic=biallelic)
+  dat.fam <- subsetDat(dat=dat,vlist=trans,biallelic=biallelic,max.GQ.pro=max.GQ,max.GQ.par=max.GQ)
   dat.fam[,(ncol(dat.fam)-9):ncol(dat.fam)] <- apply(dat.fam[,(ncol(dat.fam)-9):ncol(dat.fam)],2,as.numeric)
   return(dat.fam)
 }
@@ -446,9 +446,9 @@ deNovoRateBySize <- function(trio.dat.list,size.bins=40,count="variants"){
   return(list("DNRs"=DNRs,"bins"=size.df))
 }
 #Collect matrix of de novo rates by class by minimum proband GQ
-deNovoRateByProGQ <- function(trio.dat.list,GQ.bins=40,count="variants"){
+deNovoRateByProGQ <- function(trio.dat.list,GQ.bins=50,count="variants",max.GQ=99){
   #Create evenly spaced GQ bins
-  GQ.steps <- seq(0,1000,by=1000/GQ.bins)
+  GQ.steps <- seq(0,max.GQ+1,by=(max.GQ+1)/GQ.bins)
   
   #Iterate over min GQs and gather de novo rates
   DNRs <- sapply(GQ.steps,function(min.GQ){
@@ -767,7 +767,7 @@ plotDNRvsFreq <- function(DNRs,bins,k=4,title=NULL,legend=T,fam.type="familie",n
 }
 #Plot DNRs vs GQ for all classes
 plotDNRvsGQ <- function(DNRs,bins,k=4,title=NULL,xlabel="Mininum GQ",
-                        legend=T,fam.type="familie",nfams,count="variants",cex.lab=1){
+                        legend=T,fam.type="familie",nfams,count="variants",cex.lab=1,max.GQ=99){
   #Get x axis title
   if(count=="variants"){
     x.label <- "Carrier Frequency"
@@ -781,13 +781,13 @@ plotDNRvsGQ <- function(DNRs,bins,k=4,title=NULL,xlabel="Mininum GQ",
        xaxt="n",yaxt="n",xlab="",ylab="",yaxs="i")
   
   #Add vertical gridlines
-  abline(v=seq(0,1000,50),col="gray92")
-  abline(v=seq(0,1000,100),col="gray85")
+  abline(v=seq(0,max.GQ+1,(max.GQ+1)/20),col="gray92")
+  abline(v=seq(0,max.GQ+1,(max.GQ+1)/10),col="gray85")
   
   #Add axes & title
-  axis(1,at=seq(0,1000,100),tck=-0.03,labels=NA)
-  axis(1,at=seq(0,1000,100),tick=F,cex.axis=0.7*cex.lab,line=-0.4,
-       las=2,labels=paste(">",seq(0,1000,100),sep=""))
+  axis(1,at=seq(0,max.GQ+1,(max.GQ+1)/10),tck=-0.03,labels=NA)
+  axis(1,at=seq(0,max.GQ+1,(max.GQ+1)/10),tick=F,cex.axis=0.7*cex.lab,line=-0.4,
+       las=2,labels=paste(">",seq(0,max.GQ+1,(max.GQ+1)/10),sep=""))
   mtext(1,text=xlabel,line=2.25,cex=cex.lab)
   axis(2,at=seq(0,1,0.2),tck=-0.025,labels=NA)
   axis(2,at=seq(0,1,0.2),tick=F,line=-0.4,cex.axis=0.8,las=2,
@@ -1035,7 +1035,7 @@ wrapperInheritancePlots <- function(fam.dat.list,fam.type,count="variants"){
   dev.off()
 }
 #Wrapper for de novo rate lineplots
-wrapperDeNovoRateLines <- function(fam.dat.list,fam.type,count="variants",gq=F){
+wrapperDeNovoRateLines <- function(fam.dat.list,fam.type,count="variants",gq=F,max.GQ=99){
   #Set title prefix
   if(count=="variants"){
     title.prefix <- "SV Site "
@@ -1063,12 +1063,12 @@ wrapperDeNovoRateLines <- function(fam.dat.list,fam.type,count="variants",gq=F){
   
   #DNR by Proband GQ
   if(gq) {
-    GQ.dat <- deNovoRateByProGQ(trio.dat.list=fam.dat.list,GQ.bins=40,count=count)
+    GQ.dat <- deNovoRateByProGQ(trio.dat.list=fam.dat.list,GQ.bins=50,count=count)
     pdf(paste(OUTDIR,"/supporting_plots/sv_inheritance_plots/sv_de_novo_rate.",fam.type,"s.",count,".by_proband_GQ.pdf",sep=""),
         height=4,width=5)
     plotDNRvsGQ(DNRs=GQ.dat$DNRs,bins=GQ.dat$bins,k=4,nfams=length(fam.dat.list),
                 title=paste(title.prefix,"De Novo Rate by Min. Proband GQ",sep=""),
-                count=count,fam.type=fam.type,legend=T,xlab="Min. Proband GQ")
+                count=count,fam.type=fam.type,legend=T,xlab="Min. Proband GQ",max.GQ=max.GQ)
     dev.off()
   }
 }
@@ -1107,7 +1107,7 @@ wrapperDeNovoRateHeats <- function(fam.dat.list,fam.type,count="variants"){
   })
 }
 #Wrapper for master summary panel
-masterInhWrapper <- function(fam.dat.list,fam.type, gq=T){
+masterInhWrapper <- function(fam.dat.list,fam.type, gq=T,max.GQ=99){
   #Set title suffix
   if(fam.type=="trio"){
     title.suffix <- paste("(Trios; n=",
@@ -1162,11 +1162,11 @@ masterInhWrapper <- function(fam.dat.list,fam.type, gq=T){
                 count="variants",fam.type=fam.type,legend=F,cex.lab=cex.lab)
   #DNR vs min proband GQ
   if(gq) {
-    GQ.dat.v <- deNovoRateByProGQ(trio.dat.list=fam.dat.list,GQ.bins=40,count="variants")
+    GQ.dat.v <- deNovoRateByProGQ(trio.dat.list=fam.dat.list,GQ.bins=50,count="variants")
     plotDNRvsGQ(DNRs=GQ.dat.v$DNRs,bins=GQ.dat.v$bins,k=4,nfams=length(fam.dat.list),
                 title=paste("Site De Novo Rate by GQ",sep=""),
                 count="variants",fam.type=fam.type,legend=F,cex.lab=cex.lab,
-                xlab="Min. Proband GQ")
+                xlab="Min. Proband GQ",max.GQ=max.GQ)
   }
   #DNR heatmap (size vs freq.)
   DNR.dat.v <- deNovoRateBySizeFreq(trio.dat.list=fam.dat.list,count="variants",
@@ -1198,11 +1198,11 @@ masterInhWrapper <- function(fam.dat.list,fam.type, gq=T){
                 count="alleles",fam.type=fam.type,legend=F,cex.lab=cex.lab)
   #DNR vs min proband GQ
   if(gq){
-    GQ.dat.a <- deNovoRateByProGQ(trio.dat.list=fam.dat.list,GQ.bins=40,count="alleles")
+    GQ.dat.a <- deNovoRateByProGQ(trio.dat.list=fam.dat.list,GQ.bins=50,count="alleles")
     plotDNRvsGQ(DNRs=GQ.dat.a$DNRs,bins=GQ.dat.a$bins,k=4,nfams=length(fam.dat.list),
                 title=paste("Allele De Novo Rate by GQ",sep=""),
                 count="alleles",fam.type=fam.type,legend=F,cex.lab=cex.lab,
-                xlabel="Min. Proband GQ")
+                xlabel="Min. Proband GQ",max.GQ=max.GQ)
   }
   #DNR heatmap (size vs freq.)
   DNR.dat.a <- deNovoRateBySizeFreq(trio.dat.list=fam.dat.list,count="alleles",
@@ -1237,6 +1237,9 @@ option_list <- list(
   make_option(c("-M", "--multiallelics"), type="logical", default=FALSE,
               help="include multiallelic sites in inheritance calculations [default %default]",
               metavar="logical")
+  make_option(c("-G", "--maxgq"), type="integer", default=99,
+              help="Max GQ value, ie. 99 for GQ on a scale of [0,99]",
+              metavar="integer")
 )
 
 ###Get command-line arguments & options
@@ -1257,6 +1260,7 @@ perSampDir <- args$args[3]
 OUTDIR <- args$args[4]
 svtypes.file <- opts$svtypes
 multiallelics <- opts$multiallelics
+maxgq <- opts$maxgq
 
 # #Dev parameters
 # dat.in <- "~/scratch/xfer/gnomAD_v2_SV_MASTER_resolved_VCF.VCF_sites.stats.bed.gz"
@@ -1340,7 +1344,7 @@ if(nrow(trios)>0){
   #Read data
   trio.dat <- apply(trios[,2:4],1,function(IDs){
     IDs <- as.character(IDs)
-    return(getFamDat(dat=dat,proband=IDs[1],father=IDs[2],mother=IDs[3],biallelic=!multiallelics))
+    return(getFamDat(dat=dat,proband=IDs[1],father=IDs[2],mother=IDs[3],biallelic=!multiallelics,max.GQ=maxgq))
   })
   names(trio.dat) <- trios[,1]
   
@@ -1348,25 +1352,25 @@ if(nrow(trios)>0){
   gq <- any(unlist(lapply(trio.dat, function(trio){ sum(!is.na(trio$pro.GQ)) > 0 })))
   
   #Master wrapper
-  masterInhWrapper(fam.dat.list=trio.dat,fam.type="trio", gq=gq)
+  masterInhWrapper(fam.dat.list=trio.dat,fam.type="trio", gq=gq,max.GQ=maxgq)
   #Standard inheritance panels
   sapply(c("variants","alleles"),function(count){
     wrapperInheritancePlots(fam.dat.list=trio.dat,
                             fam.type="trio",
-                            count=count)  
+                            count=count)
   })
   #De novo rate panels
   sapply(c("variants","alleles"),function(count){
     wrapperDeNovoRateLines(fam.dat.list=trio.dat,
                            fam.type="trio",
                            count=count,
-                           gq=gq)  
+                           gq=gq,max.GQ=maxgq)
   })
   #De novo rate heatmaps
   sapply(c("variants","alleles"),function(count){
     wrapperDeNovoRateHeats(fam.dat.list=trio.dat,
                            fam.type="trio",
-                           count=count)  
+                           count=count)
   })
 }
 

--- a/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R
+++ b/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R
@@ -53,8 +53,8 @@ readDatPerSample <- function(ID,nocall.placeholder=9999){
 }
 #Subset SV stats data
 subsetDat <- function(dat,vlist,biallelic=T,
-                      min.GQ.pro=0,max.GQ.pro=999,
-                      min.GQ.par=0,max.GQ.par=999){
+                      min.GQ.pro=0,max.GQ.pro=99,
+                      min.GQ.par=0,max.GQ.par=99){
   #Check input variant list
   #Subset dat to variants found in sample & append number of alleles in sample
   x <- merge(dat,vlist,by="VID",sort=F)

--- a/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R
+++ b/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R
@@ -1063,7 +1063,7 @@ wrapperDeNovoRateLines <- function(fam.dat.list,fam.type,count="variants",gq=F,m
   
   #DNR by Proband GQ
   if(gq) {
-    GQ.dat <- deNovoRateByProGQ(trio.dat.list=fam.dat.list,GQ.bins=50,count=count)
+    GQ.dat <- deNovoRateByProGQ(trio.dat.list=fam.dat.list,GQ.bins=50,count=count,max.GQ=max.GQ)
     pdf(paste(OUTDIR,"/supporting_plots/sv_inheritance_plots/sv_de_novo_rate.",fam.type,"s.",count,".by_proband_GQ.pdf",sep=""),
         height=4,width=5)
     plotDNRvsGQ(DNRs=GQ.dat$DNRs,bins=GQ.dat$bins,k=4,nfams=length(fam.dat.list),
@@ -1162,7 +1162,7 @@ masterInhWrapper <- function(fam.dat.list,fam.type, gq=T,max.GQ=99){
                 count="variants",fam.type=fam.type,legend=F,cex.lab=cex.lab)
   #DNR vs min proband GQ
   if(gq) {
-    GQ.dat.v <- deNovoRateByProGQ(trio.dat.list=fam.dat.list,GQ.bins=50,count="variants")
+    GQ.dat.v <- deNovoRateByProGQ(trio.dat.list=fam.dat.list,GQ.bins=50,count="variants",max.GQ=max.GQ)
     plotDNRvsGQ(DNRs=GQ.dat.v$DNRs,bins=GQ.dat.v$bins,k=4,nfams=length(fam.dat.list),
                 title=paste("Site De Novo Rate by GQ",sep=""),
                 count="variants",fam.type=fam.type,legend=F,cex.lab=cex.lab,
@@ -1198,7 +1198,7 @@ masterInhWrapper <- function(fam.dat.list,fam.type, gq=T,max.GQ=99){
                 count="alleles",fam.type=fam.type,legend=F,cex.lab=cex.lab)
   #DNR vs min proband GQ
   if(gq){
-    GQ.dat.a <- deNovoRateByProGQ(trio.dat.list=fam.dat.list,GQ.bins=50,count="alleles")
+    GQ.dat.a <- deNovoRateByProGQ(trio.dat.list=fam.dat.list,GQ.bins=50,count="alleles",max.GQ=max.GQ)
     plotDNRvsGQ(DNRs=GQ.dat.a$DNRs,bins=GQ.dat.a$bins,k=4,nfams=length(fam.dat.list),
                 title=paste("Allele De Novo Rate by GQ",sep=""),
                 count="alleles",fam.type=fam.type,legend=F,cex.lab=cex.lab,

--- a/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R
+++ b/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R
@@ -1236,7 +1236,7 @@ option_list <- list(
               metavar="character"),
   make_option(c("-M", "--multiallelics"), type="logical", default=FALSE,
               help="include multiallelic sites in inheritance calculations [default %default]",
-              metavar="logical")
+              metavar="logical"),
   make_option(c("-G", "--maxgq"), type="integer", default=99,
               help="Max GQ value, ie. 99 for GQ on a scale of [0,99]",
               metavar="integer")

--- a/src/sv-pipeline/scripts/vcf_qc/plot_sv_perSample_distribs.R
+++ b/src/sv-pipeline/scripts/vcf_qc/plot_sv_perSample_distribs.R
@@ -870,7 +870,7 @@ option_list <- list(
               metavar="character"),
   make_option(c("-D", "--downsample"), type="integer", default=1000,
               help="restrict analyses to a random subset of N samples (for speed) [default %default]",
-              metavar="integer")
+              metavar="integer"),
   make_option(c("-G", "--maxgq"), type="integer", default=99,
               help="Max GQ value, ie. 99 for GQ on a scale of [0,99]",
               metavar="integer")

--- a/src/sv-pipeline/scripts/vcf_qc/plot_sv_perSample_distribs.R
+++ b/src/sv-pipeline/scripts/vcf_qc/plot_sv_perSample_distribs.R
@@ -73,7 +73,7 @@ readDatPerSample <- function(ID){
   }
 }
 #Filters VIDs for a single sample based on GQ
-GQfilterVIDs <- function(ID,min.GQ=0,max.GQ=999){
+GQfilterVIDs <- function(ID,min.GQ=0,max.GQ=99){
   #Check input variant list
   if(ID %in% names(VID.lists)){
     vlist <- VID.lists[[which(names(VID.lists)==ID)]]
@@ -114,7 +114,7 @@ countVarsSingle <- function(dat,vlist,count="variants"){
 }
 #Create matrix of variant/allele counts for a list of samples
 countVarsMulti <- function(dat,samples,count="variants",
-                           min.GQ=0,max.GQ=999,biallelic=F){
+                           min.GQ=0,max.GQ=99,biallelic=F){
   #Exclude non-biallelic sites, if optioned
   if(biallelic==T){
     dat <- dat[which(dat$carriers>0 & dat$other_gts==0),]
@@ -193,7 +193,7 @@ mediansByFreq <- function(dat,samples,svtypes,max.freqs,freq.labs,count="variant
   return(median.mat)
 }
 #Gather median count of variants per sample by minimum GQ
-mediansByGQ <- function(dat,samples,svtypes,min.GQs=seq(0,900,100),count="variants",biallelic=F){
+mediansByGQ <- function(dat,samples,svtypes,min.GQs=seq(0,90,10),count="variants",biallelic=F){
   #Iterate over min GQs and compose matrix of medians
   median.mat <- t(sapply(min.GQs,function(min.GQ){
     #Get matrix of variants per sample

--- a/wdl/CleanVcf.wdl
+++ b/wdl/CleanVcf.wdl
@@ -41,6 +41,7 @@ workflow CleanVcf {
     RuntimeAttr? runtime_override_hail_merge_clean_final
     RuntimeAttr? runtime_override_fix_header_clean_final
     RuntimeAttr? runtime_override_concat_cleaned_vcfs
+    RuntimeAttr? runtime_override_fix_bad_ends
 
     # overrides for CleanVcfContig
     RuntimeAttr? runtime_override_clean_vcf_1a
@@ -143,7 +144,8 @@ workflow CleanVcf {
         runtime_attr_override_scatter_1b=runtime_attr_override_scatter_1b,
         runtime_attr_override_filter_vcf_1b=runtime_attr_override_filter_vcf_1b,
         runtime_override_concat_vcfs_1b=runtime_override_concat_vcfs_1b,
-        runtime_override_cat_multi_cnvs_1b=runtime_override_cat_multi_cnvs_1b
+        runtime_override_cat_multi_cnvs_1b=runtime_override_cat_multi_cnvs_1b,
+        runtime_override_fix_bad_ends=runtime_override_fix_bad_ends
     }
   }
 

--- a/wdl/CleanVcfChromosome.wdl
+++ b/wdl/CleanVcfChromosome.wdl
@@ -299,7 +299,7 @@ workflow CleanVcfChromosome {
   call MiniTasks.FixEndsRescaleGQ {
     input:
       vcf = FinalCleanup.final_cleaned_shard,
-      prefix = prefix + ".ready_for_gatk",
+      prefix = prefix + ".cleaned",
       sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_override_fix_bad_ends
   }

--- a/wdl/CleanVcfChromosome.wdl
+++ b/wdl/CleanVcfChromosome.wdl
@@ -296,18 +296,17 @@ workflow CleanVcfChromosome {
 
   }
 
-  call MiniTasks.FixBadEnds {
+  call MiniTasks.FixEndsRescaleGQ {
     input:
       vcf = FinalCleanup.final_cleaned_shard,
-      vcf_idx = FinalCleanup.final_cleaned_shard_idx,
-      prefix = prefix,
+      prefix = prefix + ".ready_for_gatk",
       sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_override_fix_bad_ends
   }
   
   output {
-    File out=FixBadEnds.out
-    File out_idx=FixBadEnds.out_idx
+    File out=FixEndsRescaleGQ.out
+    File out_idx=FixEndsRescaleGQ.out_idx
   }
 }
 

--- a/wdl/CleanVcfChromosome.wdl
+++ b/wdl/CleanVcfChromosome.wdl
@@ -76,6 +76,7 @@ workflow CleanVcfChromosome {
     RuntimeAttr? runtime_override_drop_redundant_cnvs
     RuntimeAttr? runtime_override_combine_step_1_vcfs
     RuntimeAttr? runtime_override_sort_drop_redundant_cnvs
+    RuntimeAttr? runtime_override_fix_bad_ends
 
   }
 
@@ -294,10 +295,19 @@ workflow CleanVcfChromosome {
       runtime_attr_override=runtime_override_final_cleanup
 
   }
+
+  call MiniTasks.FixBadEnds {
+    input:
+      vcf = FinalCleanup.final_cleaned_shard,
+      vcf_idx = FinalCleanup.final_cleaned_shard_idx,
+      prefix = prefix,
+      sv_pipeline_docker = sv_pipeline_docker,
+      runtime_attr_override = runtime_override_fix_bad_ends
+  }
   
   output {
-    File out=FinalCleanup.final_cleaned_shard
-    File out_idx=FinalCleanup.final_cleaned_shard_idx
+    File out=FixBadEnds.out
+    File out_idx=FixBadEnds.out_idx
   }
 }
 

--- a/wdl/FilterBatchQc.wdl
+++ b/wdl/FilterBatchQc.wdl
@@ -88,7 +88,7 @@ workflow FilterBatchQc {
       runtime_attr_override = runtime_attr_subset_ped
   }
 
-  Int max_gq_ = if (defined(max_gq)) then select_first([max_gq]) else 999
+  Int max_gq_ = select_first([max_gq, 999])
 
   scatter (i in range(num_algorithms)) {
     if (defined(vcfs_array[i])) {

--- a/wdl/FilterBatchQc.wdl
+++ b/wdl/FilterBatchQc.wdl
@@ -22,6 +22,7 @@ workflow FilterBatchQc {
 
     File contig_list
     Int? random_seed
+    Int? max_gq
 
     String sv_base_mini_docker
     String sv_pipeline_docker
@@ -71,8 +72,6 @@ workflow FilterBatchQc {
   Array[File?] vcfs_array = [manta_vcf_noOutliers, delly_vcf_noOutliers, melt_vcf_noOutliers, wham_vcf_noOutliers, depth_vcf_noOutliers, merged_pesr_vcf]
   Int num_algorithms = length(algorithms)
 
-  Array[String] contigs = transpose(read_tsv(contig_list))[0]
-
   call util.GetSampleIdsFromVcf {
     input:
       vcf = select_first(vcfs_array),
@@ -89,6 +88,8 @@ workflow FilterBatchQc {
       runtime_attr_override = runtime_attr_subset_ped
   }
 
+  Int max_gq_ = if (defined(max_gq)) then select_first([max_gq]) else 999
+
   scatter (i in range(num_algorithms)) {
     if (defined(vcfs_array[i])) {
       call vcf_qc.MasterVcfQc as VcfQc {
@@ -104,8 +105,9 @@ workflow FilterBatchQc {
           sanders_2015_tarball=sanders_2015_tarball,
           collins_2017_tarball=collins_2017_tarball,
           werling_2018_tarball=werling_2018_tarball,
-          contigs=contigs,
+          primary_contigs_fai=contig_list,
           random_seed=random_seed,
+          max_gq=max_gq_,
           sv_base_mini_docker=sv_base_mini_docker,
           sv_pipeline_docker=sv_pipeline_docker,
           sv_pipeline_qc_docker=sv_pipeline_qc_docker,

--- a/wdl/MakeCohortVcf.wdl
+++ b/wdl/MakeCohortVcf.wdl
@@ -447,7 +447,6 @@ workflow MakeCohortVcf {
       runtime_override_fix_bad_ends=runtime_override_fix_bad_ends
   }
 
-  Array[String] contigs = transpose(read_tsv(contig_list))[0]
   call VcfQc.MasterVcfQc {
     input:
       vcf=CleanVcf.cleaned_vcf,
@@ -462,7 +461,7 @@ workflow MakeCohortVcf {
       sanders_2015_tarball=sanders_2015_tarball,
       collins_2017_tarball=collins_2017_tarball,
       werling_2018_tarball=werling_2018_tarball,
-      contigs=contigs,
+      primary_contigs_fai=contig_list,
       random_seed=random_seed,
       sv_pipeline_qc_docker=sv_pipeline_qc_docker,
       sv_base_mini_docker=sv_base_mini_docker,

--- a/wdl/MakeCohortVcf.wdl
+++ b/wdl/MakeCohortVcf.wdl
@@ -179,6 +179,7 @@ workflow MakeCohortVcf {
     RuntimeAttr? runtime_override_hail_merge_clean_final
     RuntimeAttr? runtime_override_fix_header_clean_final
     RuntimeAttr? runtime_override_concat_cleaned_vcfs
+    RuntimeAttr? runtime_override_fix_bad_ends
 
     RuntimeAttr? runtime_override_clean_vcf_1a
     RuntimeAttr? runtime_override_clean_vcf_2
@@ -441,7 +442,8 @@ workflow MakeCohortVcf {
       runtime_override_combine_multi_ids_4=runtime_override_combine_multi_ids_4,
       runtime_override_drop_redundant_cnvs=runtime_override_drop_redundant_cnvs,
       runtime_override_combine_step_1_vcfs=runtime_override_combine_step_1_vcfs,
-      runtime_override_sort_drop_redundant_cnvs=runtime_override_sort_drop_redundant_cnvs
+      runtime_override_sort_drop_redundant_cnvs=runtime_override_sort_drop_redundant_cnvs,
+      runtime_override_fix_bad_ends=runtime_override_fix_bad_ends
   }
 
   Array[String] contigs = transpose(read_tsv(contig_list))[0]

--- a/wdl/MakeCohortVcf.wdl
+++ b/wdl/MakeCohortVcf.wdl
@@ -61,6 +61,7 @@ workflow MakeCohortVcf {
     File empty_file
     File? outlier_samples_list
     Int? random_seed
+    Int? max_gq  # Max GQ for plotting. Default = 99, ie. GQ is on a scale of [0,99]. Prior to CleanVcf, use 999
 
     Array[File]? thousand_genomes_benchmark_calls
     Array[File]? hgsv_benchmark_calls

--- a/wdl/MasterVcfQc.wdl
+++ b/wdl/MasterVcfQc.wdl
@@ -23,7 +23,7 @@ workflow MasterVcfQc {
     File? sanders_2015_tarball
     File? collins_2017_tarball
     File? werling_2018_tarball
-    Array[String] contigs
+    File primary_contigs_fai
     Int? random_seed
     Int? max_gq  # Max GQ for plotting. Default = 99, ie. GQ is on a scale of [0,99]. Prior to CleanVcf, use 999
     File? vcf_idx
@@ -69,6 +69,8 @@ workflow MasterVcfQc {
     RuntimeAttr? runtime_override_split_shuffled_list
     RuntimeAttr? runtime_override_merge_and_tar_shard_benchmarks
   }
+  Array[String] contigs = transpose(read_tsv(primary_contigs_fai))[0]
+
   # Scatter raw variant data collection per chromosome
   scatter ( contig in contigs ) {
     # Collect VCF-wide summary stats
@@ -132,7 +134,7 @@ workflow MasterVcfQc {
       runtime_override_tar_shard_vid_lists=runtime_override_tar_shard_vid_lists,
   }
 
-  Int max_gq_ = if (defined(max_gq)) then max_gq else 99
+  Int max_gq_ = if (defined(max_gq)) then select_first([max_gq]) else 99
   # Plot per-sample stats
   call PlotQcPerSample {
     input:

--- a/wdl/MasterVcfQc.wdl
+++ b/wdl/MasterVcfQc.wdl
@@ -583,7 +583,7 @@ task PlotQcPerSample {
       ~{vcf_stats} \
       ~{samples_list} \
       ~{prefix}_perSample/ \
-      ~{prefix}_perSample_plots/
+      ~{prefix}_perSample_plots/ \
       --maxgq ~{max_gq}
 
     # Prepare output
@@ -666,7 +666,7 @@ task PlotQcPerFamily {
         ~{vcf_stats} \
         cleaned.fam \
         ~{prefix}_perSample/ \
-        ~{prefix}_perFamily_plots/
+        ~{prefix}_perFamily_plots/ \
         --maxgq ~{max_gq}
 
     else

--- a/wdl/MasterVcfQc.wdl
+++ b/wdl/MasterVcfQc.wdl
@@ -25,6 +25,7 @@ workflow MasterVcfQc {
     File? werling_2018_tarball
     Array[String] contigs
     Int? random_seed
+    Int? max_gq  # Max GQ for plotting. Default = 99, ie. GQ is on a scale of [0,99]. Prior to CleanVcf, use 999
     File? vcf_idx
 
     String sv_base_mini_docker
@@ -131,6 +132,7 @@ workflow MasterVcfQc {
       runtime_override_tar_shard_vid_lists=runtime_override_tar_shard_vid_lists,
   }
 
+  Int max_gq_ = if (defined(max_gq)) then max_gq else 99
   # Plot per-sample stats
   call PlotQcPerSample {
     input:
@@ -138,6 +140,7 @@ workflow MasterVcfQc {
       samples_list=CollectQcVcfwide.samples_list[0],
       per_sample_tarball=CollectPerSampleVidLists.vid_lists,
       prefix=prefix,
+      max_gq=max_gq_,
       sv_pipeline_qc_docker=sv_pipeline_qc_docker,
       runtime_attr_override=runtime_override_plot_qc_per_sample
   }
@@ -150,6 +153,7 @@ workflow MasterVcfQc {
       ped_file=ped_file,
       per_sample_tarball=CollectPerSampleVidLists.vid_lists,
       prefix=prefix,
+      max_gq=max_gq_,
       sv_pipeline_qc_docker=sv_pipeline_qc_docker,
       runtime_attr_override=runtime_override_plot_qc_per_family
   }
@@ -526,6 +530,7 @@ task PlotQcPerSample {
     File samples_list
     File per_sample_tarball
     String prefix
+    Int max_gq
     String sv_pipeline_qc_docker
     RuntimeAttr? runtime_attr_override
   }
@@ -577,6 +582,7 @@ task PlotQcPerSample {
       ~{samples_list} \
       ~{prefix}_perSample/ \
       ~{prefix}_perSample_plots/
+      --maxgq ~{max_gq}
 
     # Prepare output
     tar -czvf ~{prefix}.plotQC_perSample.tar.gz \
@@ -597,6 +603,7 @@ task PlotQcPerFamily {
     File ped_file
     File per_sample_tarball
     String prefix
+    Int max_gq
     String sv_pipeline_qc_docker
     RuntimeAttr? runtime_attr_override
   }
@@ -658,6 +665,7 @@ task PlotQcPerFamily {
         cleaned.fam \
         ~{prefix}_perSample/ \
         ~{prefix}_perFamily_plots/
+        --maxgq ~{max_gq}
 
     else
 

--- a/wdl/MasterVcfQc.wdl
+++ b/wdl/MasterVcfQc.wdl
@@ -134,7 +134,7 @@ workflow MasterVcfQc {
       runtime_override_tar_shard_vid_lists=runtime_override_tar_shard_vid_lists,
   }
 
-  Int max_gq_ = if (defined(max_gq)) then select_first([max_gq]) else 99
+  Int max_gq_ = select_first([max_gq, 99])
   # Plot per-sample stats
   call PlotQcPerSample {
     input:

--- a/wdl/TasksMakeCohortVcf.wdl
+++ b/wdl/TasksMakeCohortVcf.wdl
@@ -1075,11 +1075,11 @@ task FixEndsRescaleGQ {
             record.samples[sample][gq_field] = floor(record.samples[sample][gq_field] / 10)
 
 
-    with pysam.VariantFile(~{vcf}, 'r') as f_in, pysam.VariantFile(~{outfile}, 'w', header=f_in.header) as f_out:
+    with pysam.VariantFile("~{vcf}", 'r') as f_in, pysam.VariantFile("~{outfile}", 'w', header=f_in.header) as f_out:
       for record in f_in:
-        if ~{fix_ends_}:
+        if "~{fix_ends_}" == "true":
           fix_bad_end(record)
-        if ~{rescale_gq_}:
+        if "~{rescale_gq_}" == "true":
           rescale_gq(record)
         f_out.write(record)
 

--- a/wdl/TasksMakeCohortVcf.wdl
+++ b/wdl/TasksMakeCohortVcf.wdl
@@ -1032,7 +1032,7 @@ task FixEndsRescaleGQ {
   RuntimeAttr default_attr = object {
     cpu_cores: 1,
     mem_gb: 3.75,
-    disk_gb: 10,
+    disk_gb: ceil(10 + size(vcf, "GB") * 2),
     boot_disk_gb: 10,
     preemptible_tries: 3,
     max_retries: 1


### PR DESCRIPTION
### Updates
* Add task at end of CleanVcfChromosome to make VCFs compatible with GATK
  * For BND or CTX events, set END2 = END first just in case it wasn't already set
  * If END < POS, set END = POS 
  * Rescale GQ, PE_GQ, RD_GQ, and SR_GQ from [0,999] to [0,99]
* In SingleSampleFiltering.FinalVCFCleanup, remove step to fix bad END tags because it is now handled in CleanVcf and rename task to UpdateBreakendRepresentation to reflect the change
* Updated several QC and filtering scripts that had GQ scaling hard-coded to use [0,99] scale
* Small changes to MinGQ WDLs to get them to validate and run

### Testing
* Validated all WDLs and JSONs with womtool
* Ran MakeCohortVcf successfully and verified that output VCF had no END < POS and GQ QC plots were successfully generated with new scaling
* Ran single-sample WDL successfully and verified that output VCF had no END < POS
* Tested GQRecalibrator with rescaled GQ and got comparable results

### Still to do
* Test MinGQ - some scripts had GQ scaling changes. Attempted to test but encountered errors in master version of MinGQ. I fixed some issues with the WDLs along the way. The changes to MinGQ scripts only involve altering default max GQ values that can be overridden by the user anyway, so further testing was deemed low priority.
* Assess impact of GQ rescaling on filtering by GQ