### PR TITLE
Check for scramble in breakpoint overlap filter

### DIFF
--- a/src/sv-pipeline/04_variant_resolution/scripts/overlap_breakpoint_filter.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/overlap_breakpoint_filter.py
@@ -63,7 +63,7 @@ class RecordData:
         self.freq = len(self.called_samples)
         self.length = record.info['SVLEN']
         self.gt_50bp = self.length >= 50
-        self.is_mei = 'melt' in record.info['ALGORITHMS']
+        self.is_mei = 'melt' in record.info['ALGORITHMS'] or 'scramble' in record.info['ALGORITHMS']
 
     def __str__(self):
         return ",".join(str(x) for x in


### PR DESCRIPTION
Includes scramble as an MEI caller for this filter, which prioritizes MEIs over generic INS.