### PR TITLE
Option to input & subset multi-sample BED in VaPoR (+ womtool fixes)

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/RecalibrateGq.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/RecalibrateGq.json.tmpl
@@ -20,5 +20,6 @@
     "--keep-multiallelic true"
   ],
   "RecalibrateGq.sv_utils_docker": {{ dockers.sv_utils_docker | tojson }},
+  "RecalibrateGq.samtools_cloud_docker": "${workspace.samtools_cloud_docker}",
   "RecalibrateGq.gatk_docker": {{ dockers.gq_recalibrator_docker | tojson }}
 }

--- a/inputs/templates/test/GqRecalibrator/BenchmarkGqFilter.json.tmpl
+++ b/inputs/templates/test/GqRecalibrator/BenchmarkGqFilter.json.tmpl
@@ -16,7 +16,7 @@
       "vcf_index": "gs://broad-dsde-methods-tbrookin/results/gq-filtering/2022-09-05_fixed-gq-bug/hgdp_and_hgsv.cleaned_fixed_annotated_gq_recalibrated.vcf.gz.tbi",
       "property": "sl",
       "passing_score": 1,
-      "pickled_scores_file": "gs://broad-dsde-methods-tbrookin/results/gq-filtering/2022-09-05_fixed-gq-bug/hgdp_and_hgsv.cleaned_fixed_annotated_gq_recalibrated_sl.pickle",
+      "pickled_scores_file": "gs://broad-dsde-methods-tbrookin/results/gq-filtering/2022-09-05_fixed-gq-bug/hgdp_and_hgsv.cleaned_fixed_annotated_gq_recalibrated_sl.pickle"
     },
     {
       "label": "cross-validated",
@@ -24,7 +24,7 @@
       "vcf_index": "gs://broad-dsde-methods-tbrookin/results/gq-filtering/2022-09-05_fixed-gq-bug/hgdp_and_hgsv.cleaned_fixed_annotated_cross_validated.vcf.gz.tbi",
       "property": "sl",
       "passing_score": 1,
-      "pickled_scores_file": "gs://broad-dsde-methods-tbrookin/results/gq-filtering/2022-09-05_fixed-gq-bug/hgdp_and_hgsv.cleaned_fixed_annotated_cross_validated_sl.pickle",
+      "pickled_scores_file": "gs://broad-dsde-methods-tbrookin/results/gq-filtering/2022-09-05_fixed-gq-bug/hgdp_and_hgsv.cleaned_fixed_annotated_cross_validated_sl.pickle"
     },
     {
       "label": "Xuefang",

--- a/inputs/templates/test/GqRecalibrator/RecalibrateGq.json.tmpl
+++ b/inputs/templates/test/GqRecalibrator/RecalibrateGq.json.tmpl
@@ -20,5 +20,6 @@
     "--keep-multiallelic true"
   ],
   "RecalibrateGq.sv_utils_docker": {{ dockers.sv_utils_docker | tojson }},
+  "RecalibrateGq.samtools_cloud_docker": {{ dockers.samtools_cloud_docker | tojson }},
   "RecalibrateGq.gatk_docker": {{ dockers.gq_recalibrator_docker | tojson }}
 }

--- a/wdl/TasksBenchmark.wdl
+++ b/wdl/TasksBenchmark.wdl
@@ -185,10 +185,11 @@ task LocalizeCramRequestPay{
   }
 
 #extract specific contig from vcf
-task SplitBed{
-  input{
+task SplitBed {
+  input {
     String contig
-    File? bed_file
+    String? sample_to_extract
+    File bed_file
     String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
@@ -204,15 +205,15 @@ task SplitBed{
 
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 
-  output{
+  output {
     File contig_bed = "~{contig}.bed"
   }
 
   command <<<
     if [[ ~{bed_file} == *.gz ]] ;  then
-      zcat ~{bed_file} | awk '{if ($1=="~{contig}") print}'  > ~{contig}.bed
+      zcat ~{bed_file} | ~{if defined(sample_to_extract) then "grep ~{sample_to_extract} | cut -f1-5 |" else ""} awk '{if ($1=="~{contig}") print}'  > ~{contig}.bed
     else
-      awk '{if ($1=="~{contig}") print}' ~{bed_file} > ~{contig}.bed
+      ~{if defined(sample_to_extract) then "grep ~{sample_to_extract} | cut -f1-5 |" else ""} awk '{if ($1=="~{contig}") print}' ~{bed_file} > ~{contig}.bed
     fi
   >>>
 
@@ -226,11 +227,12 @@ task SplitBed{
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }
 
-  }
-task SplitVcf{
-  input{
+}
+
+task SplitVcf {
+  input {
     String contig
-    File? vcf_file
+    File vcf_file
     String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
@@ -273,10 +275,10 @@ task SplitVcf{
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }
-  }
+}
 
-task vcf2bed{
-  input{
+task vcf2bed {
+  input {
     File vcf
     File? vcf_index
     String sv_pipeline_docker
@@ -326,7 +328,7 @@ task vcf2bed{
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }
-  }
+}
 
 
 

--- a/wdl/VaPoR.wdl
+++ b/wdl/VaPoR.wdl
@@ -12,6 +12,7 @@ workflow VaPoR {
         String bam_or_cram_index
         File? vcf_file
         File? bed_file
+        String? sample_to_extract_from_bed
         File ref_fasta
         File ref_fai
         File ref_dict
@@ -32,7 +33,7 @@ workflow VaPoR {
                 prefix = prefix,
                 bam_or_cram_file = bam_or_cram_file,
                 bam_or_cram_index = bam_or_cram_index,
-                vcf_file = vcf_file,
+                vcf_file = select_first([vcf_file]),
                 ref_fasta = ref_fasta,
                 ref_fai = ref_fai,
                 ref_dict = ref_dict,
@@ -54,7 +55,8 @@ workflow VaPoR {
                 prefix = prefix,
                 bam_or_cram_file = bam_or_cram_file,
                 bam_or_cram_index = bam_or_cram_index,
-                bed_file = bed_file,
+                bed_file = select_first([bed_file]),
+                sample_to_extract = sample_to_extract_from_bed,
                 ref_fasta = ref_fasta,
                 ref_fai = ref_fai,
                 ref_dict = ref_dict,

--- a/wdl/VaPoR.wdl
+++ b/wdl/VaPoR.wdl
@@ -12,7 +12,7 @@ workflow VaPoR {
         String bam_or_cram_index
         File? vcf_file
         File? bed_file
-        String? sample_to_extract_from_bed
+        String? sample_to_extract_from_bed  # provide sample ID to extact if bed_file contains multiple samples
         File ref_fasta
         File ref_fai
         File ref_dict

--- a/wdl/VaPoRBedPerContig.wdl
+++ b/wdl/VaPoRBedPerContig.wdl
@@ -8,7 +8,8 @@ workflow VaPoRBed {
     String prefix
     String bam_or_cram_file
     String bam_or_cram_index
-    File? bed_file
+    File bed_file
+    String? sample_to_extract
     File ref_fasta
     File ref_fai
     File ref_dict
@@ -29,6 +30,7 @@ workflow VaPoRBed {
     call tasks10.SplitBed as SplitBed{
       input:
         contig = contig,
+        sample_to_extract = sample_to_extract,
         bed_file = bed_file,
         sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override=runtime_attr_SplitVcf

--- a/wdl/VaPoRVcf.wdl
+++ b/wdl/VaPoRVcf.wdl
@@ -8,7 +8,7 @@ workflow VaPoRVcf {
     String prefix
     String bam_or_cram_file
     String bam_or_cram_index
-    File? vcf_file
+    File vcf_file
     File ref_fasta
     File ref_fai
     File ref_dict


### PR DESCRIPTION
### Updates
* Option to provide multi-sample instead of single-sample BED file for VaPoR input - users should then provide a sample ID to extract from the multi-sample BED file before the VaPoR tool is invoked. Allows users to use the cohort-wide BED file produced by MainVcfQc directly
* Style edits in VaPoR WDLs: spacing, make VCF / BED file required in file-specific WDLs
* Various womtool fixes to get validation to run with validation script (tested with womtool-80)

### Testing
* Womtool validation of all WDLs and JSONs
* Tested VaPoR on Terra with multi-sample BED file + sample ID to extract
* Tested VaPoR on Terra with single-sample BED file - output identical to previous master