### PR TITLE
Set allow_overlaps=true, naive=false in ConcatCpxCnvVcfs

### DIFF
--- a/wdl/ScatterCpxGenotyping.wdl
+++ b/wdl/ScatterCpxGenotyping.wdl
@@ -118,7 +118,7 @@ workflow ScatterCpxGenotyping {
       input:
         vcfs=GenotypeShard.cpx_depth_gt_resolved_vcf,
         vcfs_idx=GenotypeShard.cpx_depth_gt_resolved_vcf_idx,
-        naive=true,
+        allow_overlaps=true,
         outfile_prefix="~{prefix}.regenotyped",
         sv_base_mini_docker=sv_base_mini_docker,
         runtime_attr_override=runtime_override_concat_cpx_cnv_vcfs


### PR DESCRIPTION
### Updates

In GenotypeComplexVariants.ScatterCpxGenotyping.ConcatCpxCnvVcfs, set allow_overlaps=true and naive=false for bcftools concat to address the following error message:
```
[E::hts_idx_push] Chromosome blocks not continuous
tbx_index_build failed: XXX.chr5.regenotyped.vcf.gz
```

### Testing

* Validated all WDLs and JSONs with womtool & Terra validation script.
* Tested on Terra in a disease cohort, where it resolved the above error message