### PR TITLE
Update ExpansionHunter Dockerfile

### DIFF
--- a/dockerfiles/str/Dockerfile
+++ b/dockerfiles/str/Dockerfile
@@ -2,7 +2,7 @@
 # list of tools and their dependencies:
 # - ExpansionHunter (custom-built);
 # - htslib, bcftools, and samtools;
-# - python3.8, pip
+# - python3.6, pip, wheel, venv
 
 FROM ubuntu:18.04
 


### PR DESCRIPTION
- Update the Dockerfile to use a custom-built of ExpansionHunter;
- Update htslib, bcftools, and samtools to their current latest versions;
- Remove TRTools and GangSTR as they are not currently used in ExpansionHunter WDL (though GangSTR has its own WDL that is currently under development);
- Copy `src/str` to the VM as it contains scripts needed in ExpansionHunter WDL. 