### PR TITLE
Disable scramble in single-sample pipeline by default until ref panel scramble VCFs added

### DIFF
--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -37,7 +37,7 @@ workflow GATKSVPipelineSingleSample {
     Boolean use_delly = false
     Boolean use_manta = true
     Boolean use_melt = true
-    Boolean use_scramble = true
+    Boolean use_scramble = false
     Boolean use_wham = true
 
     # If GatherSampleEvidence outputs already prepared


### PR DESCRIPTION
### Updates
Scramble was causing errors in the single-sample pipeline because the single-sample test JSON has not been updated with the scramble docker, and the reference panel scramble VCFs have not been added to the values JSON. Scramble should be disabled in the single-sample pipeline until these changes have been made, to avoid errors.

A future PR to enable scramble for the single-sample pipeline should:
* Add necessary ref panel scramble files to values JSON
* Add scramble docker to single-sample JSON template
* Set use_scramble = true and use_melt = false in the single-sample WDL
* Consider also configuring the GatherSampleEvidence test JSONs to use scramble by default and all Terra JSON templates

### Testing
Validated all WDLs and JSONs with womtool