### PR TITLE
Bug fix for ParseGenotyping

### DIFF
--- a/dockerfiles/igv/makeigvpesr_cram.py
+++ b/dockerfiles/igv/makeigvpesr_cram.py
@@ -46,9 +46,9 @@ def ped_info_readin(ped_file):
         pin = line.strip().split()
         if not pin[1] in out.keys():
             out[pin[1]] = [pin[1]]
-        if not(pin[2]) == 0:
+        if not (pin[2]) == 0:
             out[pin[1]].append(pin[2])
-        if not(pin[3]) == 0:
+        if not (pin[3]) == 0:
             out[pin[1]].append(pin[3])
     fin.close()
     return out
@@ -62,7 +62,7 @@ def cram_info_readin(cram_file):
         if not pin[0] in out.keys():
             out[pin[0]] = pin[1:]
     fin.close()
-    return(out)
+    return (out)
 
 
 ped_info = ped_info_readin(args.ped)

--- a/dockerfiles/igv/makeigvpesr_trio.py
+++ b/dockerfiles/igv/makeigvpesr_trio.py
@@ -44,9 +44,9 @@ def ped_info_readin(ped_file):
         pin = line.strip().split()
         if not pin[1] in out.keys():
             out[pin[1]] = [pin[1]]
-        if not(pin[2]) == 0:
+        if not (pin[2]) == 0:
             out[pin[1]].append(pin[2])
-        if not(pin[3]) == 0:
+        if not (pin[3]) == 0:
             out[pin[1]].append(pin[3])
     fin.close()
     return out
@@ -60,7 +60,7 @@ def cram_info_readin(cram_file):
         if not pin[0] in out.keys():
             out[pin[0]] = pin[1:]
     fin.close()
-    return(out)
+    return (out)
 
 
 # ped_info = ped_info_readin(args.ped)

--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -14,7 +14,7 @@
   "sv_base_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:2022-06-10-v0.23-beta-9c6fbf56",
   "sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:2022-06-10-v0.23-beta-9c6fbf56",
   "sv_pipeline_base_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2022-07-26-v0.23-beta-662e9fdd",
-  "sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2022-07-26-v0.23-beta-662e9fdd",
+  "sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/markw/sv-pipeline:mw-parse-geno-gzip-check-03a2758",
   "sv_pipeline_hail_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2022-07-26-v0.23-beta-662e9fdd",
   "sv_pipeline_updates_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2022-07-26-v0.23-beta-662e9fdd",
   "sv_pipeline_qc_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2022-07-26-v0.23-beta-662e9fdd",

--- a/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.sh
@@ -103,7 +103,7 @@ if ! [ -s ${INVCF} ]; then
   usage
   exit 0
 fi
-if [ $( file ${INVCF} | fgrep "gzip" | wc -l ) -lt 1 ]; then
+if [[ ${INVCF} != *.gz ]]; then
   echo -e "\nERROR: input VCF must be bgzipped\n"
   usage
   exit 0
@@ -118,7 +118,7 @@ if ! [ -s ${INTERVALS} ]; then
   usage
   exit 0
 fi
-if [ $( file ${INTERVALS} | fgrep "gzip" | wc -l ) -lt 1 ]; then
+if [[ ${INTERVALS} != *.gz ]]; then
   echo -e "\nERROR: intervals file must be bgzipped\n"
   usage
   exit 0
@@ -133,7 +133,7 @@ if ! [ -s ${GENOTYPES} ]; then
   usage
   exit 0
 fi
-if [ $( file ${GENOTYPES} | fgrep "gzip" | wc -l ) -lt 1 ]; then
+if [[ ${GENOTYPES} != *.gz ]]; then
   echo -e "\nERROR: melted genotypes file must be bgzipped\n"
   usage
   exit 0
@@ -171,7 +171,7 @@ GTDIR=`mktemp -d`
 
 ###PREPARE SAMPLE lists
 #Master lists of samples extracted from famfile
-if [ $( file ${FAMFILE} | fgrep "gzip" | wc -l ) -gt 0 ]; then
+if [[ ${FAMFILE} == *.gz ]]; then
   #All samples
   zcat ${FAMFILE} | fgrep -v "#" | cut -f2 | sort | uniq \
     > ${GTDIR}/all.samples.list

--- a/src/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py
+++ b/src/sv-pipeline/scripts/downstream_analysis_and_filtering/apply_minGQ_filter.py
@@ -300,7 +300,7 @@ def _get_minGQ(record, minGQ_dict, SVLEN_table, AF_table, SVTYPE_table,
         for key in list(set(EV_table.values())):
             minGQ[key] = int(globalMin)
 
-    return(minGQ)
+    return (minGQ)
 
 
 def apply_minGQ_filter(record, minGQ_dict, SVLEN_table, AF_table, SVTYPE_table,

--- a/src/svtk/svtk/pesr/pe_test.py
+++ b/src/svtk/svtk/pesr/pe_test.py
@@ -100,7 +100,7 @@ class PETest(PESRTest):
         i = 0
         for pair in pairs:
             pair = _DiscPair(*pair)
-            if(i > 1000000):
+            if (i > 1000000):
                 print(region)
                 counts = defaultdict(int)
                 break


### PR DESCRIPTION
Replaces a check for compressed inputs `process_posthoc_cpx_depth_regenotyping.sh` from GenotypeComplexVariants. The previous implementation used the `file` command to guess the file type, but it is not 100% reliable and recently misidentified a gzipped bed file as a boot sector.

This commit replaces the `file` check with a simple check for `.gz` extensions. Tested successfully on MakeCohortVcf.