### PR TITLE
Run the 5 subworkflows of MakeCohortVcf as separate steps in Terra

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
@@ -37,7 +37,7 @@ The following are the main pipeline outputs. For more information on the outputs
 |---------|--------|--------------|
 |`File`|`output_vcf`|Annotated SV VCF for the cohort***|
 |`File`|`output_vcf_idx`|Index for `output_vcf`|
-|`File`|`vcf_qc`|QC plots (bundled in a .tar.gz file)|
+|`File`|`sv_vcf_qc_output`|QC plots (bundled in a .tar.gz file)|
 
 ***Note that this VCF is not filtered
 
@@ -53,19 +53,23 @@ The following workflows are included in this workspace, to be executed in this o
 4. `04-GatherBatchEvidence`: Per-batch copy number variant calling using cn.MOPS and GATK gCNV; B-allele frequency (BAF) generation; call and evidence aggregation
 5. `05-ClusterBatch`: Per-batch variant clustering
 6. `06-GenerateBatchMetrics`: Per-batch variant filtering, metric generation
-7. `07a-FilterBatchSites`: Per-batch variant filtering
-8. `07b-PlotSVCountsPerSample`: Plot SV counts per sample per SV type to enable choice of IQR cutoff for outlier filtration in `07c-FilterBatchSamples`
-9. `07c-FilterBatchSamples`: Per-batch outlier sample filtration
-10. (Skip for a single batch) `08-MergeBatchSites`: Site merging of SVs discovered across batches, run on a cohort-level `sample_set_set`
-11. `09-GenotypeBatch`: Per-batch genotyping of all sites in the cohort. Use `09-GenotypeBatch_SingleBatch` if you only have one batch.
-12. `10-RegenotypeCNVs`: Cohort-level genotype refinement of some depth calls. Use `10-RegenotypeCNVs_SingleBatch` if you only have one batch.
-13. `11-MakeCohortVcf`: Cohort-level cross-batch integration; complex variant resolution and re-genotyping; VCF cleanup. Use `11-MakeCohortVcf_SingleBatch` if you only have one batch.
-14. `12-AnnotateVcf`: Cohort VCF annotations, including functional annotation, allele frequency (AF) annotation, and AF annotation with external population callsets. Use `12-AnnotateVcf_SingleBatch` if you only have one batch.
+7. `07-FilterBatchSites`: Per-batch variant filtering
+8. `08-PlotSVCountsPerSample`: Plot SV counts per sample per SV type to enable choice of IQR cutoff for outlier filtration in `09-FilterBatchSamples`
+9. `09-FilterBatchSamples`: Per-batch outlier sample filtration
+10. (Skip for a single batch) `10-MergeBatchSites`: Site merging of SVs discovered across batches, run on a cohort-level `sample_set_set`
+11. `11-GenotypeBatch`: Per-batch genotyping of all sites in the cohort. Use `11-GenotypeBatch_SingleBatch` if you only have one batch.
+12. `12-RegenotypeCNVs`: Cohort-level genotype refinement of some depth calls. Use `12-RegenotypeCNVs_SingleBatch` if you only have one batch.
+13. `13-CombineBatches`: Cohort-level cross-batch integration and clustering. Use `13-CombineBatches_SingleBatch` if you only have one batch.
+14. `14-ResolveComplexVariants`: Complex variant resolution. Use `14-ResolveComplexVariants_SingleBatch` if you only have one batch.
+15. `15-GenotypeComplexVariants`: Complex variant re-genotyping. Use `15-GenotypeComplexVariants_SingleBatch` if you only have one batch.
+16. `16-CleanVcf`: VCF cleanup. Use `16-CleanVcf_SingleBatch` if you only have one batch.
+17. `17-MasterVcfQc`: Generates VCF QC reports. Use `17-MasterVcfQc_SingleBatch` if you only have one batch.
+18. `18-AnnotateVcf`: Cohort VCF annotations, including functional annotation, allele frequency (AF) annotation, and AF annotation with external population callsets. Use `18-AnnotateVcf_SingleBatch` if you only have one batch.
 
 Additional downstream modules, such as those for filtering and visualization, are under development. They are not included in this workspace at this time, but the source code can be found in the [GATK-SV GitHub repository](https://github.com/broadinstitute/gatk-sv). See **Downstream steps** towards the bottom of this page for more information.
 
 Extra workflows (Not part of canonical pipeline, but included for your convenience. May require manual configuration):
-* `FilterOutlierSamples`: Filter outlier samples (in terms of SV counts) from a single VCF. Recommended to run `07b-PlotSVCountsPerSample` beforehand (reconfigured with the single VCF you want to filter) to enable IQR cutoff choice.
+* `FilterOutlierSamples`: Filter outlier samples (in terms of SV counts) from a single VCF. Recommended to run `08-PlotSVCountsPerSample` beforehand (reconfigured with the single VCF you want to filter) to enable IQR cutoff choice.
 
 For detailed instructions on running the pipeline in Terra, see **Step-by-step instructions** below.
 
@@ -143,7 +147,7 @@ To create batches (in the `sample_set` table), the easiest way is to upload a ta
 	* Another option is to use the `fiss mop` API call to delete all files that do not appear in one of the Terra data tables (intermediate files). Always ensure that you are completely done with a step and you will not need to return before using this option, as it will break call-caching. See [this blog post](https://terra.bio/deleting-intermediate-workflow-outputs/) for more details. This can also be done [via the command line](https://github.com/broadinstitute/fiss/wiki/MOP:-reducing-your-cloud-storage-footprint).
 * If your workflow fails, check the job manager for the error message. Most issues can be resolved by increasing the memory or disk. Do not delete workflow log files until you are done troubleshooting. If call-caching is enabled, do not delete any files from the failed workflow until you have run it successfully.
 * To display run costs, see [this article](https://support.terra.bio/hc/en-us/articles/360037862771#h_01EX5ED53HAZ59M29DRCG24CXY) for one-time setup instructions for non-Broad users.
-* If you only have one batch, you will need to skip `08-MergeBatchSites` and use the single-batch versions of all workflows after `09-GenotypeBatch`.
+* If you only have one batch, you will need to skip `10-MergeBatchSites` and use the single-batch versions of all workflows after `11-GenotypeBatch`.
 
 #### 01-GatherSampleEvidence
 
@@ -180,34 +184,34 @@ Read the full documentation for these modules [here](https://github.com/broadins
 * Use the same `sample_set` definitions you used for `03-TrainGCNV` and `04-GatherBatchEvidence`.
 
 
-#### 07a-FilterBatchSites, 07b-PlotSVCountsPerSample, 07c-FilterBatchSamples
+#### 07-FilterBatchSites, 08-PlotSVCountsPerSample, 09-FilterBatchSamples
 
 These three workflows make up FilterBatch; they are subdivided in this workspace to enable tuning of outlier filtration cutoffs. Read the full FilterBatch documentation [here](https://github.com/broadinstitute/gatk-sv#filter-batch).
 * Use the same `sample_set` definitions you used for `03-TrainGCNV` through `06-GenerateBatchMetrics`.
-* `07a-FilterBatchSites` does not require user intervention
-* `07b-PlotSVCountsPerSample` produces SV count plots and files, as well as a preview of the outlier samples to be filtered, but it does not perform any filtering of the VCFs. The input `N_IQR_cutoff` is used to visualize filtration thresholds on the SV count plots and preview the samples to be filtered; the default value is set to 6. You can adjust this value depending on your needs, and you can re-run the workflow with new `N_IQR_cutoff` values until the plots and outlier sample lists suit the purposes of your study. Once you have chosen an IQR cutoff, provide it to the `N_IQR_cutoff` input in `07c-FilterBatchSamples` to filter the VCFs using the chosen cutoff. 
-* `07c-FilterBatchSamples` performs outlier sample filtration, removing samples with an abnormal number of SV calls of at least one SV type. To tune the filtering threshold to your needs, edit the `N_IQR_cutoff` input value based on the plots and outlier sample preview lists from `07b-PlotSVCountsPerSample`. The default value for `N_IQR_cutoff` in this step is 10000, which essentially means that no samples are filtered.
+* `07-FilterBatchSites` does not require user intervention
+* `08-PlotSVCountsPerSample` produces SV count plots and files, as well as a preview of the outlier samples to be filtered, but it does not perform any filtering of the VCFs. The input `N_IQR_cutoff` is used to visualize filtration thresholds on the SV count plots and preview the samples to be filtered; the default value is set to 6. You can adjust this value depending on your needs, and you can re-run the workflow with new `N_IQR_cutoff` values until the plots and outlier sample lists suit the purposes of your study. Once you have chosen an IQR cutoff, provide it to the `N_IQR_cutoff` input in `09-FilterBatchSamples` to filter the VCFs using the chosen cutoff. 
+* `09-FilterBatchSamples` performs outlier sample filtration, removing samples with an abnormal number of SV calls of at least one SV type. To tune the filtering threshold to your needs, edit the `N_IQR_cutoff` input value based on the plots and outlier sample preview lists from `08-PlotSVCountsPerSample`. The default value for `N_IQR_cutoff` in this step is 10000, which essentially means that no samples are filtered.
 
-#### 08-MergeBatchSites
+#### 10-MergeBatchSites
 
 Read the full MergeBatchSites documentation [here](https://github.com/broadinstitute/gatk-sv#merge-batch-sites).
 * If you only have one batch, skip this workflow.
-* For a multi-batch cohort, `08-MergeBatchSites` is a cohort-level workflow, so it is run on a `sample_set_set` containing all of the batches in the cohort. You can create this `sample_set_set` while you are launching the `08-MergeBatchSites` workflow: click "Select Data", choose "Create new sample_set_set [...]", check all the batches to include (all of the ones used in `03-TrainGCNV` through `07c-FilterBatchSamples`), and give it a name that follows the **Sample ID requirements**. 
+* For a multi-batch cohort, `10-MergeBatchSites` is a cohort-level workflow, so it is run on a `sample_set_set` containing all of the batches in the cohort. You can create this `sample_set_set` while you are launching the `10-MergeBatchSites` workflow: click "Select Data", choose "Create new sample_set_set [...]", check all the batches to include (all of the ones used in `03-TrainGCNV` through `09-FilterBatchSamples`), and give it a name that follows the **Sample ID requirements**. 
 
 <img alt="creating a cohort sample_set_set" title="How to create a cohort sample_set_set" src="https://i.imgur.com/zKEtSbe.png" width="500">
 
-#### 09-GenotypeBatch
+#### 11-GenotypeBatch
 
 Read the full GenotypeBatch documentation [here](https://github.com/broadinstitute/gatk-sv#genotype-batch).
-* Use the same `sample_set` definitions you used for `03-TrainGCNV` through `07c-FilterBatchSamples`.
-* If you only have one batch, use the `09-GenotypeBatch_SingleBatch` version of the workflow.
+* Use the same `sample_set` definitions you used for `03-TrainGCNV` through `09-FilterBatchSamples`.
+* If you only have one batch, use the `11-GenotypeBatch_SingleBatch` version of the workflow.
 
-#### 10-RegenotypeCNVs, 11-MakeCohortVcf, and 12-AnnotateVcf
+#### 12-RegenotypeCNVs, 13-CombineBatches, 14-ResolveComplexVariants, 15-GenotypeComplexVariants, 16-CleanVcf, 17-MasterVcfQc, and 18-AnnotateVcf
 
-Read the full documentation for [RegenotypeCNVs](https://github.com/broadinstitute/gatk-sv#regenotype-cnvs), [MakeCohortVcf](https://github.com/broadinstitute/gatk-sv#make-cohort-vcf), and [AnnotateVcf](https://github.com/broadinstitute/gatk-sv#annotate-vcf) on the README.
-* For a multi-batch cohort, use the same cohort `sample_set_set` you created and used for `08-MergeBatchSites`.
+Read the full documentation for [RegenotypeCNVs](https://github.com/broadinstitute/gatk-sv#regenotype-cnvs), [MakeCohortVcf](https://github.com/broadinstitute/gatk-sv#make-cohort-vcf) (which includes `CombineBatches`, `ResolveComplexVariants`, `GenotypeComplexVariants`, `CleanVcf`, `MasterVcfQc`), and [AnnotateVcf](https://github.com/broadinstitute/gatk-sv#annotate-vcf) on the README.
+* For a multi-batch cohort, use the same cohort `sample_set_set` you created and used for `10-MergeBatchSites`.
 * If you only have one batch, use the `[...]_SingleBatch` version of the workflow.
 
 #### Downstream steps
 
-Additional downstream steps are under development. Read about some of them on the README [here](https://github.com/broadinstitute/gatk-sv#module07). Please note that the VCF produced by `11-MakeCohortVcf` (and annotated by `12-AnnotateVcf`) prioritizes sensitivity, but additional downstream filtration is recommended to improve specificity. Filtration methods are under active development by the GATK-SV team; stay tuned for updates.
+Additional downstream steps are under development. Read about some of them on the README [here](https://github.com/broadinstitute/gatk-sv#module07). Please note that the VCF produced by `16-CleanVcf` (and annotated by `18-AnnotateVcf`) prioritizes sensitivity, but additional downstream filtration is recommended to improve specificity. Filtration methods are under active development by the GATK-SV team; stay tuned for updates.

--- a/inputs/templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
@@ -19,7 +19,7 @@ The following inputs must be provided for each sample in the cohort, via the sam
 |`File`|`bam_or_cram_file`|Path to the GCS location of the input CRAM or BAM file. If using BAM files, an index `.bai` file must either be present in the same directory, or the path must be provided with the input `bam_or_cram_index`.|
 |`Boolean`|`requester_pays_cram`|Set to `true` if the case data is stored in a requester-pays GCS bucket|
 
-*See **Sample ID requirements** below for specifications. 
+*See **Sample ID requirements** below for specifications.
 
 The following cohort-level or batch-level inputs are also required:
 
@@ -189,14 +189,14 @@ Read the full documentation for these modules [here](https://github.com/broadins
 These three workflows make up FilterBatch; they are subdivided in this workspace to enable tuning of outlier filtration cutoffs. Read the full FilterBatch documentation [here](https://github.com/broadinstitute/gatk-sv#filter-batch).
 * Use the same `sample_set` definitions you used for `03-TrainGCNV` through `06-GenerateBatchMetrics`.
 * `07-FilterBatchSites` does not require user intervention
-* `08-PlotSVCountsPerSample` produces SV count plots and files, as well as a preview of the outlier samples to be filtered, but it does not perform any filtering of the VCFs. The input `N_IQR_cutoff` is used to visualize filtration thresholds on the SV count plots and preview the samples to be filtered; the default value is set to 6. You can adjust this value depending on your needs, and you can re-run the workflow with new `N_IQR_cutoff` values until the plots and outlier sample lists suit the purposes of your study. Once you have chosen an IQR cutoff, provide it to the `N_IQR_cutoff` input in `09-FilterBatchSamples` to filter the VCFs using the chosen cutoff. 
+* `08-PlotSVCountsPerSample` produces SV count plots and files, as well as a preview of the outlier samples to be filtered, but it does not perform any filtering of the VCFs. The input `N_IQR_cutoff` is used to visualize filtration thresholds on the SV count plots and preview the samples to be filtered; the default value is set to 6. You can adjust this value depending on your needs, and you can re-run the workflow with new `N_IQR_cutoff` values until the plots and outlier sample lists suit the purposes of your study. Once you have chosen an IQR cutoff, provide it to the `N_IQR_cutoff` input in `09-FilterBatchSamples` to filter the VCFs using the chosen cutoff.
 * `09-FilterBatchSamples` performs outlier sample filtration, removing samples with an abnormal number of SV calls of at least one SV type. To tune the filtering threshold to your needs, edit the `N_IQR_cutoff` input value based on the plots and outlier sample preview lists from `08-PlotSVCountsPerSample`. The default value for `N_IQR_cutoff` in this step is 10000, which essentially means that no samples are filtered.
 
 #### 10-MergeBatchSites
 
 Read the full MergeBatchSites documentation [here](https://github.com/broadinstitute/gatk-sv#merge-batch-sites).
 * If you only have one batch, skip this workflow.
-* For a multi-batch cohort, `10-MergeBatchSites` is a cohort-level workflow, so it is run on a `sample_set_set` containing all of the batches in the cohort. You can create this `sample_set_set` while you are launching the `10-MergeBatchSites` workflow: click "Select Data", choose "Create new sample_set_set [...]", check all the batches to include (all of the ones used in `03-TrainGCNV` through `09-FilterBatchSamples`), and give it a name that follows the **Sample ID requirements**. 
+* For a multi-batch cohort, `10-MergeBatchSites` is a cohort-level workflow, so it is run on a `sample_set_set` containing all of the batches in the cohort. You can create this `sample_set_set` while you are launching the `10-MergeBatchSites` workflow: click "Select Data", choose "Create new sample_set_set [...]", check all the batches to include (all of the ones used in `03-TrainGCNV` through `09-FilterBatchSamples`), and give it a name that follows the **Sample ID requirements**.
 
 <img alt="creating a cohort sample_set_set" title="How to create a cohort sample_set_set" src="https://i.imgur.com/zKEtSbe.png" width="500">
 

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/AnnotateVcf.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/AnnotateVcf.SingleBatch.json.tmpl
@@ -1,6 +1,6 @@
 {
-  "AnnotateVcf.vcf" : "${this.vcf}",
-  "AnnotateVcf.vcf_idx" : "${this.vcf_index}",
+  "AnnotateVcf.vcf" : "${this.cleaned_vcf}",
+  "AnnotateVcf.vcf_idx" : "${this.cleaned_vcf_index}",
 
   "AnnotateVcf.protein_coding_gtf" : "${workspace.protein_coding_gtf}",
   "AnnotateVcf.noncoding_bed" : "${workspace.noncoding_bed}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/AnnotateVcf.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/AnnotateVcf.json.tmpl
@@ -1,6 +1,6 @@
 {
-  "AnnotateVcf.vcf" : "${this.vcf}",
-  "AnnotateVcf.vcf_idx" : "${this.vcf_index}",
+  "AnnotateVcf.vcf" : "${this.cleaned_vcf}",
+  "AnnotateVcf.vcf_idx" : "${this.cleaned_vcf_index}",
 
   "AnnotateVcf.protein_coding_gtf" : "${workspace.protein_coding_gtf}",
   "AnnotateVcf.noncoding_bed" : "${workspace.noncoding_bed}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CleanVcf.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CleanVcf.SingleBatch.json.tmpl
@@ -1,0 +1,28 @@
+{
+  "CleanVcf.contig_list": "${workspace.primary_contigs_fai}",
+  "CleanVcf.allosome_fai": "${workspace.allosome_file}",
+  "CleanVcf.chr_x": "${workspace.chr_x}",
+  "CleanVcf.chr_y": "${workspace.chr_y}",
+
+  "CleanVcf.max_shards_per_chrom_step1": 200,
+  "CleanVcf.min_records_per_shard_step1": 5000,
+  "CleanVcf.clean_vcf1b_records_per_shard": 10000,
+  "CleanVcf.samples_per_step2_shard": 100,
+  "CleanVcf.clean_vcf5_records_per_shard": 5000,
+
+  "CleanVcf.primary_contigs_list": "${workspace.primary_contigs_list}",
+  "CleanVcf.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
+
+  "CleanVcf.linux_docker": "${workspace.linux_docker}",
+  "CleanVcf.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "CleanVcf.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
+  "CleanVcf.sv_pipeline_updates_docker": "${workspace.sv_pipeline_updates_docker}",
+  "CleanVcf.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+
+  "CleanVcf.cohort_name": "${this.sample_set_id}",
+  "CleanVcf.merged_ped_file": "${workspace.cohort_ped_file}",
+  "CleanVcf.complex_genotype_vcfs": "${this.complex_genotype_vcfs}",
+  "CleanVcf.complex_resolve_bothside_pass_lists": "${this.complex_resolve_bothside_pass_lists}",
+  "CleanVcf.complex_resolve_background_fail_lists": "${this.complex_resolve_background_fail_lists}"
+
+}

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CleanVcf.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CleanVcf.json.tmpl
@@ -1,0 +1,28 @@
+{
+  "CleanVcf.contig_list": "${workspace.primary_contigs_fai}",
+  "CleanVcf.allosome_fai": "${workspace.allosome_file}",
+  "CleanVcf.chr_x": "${workspace.chr_x}",
+  "CleanVcf.chr_y": "${workspace.chr_y}",
+
+  "CleanVcf.max_shards_per_chrom_step1": 200,
+  "CleanVcf.min_records_per_shard_step1": 5000,
+  "CleanVcf.clean_vcf1b_records_per_shard": 10000,
+  "CleanVcf.samples_per_step2_shard": 100,
+  "CleanVcf.clean_vcf5_records_per_shard": 5000,
+
+  "CleanVcf.primary_contigs_list": "${workspace.primary_contigs_list}",
+  "CleanVcf.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
+
+  "CleanVcf.linux_docker": "${workspace.linux_docker}",
+  "CleanVcf.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "CleanVcf.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
+  "CleanVcf.sv_pipeline_updates_docker": "${workspace.sv_pipeline_updates_docker}",
+  "CleanVcf.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+
+  "CleanVcf.cohort_name": "${this.sample_set_set_id}",
+  "CleanVcf.merged_ped_file": "${workspace.cohort_ped_file}",
+  "CleanVcf.complex_genotype_vcfs": "${this.complex_genotype_vcfs}",
+  "CleanVcf.complex_resolve_bothside_pass_lists": "${this.complex_resolve_bothside_pass_lists}",
+  "CleanVcf.complex_resolve_background_fail_lists": "${this.complex_resolve_background_fail_lists}"
+
+}

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CombineBatches.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CombineBatches.SingleBatch.json.tmpl
@@ -1,0 +1,19 @@
+{
+  "CombineBatches.contig_list": "${workspace.primary_contigs_fai}",
+  "CombineBatches.pe_exclude_list": "${workspace.pesr_exclude_list}",
+  "CombineBatches.depth_exclude_list": "${workspace.depth_exclude_list}",
+  "CombineBatches.empty_file" : "${workspace.empty_file}",
+
+  "CombineBatches.min_sr_background_fail_batches": 0.5,
+  "CombineBatches.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "CombineBatches.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
+  "CombineBatches.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+
+  "CombineBatches.cohort_name": "${this.sample_set_id}",
+  "CombineBatches.batches": "${this.sample_set_id}",
+  "CombineBatches.pesr_vcfs": "${this.genotyped_pesr_vcf}",
+  "CombineBatches.depth_vcfs": "${this.regenotyped_depth_vcfs}",
+  "CombineBatches.raw_sr_bothside_pass_files": "${this.sr_bothside_pass}",
+  "CombineBatches.raw_sr_background_fail_files": "${this.sr_background_fail}"
+
+}

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CombineBatches.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CombineBatches.json.tmpl
@@ -1,0 +1,19 @@
+{
+  "CombineBatches.contig_list": "${workspace.primary_contigs_fai}",
+  "CombineBatches.pe_exclude_list": "${workspace.pesr_exclude_list}",
+  "CombineBatches.depth_exclude_list": "${workspace.depth_exclude_list}",
+  "CombineBatches.empty_file" : "${workspace.empty_file}",
+
+  "CombineBatches.min_sr_background_fail_batches": 0.5,
+  "CombineBatches.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "CombineBatches.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
+  "CombineBatches.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+
+  "CombineBatches.cohort_name": "${this.sample_set_set_id}",
+  "CombineBatches.batches": "${this.sample_sets.sample_set_id}",
+  "CombineBatches.pesr_vcfs": "${this.sample_sets.genotyped_pesr_vcf}",
+  "CombineBatches.depth_vcfs": "${this.regenotyped_depth_vcfs}",
+  "CombineBatches.raw_sr_bothside_pass_files": "${this.sample_sets.sr_bothside_pass}",
+  "CombineBatches.raw_sr_background_fail_files": "${this.sample_sets.sr_background_fail}"
+
+}

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenotypeComplexVariants.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenotypeComplexVariants.SingleBatch.json.tmpl
@@ -1,0 +1,22 @@
+{
+  "GenotypeComplexVariants.bin_exclude": "${workspace.bin_exclude}",
+  "GenotypeComplexVariants.contig_list": "${workspace.primary_contigs_fai}",
+  "GenotypeComplexVariants.ref_dict": "${workspace.reference_dict}",
+
+  "GenotypeComplexVariants.linux_docker": "${workspace.linux_docker}",
+  "GenotypeComplexVariants.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "GenotypeComplexVariants.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
+  "GenotypeComplexVariants.sv_pipeline_updates_docker": "${workspace.sv_pipeline_updates_docker}",
+  "GenotypeComplexVariants.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+  "GenotypeComplexVariants.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",
+
+  "GenotypeComplexVariants.cohort_name": "${this.sample_set_id}",
+  "GenotypeComplexVariants.batches": "${this.sample_set_id}",
+  "GenotypeComplexVariants.depth_vcfs": "${this.regenotyped_depth_vcfs}",
+  "GenotypeComplexVariants.complex_resolve_vcfs": "${this.complex_resolve_vcfs}",
+  "GenotypeComplexVariants.complex_resolve_vcf_indexes": "${this.complex_resolve_vcf_indexes}",
+  "GenotypeComplexVariants.merged_ped_file": "${workspace.cohort_ped_file}",
+  "GenotypeComplexVariants.bincov_files": "${this.merged_bincov}",
+  "GenotypeComplexVariants.depth_gt_rd_sep_files": "${this.trained_genotype_depth_depth_sepcutoff}",
+  "GenotypeComplexVariants.median_coverage_files": "${this.median_cov}"
+}

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenotypeComplexVariants.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenotypeComplexVariants.json.tmpl
@@ -1,0 +1,22 @@
+{
+  "GenotypeComplexVariants.bin_exclude": "${workspace.bin_exclude}",
+  "GenotypeComplexVariants.contig_list": "${workspace.primary_contigs_fai}",
+  "GenotypeComplexVariants.ref_dict": "${workspace.reference_dict}",
+
+  "GenotypeComplexVariants.linux_docker": "${workspace.linux_docker}",
+  "GenotypeComplexVariants.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "GenotypeComplexVariants.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
+  "GenotypeComplexVariants.sv_pipeline_updates_docker": "${workspace.sv_pipeline_updates_docker}",
+  "GenotypeComplexVariants.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+  "GenotypeComplexVariants.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",
+
+  "GenotypeComplexVariants.cohort_name": "${this.sample_set_set_id}",
+  "GenotypeComplexVariants.batches": "${this.sample_sets.sample_set_id}",
+  "GenotypeComplexVariants.depth_vcfs": "${this.regenotyped_depth_vcfs}",
+  "GenotypeComplexVariants.complex_resolve_vcfs": "${this.complex_resolve_vcfs}",
+  "GenotypeComplexVariants.complex_resolve_vcf_indexes": "${this.complex_resolve_vcf_indexes}",
+  "GenotypeComplexVariants.merged_ped_file": "${workspace.cohort_ped_file}",
+  "GenotypeComplexVariants.bincov_files": "${this.sample_sets.merged_bincov}",
+  "GenotypeComplexVariants.depth_gt_rd_sep_files": "${this.sample_sets.trained_genotype_depth_depth_sepcutoff}",
+  "GenotypeComplexVariants.median_coverage_files": "${this.sample_sets.median_cov}"
+}

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MasterVcfQc.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MasterVcfQc.SingleBatch.json.tmpl
@@ -1,0 +1,20 @@
+{
+  "MasterVcfQc.primary_contigs_fai": "${workspace.primary_contigs_fai}",
+
+  "MasterVcfQc.thousand_genomes_benchmark_calls": {{ reference_resources.thousand_genomes_benchmark_calls | tojson }},
+
+  "MasterVcfQc.random_seed": 0,
+
+  "MasterVcfQc.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "MasterVcfQc.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+  "MasterVcfQc.sv_pipeline_qc_docker": "${workspace.sv_pipeline_qc_docker}",
+
+  "MasterVcfQc.prefix": "${this.sample_set_id}",
+  "MasterVcfQc.ped_file": "${workspace.cohort_ped_file}",
+
+  "MasterVcfQc.vcf": "${this.cleaned_vcf}",
+
+  "MasterVcfQc.sv_per_shard": 10000,
+  "MasterVcfQc.samples_per_shard": 100
+
+}

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MasterVcfQc.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MasterVcfQc.json.tmpl
@@ -1,0 +1,20 @@
+{
+  "MasterVcfQc.primary_contigs_fai": "${workspace.primary_contigs_fai}",
+
+  "MasterVcfQc.thousand_genomes_benchmark_calls": {{ reference_resources.thousand_genomes_benchmark_calls | tojson }},
+
+  "MasterVcfQc.random_seed": 0,
+
+  "MasterVcfQc.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "MasterVcfQc.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+  "MasterVcfQc.sv_pipeline_qc_docker": "${workspace.sv_pipeline_qc_docker}",
+
+  "MasterVcfQc.prefix": "${this.sample_set_set_id}",
+  "MasterVcfQc.ped_file": "${workspace.cohort_ped_file}",
+
+  "MasterVcfQc.vcf": "${this.cleaned_vcf}",
+
+  "MasterVcfQc.sv_per_shard": 10000,
+  "MasterVcfQc.samples_per_shard": 100
+
+}

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ResolveComplexVariants.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ResolveComplexVariants.SingleBatch.json.tmpl
@@ -1,0 +1,20 @@
+{
+  "ResolveComplexVariants.contig_list": "${workspace.primary_contigs_fai}",
+  "ResolveComplexVariants.cytobands": "${workspace.cytobands}",
+  "ResolveComplexVariants.mei_bed": "${workspace.mei_bed}",
+  "ResolveComplexVariants.pe_exclude_list": "${workspace.pesr_exclude_list}",
+  "ResolveComplexVariants.ref_dict": "${workspace.reference_dict}",
+
+  "ResolveComplexVariants.max_shard_size" : 500,
+  "ResolveComplexVariants.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "ResolveComplexVariants.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+  "ResolveComplexVariants.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
+
+  "ResolveComplexVariants.cohort_name": "${this.sample_set_id}",
+  "ResolveComplexVariants.disc_files": "${this.merged_PE}",
+  "ResolveComplexVariants.rf_cutoff_files": "${this.cutoffs}",
+  "ResolveComplexVariants.cluster_vcfs": "${this.combined_vcfs}",
+  "ResolveComplexVariants.cluster_bothside_pass_lists": "${this.cluster_bothside_pass_lists}",
+  "ResolveComplexVariants.cluster_background_fail_lists": "${this.cluster_background_fail_lists}"
+
+}

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ResolveComplexVariants.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ResolveComplexVariants.json.tmpl
@@ -1,0 +1,20 @@
+{
+  "ResolveComplexVariants.contig_list": "${workspace.primary_contigs_fai}",
+  "ResolveComplexVariants.cytobands": "${workspace.cytobands}",
+  "ResolveComplexVariants.mei_bed": "${workspace.mei_bed}",
+  "ResolveComplexVariants.pe_exclude_list": "${workspace.pesr_exclude_list}",
+  "ResolveComplexVariants.ref_dict": "${workspace.reference_dict}",
+
+  "ResolveComplexVariants.max_shard_size" : 500,
+  "ResolveComplexVariants.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
+  "ResolveComplexVariants.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
+  "ResolveComplexVariants.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
+
+  "ResolveComplexVariants.cohort_name": "${this.sample_set_set_id}",
+  "ResolveComplexVariants.disc_files": "${this.sample_sets.merged_PE}",
+  "ResolveComplexVariants.rf_cutoff_files": "${this.sample_sets.cutoffs}",
+  "ResolveComplexVariants.cluster_vcfs": "${this.combined_vcfs}",
+  "ResolveComplexVariants.cluster_bothside_pass_lists": "${this.cluster_bothside_pass_lists}",
+  "ResolveComplexVariants.cluster_background_fail_lists": "${this.cluster_background_fail_lists}"
+
+}

--- a/inputs/templates/test/MakeCohortVcf/CleanVcf.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/CleanVcf.json.tmpl
@@ -1,0 +1,34 @@
+{
+  "CleanVcf.contig_list": {{ reference_resources.primary_contigs_fai | tojson }},
+  "CleanVcf.allosome_fai": {{ reference_resources.allosome_file | tojson }},
+  "CleanVcf.chr_x": {{ reference_resources.chr_x | tojson }},
+  "CleanVcf.chr_y": {{ reference_resources.chr_y | tojson }},
+
+  "CleanVcf.max_shards_per_chrom_step1": 200,
+  "CleanVcf.min_records_per_shard_step1": 5000,
+  "CleanVcf.clean_vcf1b_records_per_shard": 10000,
+  "CleanVcf.samples_per_step2_shard": 100,
+  "CleanVcf.clean_vcf5_records_per_shard": 5000,
+
+  "CleanVcf.primary_contigs_list": {{ reference_resources.primary_contigs_list | tojson }},
+  "CleanVcf.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
+
+  "CleanVcf.linux_docker": {{ dockers.linux_docker | tojson }},
+  "CleanVcf.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
+  "CleanVcf.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
+  "CleanVcf.sv_pipeline_updates_docker": {{ dockers.sv_pipeline_updates_docker | tojson }},
+  "CleanVcf.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
+
+  "CleanVcf.cohort_name": {{ test_batch.name | tojson }},
+  "CleanVcf.merged_ped_file": {{ test_batch.ped_file | tojson }},
+  "CleanVcf.complex_genotype_vcfs": [
+    {{ test_batch.complex_genotype_vcfs | tojson }}
+  ],
+  "CleanVcf.complex_resolve_bothside_pass_lists": [
+    {{ test_batch.complex_resolve_bothside_pass_lists | tojson }}
+  ],
+  "CleanVcf.complex_resolve_background_fail_lists": [
+    {{ test_batch.complex_resolve_background_fail_lists | tojson }}
+  ]
+
+}

--- a/inputs/templates/test/MakeCohortVcf/CombineBatches.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/CombineBatches.json.tmpl
@@ -1,0 +1,29 @@
+{
+  "CombineBatches.contig_list": {{ reference_resources.primary_contigs_fai | tojson }},
+  "CombineBatches.pe_exclude_list": {{ reference_resources.pesr_exclude_list | tojson }},
+  "CombineBatches.depth_exclude_list": {{ reference_resources.depth_exclude_list | tojson }},
+  "CombineBatches.empty_file" : {{ reference_resources.empty_file | tojson }},
+
+  "CombineBatches.min_sr_background_fail_batches": 0.5,
+  "CombineBatches.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
+  "CombineBatches.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
+  "CombineBatches.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
+
+  "CombineBatches.cohort_name": {{ test_batch.name | tojson }},
+  "CombineBatches.batches": [
+    {{ test_batch.name | tojson }}
+  ],
+  "CombineBatches.pesr_vcfs": [
+    {{ test_batch.genotyped_pesr_vcf| tojson }}
+  ],
+  "CombineBatches.depth_vcfs": [
+    {{ test_batch.regenotyped_depth_vcf | tojson }}
+  ],
+  "CombineBatches.raw_sr_bothside_pass_files": [
+    {{ test_batch.raw_sr_bothside_pass_file | tojson }}
+  ],
+  "CombineBatches.raw_sr_background_fail_files": [
+    {{ test_batch.raw_sr_background_fail_file | tojson }}
+  ]
+
+}

--- a/inputs/templates/test/MakeCohortVcf/GenotypeComplexVariants.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/GenotypeComplexVariants.json.tmpl
@@ -1,0 +1,36 @@
+{
+  "GenotypeComplexVariants.bin_exclude": {{ reference_resources.bin_exclude | tojson }},
+  "GenotypeComplexVariants.contig_list": {{ reference_resources.primary_contigs_fai | tojson }},
+  "GenotypeComplexVariants.ref_dict": {{ reference_resources.reference_dict | tojson }},
+
+  "GenotypeComplexVariants.linux_docker": {{ dockers.linux_docker | tojson }},
+  "GenotypeComplexVariants.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
+  "GenotypeComplexVariants.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
+  "GenotypeComplexVariants.sv_pipeline_updates_docker": {{ dockers.sv_pipeline_updates_docker | tojson }},
+  "GenotypeComplexVariants.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
+  "GenotypeComplexVariants.sv_pipeline_rdtest_docker": {{ dockers.sv_pipeline_rdtest_docker | tojson }},
+
+  "GenotypeComplexVariants.cohort_name": {{ test_batch.name | tojson }},
+  "GenotypeComplexVariants.batches": [
+    {{ test_batch.name | tojson }}
+  ],
+  "GenotypeComplexVariants.depth_vcfs": [
+    {{ test_batch.regenotyped_depth_vcf | tojson }}
+  ],
+  "GenotypeComplexVariants.complex_resolve_vcfs": [
+    {{ test_batch.complex_resolve_vcfs | tojson }}
+  ],
+  "GenotypeComplexVariants.complex_resolve_vcf_indexes": [
+    {{ test_batch.complex_resolve_vcf_indexes | tojson }}
+  ],
+  "GenotypeComplexVariants.merged_ped_file": {{ test_batch.ped_file | tojson }},
+  "GenotypeComplexVariants.bincov_files": [
+    {{ test_batch.merged_coverage_file | tojson }}
+  ],
+  "GenotypeComplexVariants.depth_gt_rd_sep_files": [
+    {{ test_batch.depth_gt_rd_sep_file | tojson }}
+  ],
+  "GenotypeComplexVariants.median_coverage_files": [
+    {{ test_batch.medianfile | tojson }}
+  ]
+}

--- a/inputs/templates/test/MakeCohortVcf/MasterVcfQc.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/MasterVcfQc.json.tmpl
@@ -1,6 +1,6 @@
 {
   "MasterVcfQc.primary_contigs_fai": {{ reference_resources.primary_contigs_fai | tojson }},
-  
+
   "MasterVcfQc.thousand_genomes_benchmark_calls": {{ reference_resources.thousand_genomes_benchmark_calls | tojson }},
 
   "MasterVcfQc.random_seed": 0,
@@ -11,10 +11,10 @@
 
   "MasterVcfQc.prefix": {{ test_batch.name | tojson }},
   "MasterVcfQc.ped_file": {{ test_batch.ped_file | tojson }},
-  
+
   "MasterVcfQc.vcf": {{ test_batch.clean_vcf| tojson }},
 
   "MasterVcfQc.sv_per_shard": 10000,
   "MasterVcfQc.samples_per_shard": 100
-  
+
 }

--- a/inputs/templates/test/MakeCohortVcf/ResolveComplexVariants.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/ResolveComplexVariants.json.tmpl
@@ -1,0 +1,30 @@
+{
+  "ResolveComplexVariants.contig_list": {{ reference_resources.primary_contigs_fai | tojson }},
+  "ResolveComplexVariants.cytobands": {{ reference_resources.cytobands | tojson }},
+  "ResolveComplexVariants.mei_bed": {{ reference_resources.mei_bed | tojson }},
+  "ResolveComplexVariants.pe_exclude_list": {{ reference_resources.pesr_exclude_list | tojson }},
+  "ResolveComplexVariants.ref_dict": {{ reference_resources.reference_dict | tojson }},
+
+  "ResolveComplexVariants.max_shard_size" : 500,
+  "ResolveComplexVariants.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
+  "ResolveComplexVariants.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
+  "ResolveComplexVariants.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
+
+  "ResolveComplexVariants.cohort_name": {{ test_batch.name | tojson }},
+  "ResolveComplexVariants.disc_files": [
+    {{ test_batch.merged_disc_file | tojson }}
+  ],
+  "ResolveComplexVariants.rf_cutoff_files": [
+    {{ test_batch.cutoffs | tojson }}
+  ],
+  "ResolveComplexVariants.cluster_vcfs": [
+    {{ test_batch.combined_vcfs | tojson }}
+  ],
+  "ResolveComplexVariants.cluster_bothside_pass_lists": [
+    {{ test_batch.cluster_bothside_pass_lists | tojson }}
+  ],
+  "ResolveComplexVariants.cluster_background_fail_lists": [
+    {{ test_batch.cluster_background_fail_lists | tojson }}
+  ]
+
+}

--- a/scripts/test/terra_validation.py
+++ b/scripts/test/terra_validation.py
@@ -25,8 +25,7 @@ Parameters:
     --log-level LEVEL: specify level of logging information to print,
         ie. INFO, WARNING, ERROR - not case-sensitive)
 
-Outputs: If successful, last line of printout should read
-    "<N> of <N> Terra input JSONs exist and passed validation."
+Outputs: Final output lines will list number of JSONs that passed and number of JSONs that failed validation.
     Prior lines will detail the JSONs that were examined and any errors found.
 """
 
@@ -43,7 +42,7 @@ def list_jsons(inputs_paths, expected_num_jsons):
         jsons.extend([os.path.join(path, x) for x in listdir(path) if x.endswith(".json")])
     num_input_jsons = len(jsons)
     if num_input_jsons < expected_num_jsons:
-        raise Exception(f"Expected {expected_num_jsons} Terra input JSONs but found {num_input_jsons}.")
+        raise Exception(f"Expected {expected_num_jsons} Terra input JSONs but found {num_input_jsons}. To proceed anyway, edit the expected number of JSONs with the -n input.")
     jsons.sort()
     return jsons
 
@@ -84,21 +83,27 @@ def validate_terra_json(wdl, terra_json, womtool_jar):
     if valid:
         logging.info(f"PASS: {terra_json} is a valid Terra input JSON for {wdl_name}")
 
-    return int(valid)  # return 1 if valid, 0 if not valid
+    return valid
 
 
 def validate_all_terra_jsons(base_dir, womtool_jar, expected_num_inputs):
     successes = 0
+    failures = 0
     for wdl, json_file in get_wdl_json_pairs(os.path.join(base_dir, WDLS_PATH),
                                              [os.path.join(base_dir, x) for x in TERRA_INPUTS_PATHS],
                                              expected_num_inputs):
-        successes += validate_terra_json(wdl, json_file, womtool_jar)
+        valid = validate_terra_json(wdl, json_file, womtool_jar)
+        if valid:
+            successes += 1
+        else:
+            failures += 1
 
     print("\n")
-    if successes != expected_num_inputs:
-        raise RuntimeError(f"{successes} of {expected_num_inputs} Terra input JSONs passed validation.")
-    else:
-        print(f"{successes} of {expected_num_inputs} Terra input JSONs passed validation.")
+    if failures > 0:
+        raise RuntimeError(f"Some Terra input JSONs failed validation!\nPass: {successes}. Fail: {failures}.\nTotal validated: {successes + failures}. Expected number of JSONs: {expected_num_inputs}.")
+    if successes > expected_num_inputs:
+        logging.warning(f"Found more Terra input JSONs than expected! Validated: {successes}. Expected: {expected_num_inputs}.")
+    print(f"Success! All Terra input JSONs passed validation.\nPass: {successes}. Fail: {failures}.\nTotal: {successes + failures} out of {expected_num_inputs} passed.")
 
 
 # Main function
@@ -108,7 +113,7 @@ def main():
     parser.add_argument("-j", "--womtool-jar", help="Path to womtool jar", required=True)
     parser.add_argument("-n", "--num-input-jsons",
                         help="Number of Terra input JSONs expected",
-                        required=False, default=21, type=int)
+                        required=False, default=31, type=int)
     parser.add_argument("--log-level",
                         help="Specify level of logging information, ie. info, warning, error (not case-sensitive)",
                         required=False, default="INFO")

--- a/wdl/CleanVcf.wdl
+++ b/wdl/CleanVcf.wdl
@@ -3,6 +3,7 @@ version 1.0
 import "CleanVcfChromosome.wdl" as CleanVcfChromosome
 import "TasksMakeCohortVcf.wdl" as MiniTasks
 import "HailMerge.wdl" as HailMerge
+import "MakeCohortVcfMetrics.wdl" as metrics
 
 workflow CleanVcf {
   input {
@@ -29,6 +30,19 @@ workflow CleanVcf {
 
     Boolean use_hail = false
     String? gcs_project
+
+    # Module metrics parameters
+    # Run module metrics workflow at the end - on by default
+    Boolean? run_module_metrics
+    String? sv_pipeline_base_docker  # required if run_module_metrics = true
+    File? primary_contigs_list  # required if run_module_metrics = true
+    File? baseline_cluster_vcf  # baseline files are optional for metrics workflow
+    File? baseline_complex_resolve_vcf
+    File? baseline_complex_genotype_vcf
+    File? baseline_cleaned_vcf
+    File? combine_batches_merged_vcf  # intermediate merged VCFs are optional for metrics workflow
+    File? resolve_complex_merged_vcf
+    File? genotype_complex_merged_vcf
 
     String linux_docker
     String sv_base_mini_docker
@@ -176,8 +190,31 @@ workflow CleanVcf {
     }
   }
 
+  File cleaned_vcf_ = select_first([ConcatCleanedVcfs.concat_vcf, ConcatVcfsHail.merged_vcf])
+
+  Boolean run_module_metrics_ = if defined(run_module_metrics) then select_first([run_module_metrics]) else true
+  if (run_module_metrics_) {
+    call metrics.MakeCohortVcfMetrics {
+      input:
+        name = cohort_name,
+        cluster_vcf = combine_batches_merged_vcf,
+        complex_resolve_vcf = resolve_complex_merged_vcf,
+        complex_genotype_vcf = genotype_complex_merged_vcf,
+        cleaned_vcf = cleaned_vcf_,
+        baseline_cluster_vcf = baseline_cluster_vcf,
+        baseline_complex_resolve_vcf = baseline_complex_resolve_vcf,
+        baseline_complex_genotype_vcf = baseline_complex_genotype_vcf,
+        baseline_cleaned_vcf = baseline_cleaned_vcf,
+        contig_list = select_first([primary_contigs_list]),
+        linux_docker = linux_docker,
+        sv_pipeline_base_docker = select_first([sv_pipeline_base_docker]),
+        sv_base_mini_docker = sv_base_mini_docker
+    }
+  }
+
   output {
-    File cleaned_vcf = select_first([ConcatCleanedVcfs.concat_vcf, ConcatVcfsHail.merged_vcf])
+    File cleaned_vcf = cleaned_vcf_
     File cleaned_vcf_index = select_first([ConcatCleanedVcfs.concat_vcf_idx, ConcatVcfsHail.merged_vcf_index])
+    File? metrics_file_makecohortvcf = MakeCohortVcfMetrics.metrics_file
   }
 }

--- a/wdl/CombineBatches.wdl
+++ b/wdl/CombineBatches.wdl
@@ -402,7 +402,7 @@ workflow CombineBatches {
     Array[File] combined_vcf_indexes = vcf_indexes_out_
     Array[File] cluster_bothside_pass_lists = UpdateBothsidePassSecond.updated_list
     Array[File] cluster_background_fail_lists = UpdateBackgroundFailSecond.updated_list
-    File? merged_vcf = ConcatVcfs.concat_vcf
-    File? merged_vcf_index = ConcatVcfs.concat_vcf_idx
+    File? combine_batches_merged_vcf = ConcatVcfs.concat_vcf
+    File? combine_batches_merged_vcf_index = ConcatVcfs.concat_vcf_idx
   }
 }

--- a/wdl/CombineBatches.wdl
+++ b/wdl/CombineBatches.wdl
@@ -398,8 +398,8 @@ workflow CombineBatches {
 
   #Final outputs
   output {
-    Array[File] vcfs = vcfs_out_
-    Array[File] vcf_indexes = vcf_indexes_out_
+    Array[File] combined_vcfs = vcfs_out_
+    Array[File] combined_vcf_indexes = vcf_indexes_out_
     Array[File] cluster_bothside_pass_lists = UpdateBothsidePassSecond.updated_list
     Array[File] cluster_background_fail_lists = UpdateBackgroundFailSecond.updated_list
     File? merged_vcf = ConcatVcfs.concat_vcf

--- a/wdl/GenotypeComplexVariants.wdl
+++ b/wdl/GenotypeComplexVariants.wdl
@@ -136,7 +136,7 @@ workflow GenotypeComplexVariants {
   output {
     Array[File] complex_genotype_vcfs = ScatterCpxGenotyping.cpx_depth_gt_resolved_vcf
     Array[File] complex_genotype_vcf_indexes = ScatterCpxGenotyping.cpx_depth_gt_resolved_vcf_idx
-    File? merged_vcf = ConcatVcfs.concat_vcf
-    File? merged_vcf_index = ConcatVcfs.concat_vcf_idx
+    File? complex_genotype_merged_vcf = ConcatVcfs.concat_vcf
+    File? complex_genotype_merged_vcf_index = ConcatVcfs.concat_vcf_idx
   }
 }

--- a/wdl/MakeCohortVcf.wdl
+++ b/wdl/MakeCohortVcf.wdl
@@ -401,9 +401,9 @@ workflow MakeCohortVcf {
       outlier_samples_list=outlier_samples_list,
       use_hail=use_hail,
       gcs_project=gcs_project,
-      combine_batches_merged_vcf=CombineBatches.merged_vcf,
-      resolve_complex_merged_vcf=ResolveComplexVariants.merged_vcf,
-      genotype_complex_merged_vcf=GenotypeComplexVariants.merged_vcf,
+      combine_batches_merged_vcf=CombineBatches.combine_batches_merged_vcf,
+      resolve_complex_merged_vcf=ResolveComplexVariants.complex_resolve_merged_vcf,
+      genotype_complex_merged_vcf=GenotypeComplexVariants.complex_genotype_merged_vcf,
       baseline_cluster_vcf = baseline_cluster_vcf,
       baseline_complex_resolve_vcf = baseline_complex_resolve_vcf,
       baseline_complex_genotype_vcf = baseline_complex_genotype_vcf,
@@ -484,12 +484,12 @@ workflow MakeCohortVcf {
     File vcf_qc = MasterVcfQc.sv_vcf_qc_output
 
     # If merge_intermediate_vcfs enabled
-    File? cluster_vcf = CombineBatches.merged_vcf
-    File? cluster_vcf_index = CombineBatches.merged_vcf_index
-    File? complex_resolve_vcf = ResolveComplexVariants.merged_vcf
-    File? complex_resolve_vcf_index = ResolveComplexVariants.merged_vcf_index
-    File? complex_genotype_vcf = GenotypeComplexVariants.merged_vcf
-    File? complex_genotype_vcf_index = GenotypeComplexVariants.merged_vcf_index
+    File? cluster_vcf = CombineBatches.combine_batches_merged_vcf
+    File? cluster_vcf_index = CombineBatches.combine_batches_merged_vcf_index
+    File? complex_resolve_vcf = ResolveComplexVariants.complex_resolve_merged_vcf
+    File? complex_resolve_vcf_index = ResolveComplexVariants.complex_resolve_merged_vcf_index
+    File? complex_genotype_vcf = GenotypeComplexVariants.complex_genotype_merged_vcf
+    File? complex_genotype_vcf_index = GenotypeComplexVariants.complex_genotype_merged_vcf_index
 
     File? metrics_file_makecohortvcf = CleanVcf.metrics_file_makecohortvcf
   }

--- a/wdl/ResolveComplexVariants.wdl
+++ b/wdl/ResolveComplexVariants.wdl
@@ -223,8 +223,8 @@ workflow ResolveComplexVariants {
     Array[File] complex_resolve_background_fail_lists = UpdateBackgroundFail.updated_list
     Array[File] breakpoint_overlap_dropped_record_vcfs = BreakpointOverlap.dropped_record_vcf
     Array[File] breakpoint_overlap_dropped_record_vcf_indexes = BreakpointOverlap.dropped_record_vcf_index
-    File? merged_vcf = ConcatVcfs.concat_vcf
-    File? merged_vcf_index = ConcatVcfs.concat_vcf_idx
+    File? complex_resolve_merged_vcf = ConcatVcfs.concat_vcf
+    File? complex_resolve_merged_vcf_index = ConcatVcfs.concat_vcf_idx
   }
 }
 


### PR DESCRIPTION
### Updates
Changes in order to run the 5 subworkflows of MakeCohortVcf (CombineBatches, ResolveComplexVariants, GenotypeComplexVariants, CleanVcf, MasterVcfQc) as separate steps. This PR is primarily aimed at Terra and follow-up is needed to complete the changes for testing on cromwell.
1. Add Terra JSON templates for the 5 subworkflows  - one multi-batch (to run on sample_set_set) and one single-batch for each
2. Add test JSON templates for the 5 subworkflows
3. Move MakeCohortVcfMetrics to the end of CleanVcf to avoid having to run it as a separate workflow
4. Updates to Terra JSON validation script to a) increase the number of expected JSONs and b) make it clearer how many JSONs passed vs. failed vs. were expected
5. Edit output file names of subworkflows so that they will be unique in the Terra data table
6. Edit Terra dashboard to a) add the new subworkflows and b) renumber the existing workflows
7. Reference cleaned_vcf column in Terra data table for AnnotateVcf input 
8. (Not visible in code changes) Added subworkflows to Dockstore and re-added renumbered workflows with new names

### Follow-up changes needed
1. Remove MakeCohortVcf; edit batch & single-sample WDLs as necessary to directly call sub-workflows
2. Make the subworkflow outputs workflow-level outputs of the Batch WDL
3. Run the batch WDL and update the test set values JSON
4. Validate the individual test subworkflow JSONs once they are able to be generated with the updated values JSON

### Testing
1. Validated all Terra JSONs with the validation script
2. Validated all generated test JSONs with womtool - note that the subworkflow JSONs for ResolveComplexVariants, GenotypeComplexVariants, and CleanVcf are not built due to lacking input data in the values JSON so they were not validated
3. Ran all subworkflows & AnnotateVcf in Terra with WDLs & JSONs from commit 135a7f9 on this branch - on two batches (all succeeded) and on a single batch (CleanVcf_SingleBatch still in progress, also ran full MakeCohortVcf_SingleBatch successfully to test changes to that WDL)

Note that once this PR is merged, the Terra workspace will need to be fully updated with the renumbered workflows, latest workflow versions, latest dockers, and updated dashboard. Users in the midst of processing may find the renumbering confusing.