### PR TITLE
Enable docker build on m1 macs

### DIFF
--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -43,3 +43,5 @@ Conda packages `termcolor` and `pprint` are assumed to be available.
 * `test_build_docker.ipynb` is for debugging and testing purposes
 
 * Use `update_json_docker.sh` to update dockers tags across all json parameter files
+
+* When building on Apple Silicon macs (newer macs with e.g. the M1 or M2 chipset), ensure that Rosetta is installed: `softwareupdate --install-rosetta`. Note that docker software is still somewhat unstable on these devices, so we cannot fully support them. We have had the most success by restricting docker desktop to 1 CPU (otherwise builds often churn forever without progress).

--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -498,7 +498,7 @@ class ImageBuilder:  # class for building and pushing a single image
             print(f"skipping build of {self.local_image} because it is already built and --no-force-rebuild is set")
             return
         # standard build command
-        docker_build_command = "docker build --progress plain --network=host \\\n    "
+        docker_build_command = "docker build --platform linux/amd64 --progress plain --network=host \\\n    "
         docker_build_command += "-f " + f"{self.working_dir}/dockerfiles/{self.name}/Dockerfile" + " \\\n    "
         docker_build_command += "--tag " + self.local_image + " \\\n    "
         # parse extra args list


### PR DESCRIPTION
Two minor changes, both important. Specifying platform in the docker build allows the mac to emulate an intel chip, and installing rosetta makes that emulation better (without that, java compilation via gradle seems to hang).

I successfully ran `./scripts/docker/build_docker.py --targets all --output-json /dev/null`

I tested my own docker (sv_utils_docker) because it contains a test suite. I ran in on my linux box and the test suite completed just fine.

For anyone attempting to build many images on the macbook pro, I recommend adding the option `--prune-after-each-image` to free up resources. I also set up my Docker Desktop to use: 5 CPUs, 20 GB of RAM, 2 GB of swap. Insufficient resources can result in crashes, or just hanging and failing to progress after a certain point.