### PR TITLE
Authenticate the bot to push to a protected branch using its PAT

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -160,6 +160,8 @@ jobs:
         with:
           # See the comment on build_args_job.
           fetch-depth: 0
+          # Authenticates git using the bot's access token.
+          token: ${{ secrets.BOT_PAT }}
 
       - name: Setup Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
In the `publish` job, after the affected docker images are rebuilt and pushed to GCR, `dockers.json` is updated with the newly built images. The `gatk-sv-bot` will commit the changes and push them to the `master` branch. By default, the bot inherits the authorization to push to master from Github actions; however, if the `master` branch is protected (e.g., it requires all commits made through PRs and require PR review), the bot's account should be exempted from the protection checks and it needs to authenticate using its own access token in order to push to a protected branch. 

This PR authenticates git in the `Publish` job (note that it does not impact the `Test Images Build` job) with the personal access token (PAT) of the bot. 