### PR TITLE
Improvements on the commit made by the bot on the updated dockers.json

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -214,7 +214,9 @@ jobs:
       - name: Commit Changes to dockers.json
         if: steps.build_and_publish.outputs.CHANGED
         run: |
+          COMMIT_SHA=${{ needs.build_args_job.outputs.head_sha }}
           git config --global user.name 'gatk-sv-bot'
           git config --global user.email '101641599+gatk-sv-bot@users.noreply.github.com'
-          git commit -am "Update dockers.json with newly built and published images."
+          git commit ./inputs/values/dockers.json -m "Update docker images list, triggered by "${COMMIT_SHA::8}
+          git pull --rebase origin master
           git push


### PR DESCRIPTION
Three improvements: 
- To address the scenario where a new commit is made to the `master` branch between the time the `Deploy` job is triggered and the changes to `dockers.json` are commit back to the `master` branch, the bot will `rebase` the feature branch onto master before pushing it, so to incorporate all the possible commits.
- The commit is restricted to `dockers.json` hence to avoid any accidental changes.
- The commit message contains a reference to the commit SHA that triggered the job for easier/quicker references. 