### PR TITLE
Update BenchmarkGqFilter to pass miniwdl validation

### DIFF
--- a/wdl/BenchmarkGqFilter.wdl
+++ b/wdl/BenchmarkGqFilter.wdl
@@ -147,7 +147,6 @@ task BenchmarkFilter {
 
     String scores_data_json = "scores_data.json"
     String benchmark_figure_filename = "quality-benchmark.pdf"
-    String args_str = if length(benchmark_args) > 0 then "~{sep=' ' benchmark_args}" else ""
 
     runtime {
         docker: sv_utils_docker
@@ -192,7 +191,7 @@ task BenchmarkFilter {
             --ped-file ~{ped_file} \
             --scores-data-json ~{scores_data_json} \
             --figure-save-file ~{benchmark_figure_filename} \
-            ~{args_str}
+            ~{sep=' ' benchmark_args}
     >>>
 
     output {

--- a/wdl/BenchmarkGqFilter.wdl
+++ b/wdl/BenchmarkGqFilter.wdl
@@ -162,25 +162,25 @@ task BenchmarkFilter {
         set -euo pipefail
 
         # transform scores_data_sets into input format expected by benchmark_variant_filter
-        python - <<'____EoF'
-import json
-with open("~{write_json(scores_data_sets)}", 'r') as f_in:
-  input_json = json.load(f_in)
-output_json={
-  "~{data_label}" : {
-    "vcf" : "~{variant_properties}",
-    "scores_source": {
-      scores_source["label"] : {
-        key: value for key, value in scores_source.items()
-        if key != "label"
-      }
-      for scores_source in input_json
-    }
-  }
-}
-with open("~{scores_data_json}", 'w') as f_out:
-  json.dump(output_json, f_out, indent=2)
-____EoF
+        python <<CODE
+        import json
+        with open("~{write_json(scores_data_sets)}", 'r') as f_in:
+          input_json = json.load(f_in)
+        output_json={
+          "~{data_label}" : {
+            "vcf" : "~{variant_properties}",
+            "scores_source": {
+              scores_source["label"] : {
+                key: value for key, value in scores_source.items()
+                if key != "label"
+              }
+              for scores_source in input_json
+            }
+          }
+        }
+        with open("~{scores_data_json}", 'w') as f_out:
+          json.dump(output_json, f_out, indent=2)
+        CODE
 
         # just for debugging:
         echo "~{scores_data_json}:"


### PR DESCRIPTION
Miniwdl complains about how `args_str` is defined and used; the simplest solution to me was to pass the array of arguments to the task and concatenate them in the script, instead of joining at wdl level. 

I am also changing the inline python code definition to match the more commonly used style in the pipeline.