### PR TITLE
Tb main vcf qc rename samples

### DIFF
--- a/inputs/templates/test/MainVcfQc/MainVcfQc.per_sample_benchmark.json.tmpl
+++ b/inputs/templates/test/MainVcfQc/MainVcfQc.per_sample_benchmark.json.tmpl
@@ -7,15 +7,27 @@
     {{ reference_resources.hgsv_byrska_bishop_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.thousand_genomes_site_level_benchmarking_dataset | tojson }}
   ],
+  "MainVcfQc.sample_level_comparison_datasets": [
+    {{ reference_resources.hgsv_byrska_bishop_sample_level_benchmarking_dataset | tojson }}
+  ],
+  "MainVcfQc.sample_renaming_tsv": {{ reference_resources.hgsv_byrska_bishop_sample_renaming_tsv | tojson }},
+
   "MainVcfQc.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
   "MainVcfQc.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
   "MainVcfQc.sv_pipeline_qc_docker": {{ dockers.sv_pipeline_qc_docker | tojson }},
 
-  "MainVcfQc.prefix": {{ test_batch.name | tojson }},
-  "MainVcfQc.ped_file": {{ test_batch.ped_file | tojson }},
+  "MainVcfQc.prefix": "HGDP_and_HGSV",
+  "MainVcfQc.ped_file": {{ test_batch.hgdp_1kgp_ped | tojson }},
 
-  "MainVcfQc.vcfs": [ {{ test_batch.clean_vcf | tojson }} ],
-
+  "MainVcfQc.vcfs": [ {{ test_batch.gq_filtered_vcf | tojson }} ],
   "MainVcfQc.sv_per_shard": 2500,
-  "MainVcfQc.samples_per_shard": 600
+  "MainVcfQc.samples_per_shard": 600,
+  "MainVcfQc.runtime_override_per_sample_benchmark_plot": {
+    "mem_gb": 30,
+    "disk_gb": 50
+  },
+  "MainVcfQc.runtime_override_plot_qc_per_family": {
+    "mem_gb": 15,
+    "disk_gb": 100
+  }
 }

--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -16,7 +16,7 @@
   "sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2022-09-13-v0.25.1-beta-f6d0c4da",
   "sv_pipeline_hail_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2022-09-13-v0.25.1-beta-f6d0c4da",
   "sv_pipeline_updates_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2022-09-13-v0.25.1-beta-f6d0c4da",
-  "sv_pipeline_qc_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2022-09-13-v0.25.1-beta-f6d0c4da",
+  "sv_pipeline_qc_docker": "us.gcr.io/broad-dsde-methods/tbrookin/sv-pipeline:0a4ac93",
   "sv_pipeline_rdtest_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2022-09-13-v0.25.1-beta-f6d0c4da",
   "wham_docker": "us.gcr.io/broad-dsde-methods/wham:8645aa",
   "igv_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/igv:mw-xz-fixes-2-b1be6a9",

--- a/inputs/values/ref_panel_1kg.json
+++ b/inputs/values/ref_panel_1kg.json
@@ -1115,6 +1115,9 @@
     ],
     "clean_vcf": "gs://gatk-sv-ref-panel-1kg/outputs/MakeCohortVcf/8a209488-c928-449d-92cd-0a5131e92b7c/call-CleanVcf/CleanVcf/277f3f25-bb99-4fe4-a48b-567fd3f344f9/call-ConcatCleanedVcfs/ref_panel_1kg.cleaned.vcf.gz",
     "clean_vcf_index": "gs://gatk-sv-ref-panel-1kg/outputs/MakeCohortVcf/8a209488-c928-449d-92cd-0a5131e92b7c/call-CleanVcf/CleanVcf/277f3f25-bb99-4fe4-a48b-567fd3f344f9/call-ConcatCleanedVcfs/ref_panel_1kg.cleaned.vcf.gz.tbi",
+    "gq_filtered_vcf": "gs://gatk-sv-ref-panel-1kg/outputs/qg_filter/hgdp_and_hgsv.cleaned_fixed_annotated_gq_recalibrated.vcf.gz",
+    "gq_filtered_vcf_index": "gs://gatk-sv-ref-panel-1kg/outputs/qg_filter/hgdp_and_hgsv.cleaned_fixed_annotated_gq_recalibrated.vcf.gz.tbi",
+    "hgdp_1kgp_ped": "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/HGDP_1KGP.ped",
     "cohort_depth_vcf": "gs://gatk-sv-ref-panel-1kg/outputs/GATKSVPipelineBatch/38c65ca4-2a07-4805-86b6-214696075fef/call-GATKSVPipelinePhase1/GATKSVPipelinePhase1/acce2c71-7458-4205-ae13-624f6efc9956/call-FilterBatch/FilterBatch/184defa3-e61c-4757-9962-f685f6d0d204/call-FilterBatchSamples/FilterBatchSamples/b308c32e-d171-4d8d-aeaf-b561c55b06b4/call-ExcludeOutliers/shard-4/cacheCopy/ref_panel_1kg.depth.outliers_removed.vcf.gz",
     "cohort_pesr_vcf": "gs://gatk-sv-ref-panel-1kg/outputs/GATKSVPipelineBatch/38c65ca4-2a07-4805-86b6-214696075fef/call-GATKSVPipelinePhase1/GATKSVPipelinePhase1/acce2c71-7458-4205-ae13-624f6efc9956/call-FilterBatch/FilterBatch/184defa3-e61c-4757-9962-f685f6d0d204/call-FilterBatchSamples/FilterBatchSamples/b308c32e-d171-4d8d-aeaf-b561c55b06b4/call-MergePesrVcfs/cacheCopy/ref_panel_1kg.filtered_pesr_merged.vcf.gz",
     "contig_ploidy_model_tar": "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v2/gcnv/ref_panel_1kg_v2-contig-ploidy-model.tar.gz",
@@ -2236,6 +2239,7 @@
     "name": "ref_panel_1kg",
     "outlier_cutoff_table": "gs://gatk-sv-resources-public/hg38/v0/sv-resources/ref-panel/1KG/v1/module03_outlier_cutoff_table.tsv",
     "ped_file": "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/ref-panel/1KG/v1/ped/1kg_ref_panel_v1.ped",
+
     "qc_definitions": "gs://gatk-sv-ref-panel-1kg/outputs/GATKSVPipelineBatch/38c65ca4-2a07-4805-86b6-214696075fef/ref_panel_1kg.qc_definitions.tsv",
     "qc_file": "gs://gatk-sv-ref-panel-1kg/outputs/GATKSVPipelineBatch/38c65ca4-2a07-4805-86b6-214696075fef/sv_qc.ref_panel_1kg.tsv",
     "raw_sr_background_fail_file": "gs://gatk-sv-ref-panel-1kg/outputs/GATKSVPipelineBatch/38c65ca4-2a07-4805-86b6-214696075fef/call-GenotypeBatch/GenotypeBatch/ad17f522-0950-4f0a-9148-a13f689082ed/call-GenotypePESRPart2/GenotypePESRPart2/ce1f4075-1a3e-44b5-9cfe-bfb701327616/call-TripleStreamCatFail/cacheCopy/ref_panel_1kg.genotype_SR_part2_background_fail.txt",

--- a/inputs/values/resources_hg38.json
+++ b/inputs/values/resources_hg38.json
@@ -43,6 +43,7 @@
   "gnomad_v2_collins_sample_level_benchmarking_dataset": ["gnomAD_v2_Collins", "gs://gatk-sv-resources-secure/hg38/v0/sv-resources/resources/v1/gnomAD_v2_Collins_perSample.tar.gz"],
   "gnomad_v2_collins_site_level_benchmarking_dataset" : ["gnomAD_v2_Collins", "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/gnomAD_v2_Collins"],
   "hgsv_byrska_bishop_sample_level_benchmarking_dataset": ["HGSV_ByrskaBishop", "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/HGSV_ByrskaBishop_GATKSV_perSample.tar.gz"],
+  "hgsv_byrska_bishop_sample_renaming_tsv": "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/rename_sample_ids_HGSV_ByrskaBishop.tsv",
   "hgsv_byrska_bishop_site_level_benchmarking_dataset" : ["HGSV_ByrskaBishop", "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/HGSV_ByrskaBishop_GATKSV"],
   "hgsv_ebert_sample_level_benchmarking_dataset": ["HGSV_Ebert", "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/HGSV_Ebert_perSample.tar.gz"],
   "ssc_belyeu_sample_level_benchmarking_dataset": ["SSC_Belyeu", "gs://gatk-sv-resources-secure/resources/hg38_benchmarking/SSC_Belyeu_perSample.tar.gz"],

--- a/scripts/inputs/get_rename_benchmark_samples_map.py
+++ b/scripts/inputs/get_rename_benchmark_samples_map.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import warnings
+import argparse
+import tarfile
+import pysam
+import numpy
+from typing import List, Text, Dict, Mapping, Iterable, Iterator, Callable, Tuple
+
+# define type for function that matches sample IDs between cohort VCF and benchmark tar file
+SampleIdMatcher = Callable[[List[str], List[str]], Iterator[Tuple[str, str]]]
+
+
+def __parse_arguments(argv: List[Text]) -> argparse.Namespace:
+
+    # noinspection PyTypeChecker
+    parser = argparse.ArgumentParser(
+        description="Get TSV file with mapping from sample IDs in external benchmarking set to corresponding sample IDs"
+                    "in cohort VCF",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        prog=argv[0]
+    )
+    parser.add_argument("benchmark_tar", type=str, help="Tar file with bed files used for per-sample benchmarking")
+    parser.add_argument("cohort_vcf", type=str, help="Cohort VCF to be used in MainVcfQc")
+    parser.add_argument("save_tsv_file", type=str, help="File to save samples map in TSV format")
+
+    parsed_arguments = parser.parse_args(argv[1:] if len(argv) > 1 else ["--help"])
+    return parsed_arguments
+
+
+def match_benchmark_contains_vcf_case_insensitive(
+        benchmark_sample_ids: Iterable[str], vcf_sample_ids: Iterable[str],
+) -> Iterator[Tuple[str, str]]:
+    """ SampleIdMatcher that assumes benchmark sample IDs contain VCF sample IDs, possibly in a different case """
+    def _make_searchable(_sample_ids: Iterable[str]) -> (List[str], List[str]):
+        # given iterable of sample IDs, make version that is searchable (lower-case, with underscores removed), and sort
+        # both the searchable sample IDs and originals according to the order of the searchable list
+        return zip(
+            *sorted([(_sample_id, _sample_id.lower().strip('_')) for _sample_id in _sample_ids],
+                    key=lambda tup: tup[1])
+        )
+    benchmark_sample_ids, searchable_benchmark_ids = _make_searchable(benchmark_sample_ids)
+    vcf_sample_ids, searchable_vcf_sample_ids = _make_searchable(vcf_sample_ids)
+    for vcf_ind, (benchmark_ind, searchable_benchmark_id) in zip(
+            numpy.searchsorted(searchable_vcf_sample_ids, searchable_benchmark_ids, side="left"),
+            enumerate(searchable_benchmark_ids)
+    ):
+        if searchable_vcf_sample_ids[vcf_ind] in searchable_benchmark_id:
+            yield benchmark_sample_ids[benchmark_ind], vcf_sample_ids[vcf_ind]
+        elif vcf_ind > 0 and searchable_vcf_sample_ids[vcf_ind - 1] in searchable_benchmark_id:
+            yield benchmark_sample_ids[benchmark_ind], vcf_sample_ids[vcf_ind - 1]
+        else:
+            warnings.warn(f"{searchable_benchmark_id} has no match")
+
+
+def main(arguments: List[str]):
+    """ Get command-line arguments, create map from benchmark sample ID to cohort VCF sample ID, save as TSV """
+    options = __parse_arguments(arguments)
+    samples_map = get_rename_benchmark_samples_map(
+        benchmark_tar=options.benchmark_tar,
+        cohort_vcf=options.cohort_vcf,
+        get_sample_id_matches=match_benchmark_contains_vcf_case_insensitive
+    )
+    save_samples_map_tsv(samples_map=samples_map, save_tsv_file=options.save_tsv_file)
+
+
+def get_rename_benchmark_samples_map(
+        benchmark_tar: str,
+        cohort_vcf: str,
+        get_sample_id_matches: SampleIdMatcher = match_benchmark_contains_vcf_case_insensitive
+) -> Dict[str, str]:
+    """
+    Get mapping from benchmark sample IDs to cohort sample IDs. This function is defined with passable matching function
+    in case future cohort VCFs / benchmark data sets require a different logic.
+    Args:
+        benchmark_tar: str
+            path to tar file with benchmarking BED files
+        cohort_vcf: str
+            path to cohort VCF
+        get_sample_id_matches: SampleIdMatcher (default=match_benchmark_startswith_vcf_lower)
+            Callable that takes list of sample IDs from the benchmark set and a list of sample IDs from the cohort VCF,
+            and yields tuples of matching (benchmark_sample_id, cohort sample_id) pairs
+    Returns:
+        benchmark_samples_map: Dict[str, str]
+            Mapping from benchmark sample ID to corresponding cohort VCF sample ID
+    """
+    benchmark_sample_ids = get_benchmark_sample_ids(benchmark_tar)
+    vcf_sample_ids = get_vcf_sample_ids(cohort_vcf)
+    return {
+        benchmark_id: vcf_id for benchmark_id, vcf_id in get_sample_id_matches(benchmark_sample_ids, vcf_sample_ids)
+    }
+
+
+def get_vcf_sample_ids(vcf: str) -> List[str]:
+    """ Extract sample IDs from VCF """
+    with pysam.VariantFile(vcf, 'r') as f_in:
+        return list(f_in.header.samples)
+
+
+def get_benchmark_sample_ids(benchmark_tar: str) -> List[str]:
+    """ Extract sample IDs from benchmark tar file """
+    return [os.path.basename(bed_file).split('.', 1)[0] for bed_file in get_tar_files(benchmark_tar)
+            if bed_file.endswith(".bed.gz")]
+
+
+def get_tar_files(path_to_tar_file: str) -> List[str]:
+    """ Get contents of tar file """
+    with tarfile.open(path_to_tar_file, 'r') as tar_in:
+        return [tar_info.name for tar_info in tar_in.getmembers()]
+
+
+def save_samples_map_tsv(
+        samples_map: Mapping[str, str],
+        save_tsv_file: str
+):
+    """ Save mapping from benchmark sample ID to cohort sample ID in TSV format """
+    with open(save_tsv_file, 'w') as f_out:
+        for benchmark_sample_id, vcf_sample_id in samples_map.items():
+            f_out.write(f"{benchmark_sample_id}\t{vcf_sample_id}\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/src/sv-pipeline/scripts/vcf_qc/collectQC.perSample_benchmarking.sh
+++ b/src/sv-pipeline/scripts/vcf_qc/collectQC.perSample_benchmarking.sh
@@ -154,15 +154,15 @@ while read ID; do
   VIDlist=$( find ${OVRTMP}/persamp/ -name "${ID}.VIDs_genotypes.txt.gz" )
   if [ ! -z ${VIDlist} ] && [ -s ${VIDlist} ]; then
     echo $ID
-    zcat ${VCFSTATS} | head -n1 > \
-    ${OVRTMP}/SET1_calls/${ID}.SET1.SV_calls.bed
-    zcat ${VIDlist} | cut -f1 | fgrep -wf - <( zcat ${VCFSTATS} ) >> \
-    ${OVRTMP}/SET1_calls/${ID}.SET1.SV_calls.bed
+    zcat ${VCFSTATS} | head -n1 > ${OVRTMP}/SET1_calls/${ID}.SET1.SV_calls.bed
+    zcat ${VIDlist} | cut -f1 | fgrep -wf - <( zcat ${VCFSTATS} ) >> ${OVRTMP}/SET1_calls/${ID}.SET1.SV_calls.bed
     bgzip -f ${OVRTMP}/SET1_calls/${ID}.SET1.SV_calls.bed
+    rm -f ${OVRTMP}/SET1_calls/${ID}.SET1.SV_calls.bed
     tabix -f ${OVRTMP}/SET1_calls/${ID}.SET1.SV_calls.bed.gz
   fi
 done < ${SAMPLES}
 tar -czvf ${OVRTMP}/SET1_calls.tar.gz ${OVRTMP}/SET1_calls
+rm -rf ${OVRTMP}/SET1_calls
 
 
 ###RUN COMPARISONS

--- a/src/sv-pipeline/scripts/vcf_qc/compare_callsets.sh
+++ b/src/sv-pipeline/scripts/vcf_qc/compare_callsets.sh
@@ -94,11 +94,11 @@ elif ! [ -s ${SET2} ]; then
 fi
 #Check for required list of contigs
 if [ -z ${CONTIGS} ]; then
-  echo -e "\ncompare_callsets_perSample.sh ERROR: input contig list not specified\n"
+  echo -e "\ncompare_callsets.sh ERROR: input contig list not specified\n"
   usage
   exit 1
 elif ! [ -s ${CONTIGS} ]; then
-  echo -e "\ncompare_callsets_perSample.sh ERROR: input contig list either empty or not found\n"
+  echo -e "\ncompare_callsets.sh ERROR: input contig list either empty or not found\n"
   usage
   exit 1
 fi

--- a/src/sv_utils/src/sv_utils/benchmark_variant_filter.py
+++ b/src/sv_utils/src/sv_utils/benchmark_variant_filter.py
@@ -2343,6 +2343,7 @@ def get_filter_quality_figures(
             sv_selectors=sv_selectors,
             best_thresholds=best_thresholds,
             num_inheritance_stats_rows=num_inheritance_stats_rows,
+
             title_font_size=title_font_size,
             label_font_size=label_font_size,
             legend_font_size=legend_font_size,

--- a/wdl/CollectPerSampleBenchmarking.wdl
+++ b/wdl/CollectPerSampleBenchmarking.wdl
@@ -9,6 +9,7 @@ workflow CollectPerSampleBenchmarking {
     File samples_list
     File per_sample_tarball
     File comparison_tarball
+    File? sample_renaming_tsv
     String prefix
     Array[String] contigs
     String comparison_set_name
@@ -29,6 +30,17 @@ workflow CollectPerSampleBenchmarking {
 
   String output_prefix = "~{prefix}.sample_benchmark"
 
+  if(defined(sample_renaming_tsv)) {
+    # rename samples in external benchmarking data
+    call RenameBenchmarkTarfileSamples {
+      input:
+        benchmark_tarfile=comparison_tarball,
+        sample_renaming_tsv=select_first([sample_renaming_tsv]),
+        sv_base_mini_docker=sv_base_mini_docker
+    }
+  }
+  File comparison_tarball_=select_first([RenameBenchmarkTarfileSamples.benchmark_renamed_samples, comparison_tarball])
+
   call MiniTasks.SplitUncompressed as SplitShuffledList {
       input:
         whole_file=samples_list,
@@ -47,7 +59,7 @@ workflow CollectPerSampleBenchmarking {
         vcf_stats=vcf_stats,
         samples_list=sublist,
         per_sample_tarball=per_sample_tarball,
-        comparison_tarball=comparison_tarball,
+        comparison_tarball=comparison_tarball_,
         prefix=output_prefix,
         contigs=contigs,
         comparison_set_name=comparison_set_name,
@@ -67,6 +79,81 @@ workflow CollectPerSampleBenchmarking {
   # Return tarball of results
   output {
     File benchmarking_results_tarball = MergeTarredResults.tarball
+  }
+}
+
+
+# rename samples in comparison benchmark to match the cohort VCF
+task RenameBenchmarkTarfileSamples {
+  input {
+    File benchmark_tarfile
+    File sample_renaming_tsv  # TSV file with original sample IDs in 1st column, and desired sample IDs in 2nd column
+    String sv_base_mini_docker
+    String renamed_suffix = "renamed_samples"
+    RuntimeAttr? runtime_attr_override
+  }
+
+  String benchmark_renamed_samples_filename = basename(benchmark_tarfile, ".tar.gz") + "_~{renamed_suffix}.tar.gz"
+
+  # Disk must be scaled proportionally to the size of the archive. Since the archive contains compressed files, the
+  # extracted files should be sized comparably to the archive
+  Float input_size = size(benchmark_tarfile, "GiB")
+  RuntimeAttr default_attr = object {
+    mem_gb: 2.0,
+    disk_gb: ceil(10.0 + 3 * input_size),
+    cpu_cores: 1,
+    preemptible_tries: 3,
+    max_retries: 1,
+    boot_disk_gb: 10
+  }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+  command <<<
+    set -euo pipefail
+    # find the folder the benchmark tarfile will extract to
+    ARCHIVE_DIR=$(basename $(tar --list -f "~{benchmark_tarfile}" | head -n1))
+    # extrct archive
+    tar -xf "~{benchmark_tarfile}"
+
+    # define function to rename the sample IDs
+    function rename_file() {
+      filename=$1
+      original_id=$2
+      renamed_id=$3
+      if [ "$original_id" != "$renamed_id" ]; then
+        new_filename=$(echo "$filename" | sed "s/$original_id/$renamed_id/")
+        mv "$filename" "$new_filename"
+      fi
+    }
+    export -f rename_file
+
+    # loop over sample IDs to rename and do the renaming
+    cd "$ARCHIVE_DIR"
+    while read ORIGINAL_SAMPLE_ID RENAMED_SAMPLE_ID; do
+      find . -name "$ORIGINAL_SAMPLE_ID.*.bed.gz*" \
+        | xargs -I{} bash -c "rename_file {} $ORIGINAL_SAMPLE_ID $RENAMED_SAMPLE_ID"
+    done < "~{sample_renaming_tsv}"
+    cd ..
+
+    # archive the new files
+    tar cz -f "~{benchmark_renamed_samples_filename}" "$ARCHIVE_DIR"
+
+    # remove the unarchived files (in case this is being run in local mode)
+    rm -r "$ARCHIVE_DIR"
+  >>>
+
+  output {
+    File benchmark_renamed_samples = benchmark_renamed_samples_filename
+  }
+
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: sv_base_mini_docker
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }
 }
 
@@ -91,7 +178,7 @@ task BenchmarkSamples {
   Float input_size = size([vcf_stats, samples_list, per_sample_tarball, comparison_tarball], "GiB")
   RuntimeAttr runtime_default = object {
     mem_gb: 3.75,
-    disk_gb: ceil(10.0 + input_size * 3.5),
+    disk_gb: ceil(10.0 + input_size * 15),
     cpu_cores: 1,
     preemptible_tries: 3,
     max_retries: 1,

--- a/wdl/FilterBatchQc.wdl
+++ b/wdl/FilterBatchQc.wdl
@@ -21,6 +21,7 @@ workflow FilterBatchQc {
     File ped_file
     Array[Array[String]]? site_level_comparison_datasets    # Array of two-element arrays, one per dataset, each of format [prefix, gs:// path to directory with one BED per population]
     Array[Array[String]]? sample_level_comparison_datasets  # Array of two-element arrays, one per dataset, each of format [prefix, gs:// path to per-sample tarballs]
+    File? sample_renaming_tsv # File with mapping to rename sample IDs for compatibility with sample_level_comparison_datasets
 
     File contig_list
     Int? random_seed
@@ -102,6 +103,7 @@ workflow FilterBatchQc {
           samples_per_shard=600,
           site_level_comparison_datasets=site_level_comparison_datasets,
           sample_level_comparison_datasets=sample_level_comparison_datasets,
+          sample_renaming_tsv=sample_renaming_tsv,
           primary_contigs_fai=contig_list,
           random_seed=random_seed,
           max_gq=max_gq_,

--- a/wdl/MakeCohortVcf.wdl
+++ b/wdl/MakeCohortVcf.wdl
@@ -64,6 +64,7 @@ workflow MakeCohortVcf {
 
     Array[Array[String]]? site_level_comparison_datasets    # Array of two-element arrays, one per dataset, each of format [prefix, gs:// path to directory with one BED per population]
     Array[Array[String]]? sample_level_comparison_datasets  # Array of two-element arrays, one per dataset, each of format [prefix, gs:// path to per-sample tarballs]
+    File? sample_renaming_tsv # File with mapping to rename sample IDs for compatibility with sample_level_comparison_datasets
 
     # Module metrics parameters
     # Run module metrics workflow at the end - on by default
@@ -459,6 +460,7 @@ workflow MakeCohortVcf {
       samples_per_shard=600,
       site_level_comparison_datasets=site_level_comparison_datasets,
       sample_level_comparison_datasets=sample_level_comparison_datasets,
+      sample_renaming_tsv=sample_renaming_tsv,
       primary_contigs_fai=contig_list,
       random_seed=random_seed,
       sv_pipeline_qc_docker=sv_pipeline_qc_docker,

--- a/wdl/TasksMakeCohortVcf.wdl
+++ b/wdl/TasksMakeCohortVcf.wdl
@@ -991,14 +991,14 @@ task ScatterVcf {
   command <<<
     set -euo pipefail
     # in case the file is empty create an empty shard
-    bcftools view -h ~{vcf} | bgzip -c > ~{prefix}.0.vcf.gz
-    bcftools +scatter ~{vcf} -o . -O z -p ~{prefix}. --threads ~{threads} -n ~{records_per_shard} ~{"-r " + contig}
+    bcftools view -h ~{vcf} | bgzip -c > "~{prefix}.0.vcf.gz"
+    bcftools +scatter ~{vcf} -o . -O z -p "~{prefix}". --threads ~{threads} -n ~{records_per_shard} ~{"-r " + contig}
 
-    ls ~{prefix}.*.vcf.gz | sort -k1,1V > vcfs.list
+    ls "~{prefix}".*.vcf.gz | sort -k1,1V > vcfs.list
     i=0
-    while read vcf; do
+    while read VCF; do
       shard_no=`printf %06d $i`
-      mv ${vcf} ~{prefix}.shard_${shard_no}.vcf.gz
+      mv "$VCF" "~{prefix}.shard_${shard_no}.vcf.gz"
       i=$((i+1))
     done < vcfs.list
   >>>


### PR DESCRIPTION
Add utility to optionally rename input VCF sample IDs to conform to comparison data set.