### PR TITLE
Improve EH JSON to TSV conversion when the JSON is missing LocusResults

### DIFF
--- a/src/str/combine_expansion_hunter_json_to_tsv.py
+++ b/src/str/combine_expansion_hunter_json_to_tsv.py
@@ -106,7 +106,7 @@ def main():
     if args.sample_metadata:
         sample_metadata_df = pd.read_table(args.sample_metadata)
         sample_id_column_idx = get_sample_id_column_index(sample_metadata_df, column_name=args.sample_metadata_key)
-        if sample_id_column_idx is -1:
+        if sample_id_column_idx == -1:
             raise ValueError(f"'sample_id' column not found in sample metadata table. The columns found were: {sample_metadata_df.columns}")
         sample_id_column = sample_metadata_df.columns[sample_id_column_idx]
         for _, row in sample_metadata_df.iterrows():

--- a/src/str/combine_expansion_hunter_json_to_tsv.py
+++ b/src/str/combine_expansion_hunter_json_to_tsv.py
@@ -21,7 +21,7 @@ MISSING_LOCUS_RESULTS_WARNING_MESSAGE = \
     "Rerunning EH with a correct value of `--sex` argument may fix this issue. " \
     "Another issue could be running ExpansionHunter on female samples with a variant " \
     "catalog that only contains sites on ChrY; or in more general sense, running " \
-    "ExpansionHunter on a sample that contains no reads on none of the chromosomes " \
+    "ExpansionHunter on a sample that contains no reads on any of the chromosomes " \
     "specified in the variant catalog (e.g., the sample only contains reads on Chr1 " \
     "while variant catalog contains sites on Chr2 only)."
 

--- a/src/str/combine_json_to_tsv.py
+++ b/src/str/combine_json_to_tsv.py
@@ -167,11 +167,11 @@ def join_with_sample_metadata(df, df_sample_id_columns, sample_metadata_df, samp
         pandas.DataFrame: The DataFrame resulting from a LEFT join between df and sample_metadata_df
     """
     sample_id_column_idx1 = get_sample_id_column_index(df, column_name=df_sample_id_columns)
-    if sample_id_column_idx1 is -1:
+    if sample_id_column_idx1 == -1:
         raise ValueError(f"'sample_id' field not found in json files. The fields found were: {df.columns}")
 
     sample_id_column_idx2 = get_sample_id_column_index(sample_metadata_df, column_name=sample_metadata_df_sample_id_column)
-    if sample_id_column_idx2 is -1:
+    if sample_id_column_idx2 == -1:
         raise ValueError(f"'sample_id' column not found in sample metadata table. The columns found were: {sample_metadata_df.columns}")
 
     sample_id_column1 = df.columns[sample_id_column_idx1]


### PR DESCRIPTION
There are a few cases where ExpansionHunter (EH) may generate a JSON file that is missing the `LocusResults` key (see the following JSON file as an example). In general, this can happen when EH cannot process _any of the sites_ in the provided variant catalog, and one possible case is when the site is defined on a chromosome which the sample does not contain (e.g., asking for sites on `chrY` while studying female samples).

```json
{
  "SampleParameters": {
    "SampleId": "NA19238.final",
    "Sex": "Female"
  }
}
```

EH logs every site that it cannot process as the following, and if it fails on _all the sites_ specified in the variant catalog, then its generated output JSON file will be missing `LocusResults`. 

> Error on locus spec chrY-1377068-1377082-AC: Error loading locus chrY-1377068-1377082-AC: Flanks can contain at most 5 characters N but found 2000 Ns

The lack of `LocusResults` key causes a few corner case errors with the script used to convert JSON to TSV. This PR patches the script to only log a warning for such corner cases instead of the failing. 

PS: a minor correction on checking the value of an integer variable is also PR'd. 
