### PR TITLE
Improvements on scaling the EH WDL to more batches

### DIFF
--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -21,6 +21,8 @@ workflow ExpansionHunter {
         File? reference_fasta_index
         Array[File] split_variant_catalogs
         String sample_id
+        Boolean? generate_realigned_bam
+        Boolean? generate_vcf
         File? ped_file
         String expansion_hunter_docker
         String python_docker
@@ -44,6 +46,9 @@ workflow ExpansionHunter {
         reference_fasta_index,
         reference_fasta + ".fai"])
 
+    Boolean generate_realigned_bam_ = select_first([generate_realigned_bam, false])
+    Boolean generate_vcf_ = select_first([generate_vcf, false])
+
     scatter (i in range(length(split_variant_catalogs))) {
         call RunExpansionHunter as expanionHunter {
             input:
@@ -53,6 +58,8 @@ workflow ExpansionHunter {
                 reference_fasta_index = reference_fasta_index_,
                 variant_catalog = split_variant_catalogs[i],
                 sample_id = sample_id,
+                generate_realigned_bam = generate_realigned_bam_,
+                generate_vcf = generate_vcf_,
                 ped_file = ped_file,
                 expansion_hunter_docker = expansion_hunter_docker,
                 runtime_attr_override = runtime_attr
@@ -65,6 +72,8 @@ workflow ExpansionHunter {
             jsons = expanionHunter.json,
             overlapping_reads = expanionHunter.overlapping_reads,
             timings = expanionHunter.timing,
+            generate_realigned_bam = generate_realigned_bam_,
+            generate_vcf = generate_vcf_,
             output_prefix = sample_id,
             expansion_hunter_docker = expansion_hunter_docker
     }
@@ -85,6 +94,8 @@ task RunExpansionHunter {
         File reference_fasta_index
         File variant_catalog
         String sample_id
+        Boolean generate_realigned_bam
+        Boolean generate_vcf
         File? ped_file
         String expansion_hunter_docker
         RuntimeAttr? runtime_attr_override
@@ -129,7 +140,17 @@ task RunExpansionHunter {
             --record-timing \
             $sex
 
-        bgzip ~{sample_id}.vcf
+        if [ ~{generate_realigned_bam} = false ]; then
+            rm ~{sample_id}_realigned.bam
+            touch ~{sample_id}_realigned.bam
+        fi
+
+        if [ ~{generate_vcf} = false ]; then
+            rm ~{sample_id}.vcf
+            touch ~{sample_id}.vcf.gz
+        else
+            bgzip ~{sample_id}.vcf
+        fi
     >>>
 
     RuntimeAttr default_runtime_ = object {
@@ -165,6 +186,8 @@ task ConcatEHOutputs {
         Array[File] jsons
         Array[File] overlapping_reads
         Array[File] timings
+        Boolean generate_realigned_bam
+        Boolean generate_vcf
         String? output_prefix
         String expansion_hunter_docker
         RuntimeAttr? runtime_attr_override
@@ -189,11 +212,19 @@ task ConcatEHOutputs {
             mv $TEMP_MERGED_JSON $MERGED_JSON
         done < $JSONS_FILENAME
 
-        VCFS="~{write_lines(vcfs_gz)}"
-        bcftools concat --no-version --naive-force --output-type z --file-list ${VCFS} --output "~{output_prefix}.vcf.gz"
+        if [ ~{generate_vcf} = true ]; then
+            VCFS="~{write_lines(vcfs_gz)}"
+            bcftools concat --no-version --naive-force --output-type z --file-list ${VCFS} --output "~{output_prefix}.vcf.gz"
+        else
+            touch ~{output_prefix}.vcf.gz
+        fi
 
-        BAMS="~{write_lines(overlapping_reads)}"
-        samtools merge ~{output_prefix}.bam -b ${BAMS}
+        if [ ~{generate_realigned_bam} = true ]; then
+            BAMS="~{write_lines(overlapping_reads)}"
+            samtools merge ~{output_prefix}.bam -b ${BAMS}
+        else
+            touch ~{output_prefix}.bam
+        fi
 
         TIMINGS_FILENAME="~{write_lines(timings)}"
         MERGED_TIMINGS_FILENAME=~{output_prefix}.tsv

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -219,7 +219,7 @@ task ConcatEHOutputs {
             touch ~{output_prefix}.vcf.gz
         fi
 
-        if [ ~{generate_realigned_bam} = true ]; then
+        if ~{generate_realigned_bam}; then
             BAMS="~{write_lines(overlapping_reads)}"
             samtools merge ~{output_prefix}.bam -b ${BAMS}
         else

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -140,7 +140,7 @@ task RunExpansionHunter {
             --record-timing \
             $sex
 
-        if [ ~{generate_realigned_bam} = false ]; then
+        if ~{generate_realigned_bam}; then
             rm ~{sample_id}_realigned.bam
             touch ~{sample_id}_realigned.bam
         fi

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -212,7 +212,7 @@ task ConcatEHOutputs {
             mv $TEMP_MERGED_JSON $MERGED_JSON
         done < $JSONS_FILENAME
 
-        if [ ~{generate_vcf} = true ]; then
+        if ~{generate_vcf}; then
             VCFS="~{write_lines(vcfs_gz)}"
             bcftools concat --no-version --naive-force --output-type z --file-list ${VCFS} --output "~{output_prefix}.vcf.gz"
         else

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -145,7 +145,7 @@ task RunExpansionHunter {
             touch ~{sample_id}_realigned.bam
         fi
 
-        if [ ~{generate_vcf} = false ]; then
+        if ~{generate_vcf}; then
             rm ~{sample_id}.vcf
             touch ~{sample_id}.vcf.gz
         else

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -56,7 +56,7 @@ workflow ExpansionHunterScatter {
                 bam_or_cram_index=bam_or_cram_index_,
                 reference_fasta=reference_fasta,
                 reference_fasta_index=reference_fasta_index_,
-                split_variant_catalogs=split_variant_catalog.catalogs_json,
+                split_variant_catalogs=SplitVariantCatalog.catalogs_json,
                 sample_id=sample_id,
                 ped_file=ped_file,
                 generate_realigned_bam=generate_realigned_bam,

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -14,6 +14,8 @@ workflow ExpansionHunterScatter {
         File? reference_fasta_index
         File variant_catalog_json
         Int? variant_catalog_batch_size
+        Boolean? generate_realigned_bam
+        Boolean? generate_vcf
         String expansion_hunter_docker
         String python_docker
         RuntimeAttr? runtime_attr
@@ -57,6 +59,8 @@ workflow ExpansionHunterScatter {
                 split_variant_catalogs=svc.catalogs_json,
                 sample_id=sample_id,
                 ped_file=ped_file,
+                generate_realigned_bam=generate_realigned_bam,
+                generate_vcf=generate_vcf,
                 expansion_hunter_docker=expansion_hunter_docker,
                 python_docker=python_docker
         }

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -28,7 +28,7 @@ workflow ExpansionHunterScatter {
 
     String variant_catalog_batch_size_ = select_first([variant_catalog_batch_size, 1000])
 
-    call SplitVariantCatalog as svc {
+    call SplitVariantCatalog as split_variant_catalog {
         input:
             variant_catalog = variant_catalog_json,
             batch_size = variant_catalog_batch_size_,
@@ -56,7 +56,7 @@ workflow ExpansionHunterScatter {
                 bam_or_cram_index=bam_or_cram_index_,
                 reference_fasta=reference_fasta,
                 reference_fasta_index=reference_fasta_index_,
-                split_variant_catalogs=svc.catalogs_json,
+                split_variant_catalogs=split_variant_catalog.catalogs_json,
                 sample_id=sample_id,
                 ped_file=ped_file,
                 generate_realigned_bam=generate_realigned_bam,

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -28,7 +28,7 @@ workflow ExpansionHunterScatter {
 
     String variant_catalog_batch_size_ = select_first([variant_catalog_batch_size, 1000])
 
-    call SplitVariantCatalog as split_variant_catalog {
+    call SplitVariantCatalog {
         input:
             variant_catalog = variant_catalog_json,
             batch_size = variant_catalog_batch_size_,


### PR DESCRIPTION
The PR implements the following improvements on scaling the EH WDL to a more extensive variant catalog:

- The script used for merging the outputs of different batches operates on a space-delimited list of objects in a Google storage bucket. As the number of sets grows, the list creates a very long bash command, which can hit the maximum bash line length. This PR improves the merging of JSON and TSV files by writing their list of a file, reading the file line-by-line, and merging one file at a time with the previously merged files. 
- Add two flags to enable/disable creating VCF and re-aligned BAM files. We use these files predominantly for visualization purposes; hence, by default, they're disabled. 