### PR TITLE
Update Whamg.wdl

### DIFF
--- a/wdl/Whamg.wdl
+++ b/wdl/Whamg.wdl
@@ -158,7 +158,6 @@ task RunWhamg {
     set -euo pipefail
     # print some info that may be useful for debugging
     df -h
-    cat /sys/fs/cgroup/memory/memory.stat
     echo "whamg $(./whamg 2>&1 >/dev/null | grep Version)"
     
     # ensure that index files are present in appropriate locations
@@ -295,7 +294,6 @@ task RunWhamgIncludelist {
     set -euo pipefail
     # print some info that may be useful for debugging
     df -h
-    cat /sys/fs/cgroup/memory/memory.stat
     echo "whamg $(./whamg 2>&1 >/dev/null | grep Version)"
     
     # ensure that index files are present in appropriate locations


### PR DESCRIPTION
Updated Whamg.wdl to delete cat /sys/fs/cgroup/memory/memory.stat, to allow for continued use of v.0.9.1-beta-hotfix