### PR TITLE
Decrease disk usage building dockers on GitHub

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -139,7 +139,8 @@ jobs:
           python build_docker.py \
             --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \
             --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} \
-            --image-tag ${{ needs.build_args_job.outputs.image_tag }}
+            --image-tag ${{ needs.build_args_job.outputs.image_tag }} \
+            --prune-after-each-image
 
   publish_job:
     # This job first configures gcloud with the authentication of a
@@ -209,7 +210,8 @@ jobs:
             --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \
             --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} \
             --gcr-project ${{ secrets.GCP_PROJECT_ID }}/gatk-sv \
-            --image-tag ${{ needs.build_args_job.outputs.image_tag }}
+            --image-tag ${{ needs.build_args_job.outputs.image_tag }} \
+            --prune-after-each-image
           CHANGED=$(git diff --quiet ./inputs/values/dockers.json || echo True)
           echo "::set-output name=CHANGED::$CHANGED"
 


### PR DESCRIPTION
VMs for GitHub actions have tiny disks. To save space:
* Add flag to "docker system prune" after each image is successfully built
* Set this flag when building dockers on Github actions to free disk space