### PR TITLE
Improvement on overriding the runtime attributes of EH-related tasks

### DIFF
--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -26,8 +26,8 @@ workflow ExpansionHunter {
         File? ped_file
         String expansion_hunter_docker
         String python_docker
-        RuntimeAttr? runtime_attr
-        RuntimeAttr? runtime_override_concat
+        RuntimeAttr? runtime_eh
+        RuntimeAttr? runtime_concat
     }
 
     parameter_meta {
@@ -62,7 +62,7 @@ workflow ExpansionHunter {
                 generate_vcf = generate_vcf_,
                 ped_file = ped_file,
                 expansion_hunter_docker = expansion_hunter_docker,
-                runtime_attr_override = runtime_attr
+                runtime_attr_override = runtime_eh
         }
     }
 
@@ -76,7 +76,8 @@ workflow ExpansionHunter {
             generate_realigned_bam = generate_realigned_bam_,
             generate_vcf = generate_vcf_,
             output_prefix = sample_id,
-            expansion_hunter_docker = expansion_hunter_docker
+            expansion_hunter_docker = expansion_hunter_docker,
+            runtime_attr_override = runtime_concat
     }
 
     output {

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -62,7 +62,7 @@ workflow ExpansionHunter {
                 generate_vcf = generate_vcf_,
                 ped_file = ped_file,
                 expansion_hunter_docker = expansion_hunter_docker,
-                runtime_attr_override = runtime_eh
+                runtime_override = runtime_eh
         }
     }
 
@@ -77,7 +77,7 @@ workflow ExpansionHunter {
             generate_vcf = generate_vcf_,
             output_prefix = sample_id,
             expansion_hunter_docker = expansion_hunter_docker,
-            runtime_attr_override = runtime_concat
+            runtime_override = runtime_concat
     }
 
     output {
@@ -101,7 +101,7 @@ task RunExpansionHunter {
         Boolean generate_vcf
         File? ped_file
         String expansion_hunter_docker
-        RuntimeAttr? runtime_attr_override
+        RuntimeAttr? runtime_override
     }
 
     output {
@@ -161,7 +161,7 @@ task RunExpansionHunter {
         mv ~{sample_id}.*_json_files_variants.tsv ~{sample_id}_variants.tsv
     >>>
 
-    RuntimeAttr default_runtime_ = object {
+    RuntimeAttr runtime_default = object {
         cpu_cores: 1,
         mem_gb: 3.75,
         boot_disk_gb: 10,
@@ -173,18 +173,16 @@ task RunExpansionHunter {
             reference_fasta,
             reference_fasta_index], "GiB"))
     }
-    RuntimeAttr runtime_attr = select_first([
-        runtime_attr_override,
-        default_runtime_])
+    RuntimeAttr runtime_attr = select_first([runtime_override, runtime_default])
 
     runtime {
         docker: expansion_hunter_docker
-        cpu: runtime_attr.cpu_cores
-        memory: runtime_attr.mem_gb + " GiB"
-        disks: "local-disk " + runtime_attr.disk_gb + " HDD"
-        bootDiskSizeGb: runtime_attr.boot_disk_gb
-        preemptible: runtime_attr.preemptible_tries
-        maxRetries: runtime_attr.max_retries
+        cpu: select_first([runtime_attr.cpu_cores, runtime_default.cpu_cores])
+        memory: select_first([runtime_attr.mem_gb, runtime_default.mem_gb]) + " GiB"
+        disks: "local-disk " + select_first([runtime_attr.disk_gb, runtime_default.disk_gb])  + " HDD"
+        bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, runtime_default.boot_disk_gb])
+        preemptible: select_first([runtime_attr.preemptible_tries, runtime_default.preemptible_tries])
+        maxRetries: select_first([runtime_attr.max_retries, runtime_default.max_retries])
     }
 }
 
@@ -199,7 +197,7 @@ task ConcatEHOutputs {
         Boolean generate_vcf
         String? output_prefix
         String expansion_hunter_docker
-        RuntimeAttr? runtime_attr_override
+        RuntimeAttr? runtime_override
     }
 
     output {
@@ -243,7 +241,7 @@ task ConcatEHOutputs {
         merge_tsv "~{write_lines(variants_tsvs)}" "~{output_prefix}_variants.tsv"
     >>>
 
-    RuntimeAttr runtime_attr_str_profile_default = object {
+    RuntimeAttr runtime_default = object {
         cpu_cores: 1,
         mem_gb: 4,
         boot_disk_gb: 10,
@@ -257,17 +255,15 @@ task ConcatEHOutputs {
                 size(overlapping_reads, "GiB") +
                 size(timings, "GiB")))
     }
-    RuntimeAttr runtime_attr = select_first([
-        runtime_attr_override,
-        runtime_attr_str_profile_default])
+    RuntimeAttr runtime_attr = select_first([runtime_override, runtime_default])
 
     runtime {
         docker: expansion_hunter_docker
-        cpu: runtime_attr.cpu_cores
-        memory: runtime_attr.mem_gb + " GiB"
-        disks: "local-disk " + runtime_attr.disk_gb + " HDD"
-        bootDiskSizeGb: runtime_attr.boot_disk_gb
-        preemptible: runtime_attr.preemptible_tries
-        maxRetries: runtime_attr.max_retries
+        cpu: select_first([runtime_attr.cpu_cores, runtime_default.cpu_cores])
+        memory: select_first([runtime_attr.mem_gb, runtime_default.mem_gb]) + " GiB"
+        disks: "local-disk " + select_first([runtime_attr.disk_gb, runtime_default.disk_gb]) + " HDD"
+        bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, runtime_default.boot_disk_gb])
+        preemptible: select_first([runtime_attr.preemptible_tries, runtime_default.preemptible_tries])
+        maxRetries: select_first([runtime_attr.max_retries, runtime_default.max_retries])
     }
 }

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -18,7 +18,9 @@ workflow ExpansionHunterScatter {
         Boolean? generate_vcf
         String expansion_hunter_docker
         String python_docker
-        RuntimeAttr? runtime_attr
+        RuntimeAttr? runtime_split_var_catalog
+        RuntimeAttr? runtime_eh
+        RuntimeAttr? runtime_concat
     }
 
     parameter_meta {
@@ -33,7 +35,8 @@ workflow ExpansionHunterScatter {
             variant_catalog = variant_catalog_json,
             batch_size = variant_catalog_batch_size_,
             output_prefix = basename(variant_catalog_json, ".json"),
-            python_docker = python_docker
+            python_docker = python_docker,
+            runtime_attr_override = runtime_split_var_catalog
     }
 
     scatter (i in range(length(bams_or_crams))) {
@@ -62,7 +65,9 @@ workflow ExpansionHunterScatter {
                 generate_realigned_bam=generate_realigned_bam,
                 generate_vcf=generate_vcf,
                 expansion_hunter_docker=expansion_hunter_docker,
-                python_docker=python_docker
+                python_docker=python_docker,
+                runtime_eh=runtime_eh,
+                runtime_concat=runtime_concat
         }
     }
 
@@ -130,7 +135,7 @@ task SplitVariantCatalog {
         boot_disk_gb: 10,
         preemptible_tries: 3,
         max_retries: 1,
-        disk_gb: 10
+        disk_gb: 10 + (2 * ceil(size(variant_catalog, "GiB")))
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -36,7 +36,7 @@ workflow ExpansionHunterScatter {
             batch_size = variant_catalog_batch_size_,
             output_prefix = basename(variant_catalog_json, ".json"),
             python_docker = python_docker,
-            runtime_attr_override = runtime_split_var_catalog
+            runtime_override = runtime_split_var_catalog
     }
 
     scatter (i in range(length(bams_or_crams))) {
@@ -86,7 +86,7 @@ task SplitVariantCatalog {
         Int batch_size
         String output_prefix
         String python_docker
-        RuntimeAttr? runtime_attr_override
+        RuntimeAttr? runtime_override
     }
 
     output {
@@ -129,7 +129,7 @@ task SplitVariantCatalog {
         CODE
     >>>
 
-    RuntimeAttr default_attr = object {
+    RuntimeAttr runtime_default = object {
         cpu_cores: 1,
         mem_gb: 3.75,
         boot_disk_gb: 10,
@@ -137,15 +137,15 @@ task SplitVariantCatalog {
         max_retries: 1,
         disk_gb: 10 + (2 * ceil(size(variant_catalog, "GiB")))
     }
-    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+    RuntimeAttr runtime_attr = select_first([runtime_override, runtime_default])
 
     runtime {
         docker: python_docker
-        cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
-        memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
-        disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
-        bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
-        preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
-        maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
+        cpu: select_first([runtime_attr.cpu_cores, runtime_default.cpu_cores])
+        memory: select_first([runtime_attr.mem_gb, runtime_default.mem_gb]) + " GiB"
+        disks: "local-disk " + select_first([runtime_attr.disk_gb, runtime_default.disk_gb]) + " HDD"
+        bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, runtime_default.boot_disk_gb])
+        preemptible: select_first([runtime_attr.preemptible_tries, runtime_default.preemptible_tries])
+        maxRetries: select_first([runtime_attr.max_retries, runtime_default.max_retries])
     }
 }


### PR DESCRIPTION
- Implement per-attribute overriding runtime attributes;
- Add an option to the `ExpansionHunterScatter.wdl` to take runtime overrides for the two tasks of `ExpansionHunter.wdl`: running the EH and concatenating the results of scatters;
- Refactor the related variables for simplicity/readability. 