### PR TITLE
Handle low PE cutoff in genotyping

### DIFF
--- a/src/sv-pipeline/04_variant_resolution/scripts/PE_genotype.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/PE_genotype.sh
@@ -214,7 +214,7 @@ zcat pe.geno.final.txt.gz|awk '{if ($NF==0 && $3==0) print $0 "\t" 999}'|gzip>nu
 ##null genotype but has PE reads determined by poisson test##
 zcat pe.geno.final.txt.gz|awk '{if ($NF==0 && $3>0) print}' > null.wreads.txt
 if [ -s null.wreads.txt ]; then
-  zcat null.wreads.txt \
+  cat null.wreads.txt \
     | Rscript -e 'd<-read.table("stdin")' \
     -e "z<-cbind(d[1],d[,2],d[,3],d[,4],round(matrix(apply(d[,3,drop=F],1, function (x) -10*log10(1-ppois(0, lambda=x))* $normalization) ,ncol=1)) )" \
     -e 'write.table(z,"null.wreads.geno.txt",col.names=FALSE,quote=FALSE,row.names=FALSE,sep = "\t")'


### PR DESCRIPTION
### Updates

Address issue observed with some DRAGEN data in which lower than usual RF PE cutoffs lead to no null GTs that have any PE evidence in some batches (any PE evidence -> non-ref GT, and all null GTs have no PE evidence), resulting in an empty expected file during GenotypePESRPart1.TrainPEGenotyping.GenotypePEPart1. To circumvent the issue, check if the file is empty before proceeding. No further changes should be necessary as all other cases are handled separately.

### Testing

Tested GenotypeBatch on batch that had the error with the WDL on this branch (commit 25bff82) and sv_pipeline_docker set to us.gcr.io/broad-dsde-methods/eph/sv-pipeline:eph-handle-low-pe-cutoff-geno-25bff82. It passed GenotypePESRPart1 and only failed at the last step of GenotypePESRPart2 with an out-of-disk error in ConcatGenotypedVcfs. Currently re-running with more disk but this OOD error is expected to be unrelated to the change.

 