### PR TITLE
Plot SV counts at the end of the ClusterBatch module

### DIFF
--- a/inputs/templates/test/ClusterBatch/ClusterBatch.json.tmpl
+++ b/inputs/templates/test/ClusterBatch/ClusterBatch.json.tmpl
@@ -29,5 +29,7 @@
   "ClusterBatch.wham_vcf_tar": {{ test_batch.std_wham_vcf_tar | tojson }},
   "ClusterBatch.manta_vcf_tar": {{ test_batch.std_manta_vcf_tar | tojson }},
   "ClusterBatch.melt_vcf_tar": {{ test_batch.std_melt_vcf_tar | tojson }},
-  "ClusterBatch.ped_file": {{ test_batch.ped_file | tojson }}
+  "ClusterBatch.ped_file": {{ test_batch.ped_file | tojson }},
+
+  "ClusterBatch.outlier_cutoff_nIQR": "10000"
 }

--- a/wdl/ClusterBatch.wdl
+++ b/wdl/ClusterBatch.wdl
@@ -291,7 +291,7 @@ workflow ClusterBatch {
   call sv_counts.PlotSVCountsPerSample {
     input:
       prefix = batch,
-      vcfs = [select_first([ClusterPESR_manta.clustered_vcf]), select_first([ClusterPESR_wham.clustered_vcf]), select_first([ClusterPESR_melt.clustered_vcf]), select_first([ClusterPESR_scramble.clustered_vcf])],
+      vcfs = select_all([ClusterDepth.clustered_vcf, ClusterPESR_manta.clustered_vcf, ClusterPESR_wham.clustered_vcf, ClusterPESR_melt.clustered_vcf, ClusterPESR_scramble.clustered_vcf]),
       N_IQR_cutoff = outlier_cutoff_nIQR,
       sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_count_svs = runtime_attr_count_svs,


### PR DESCRIPTION
The plots will be used for removing outliers before training the random forest model. This is the first step in resolving the issue #44.