### PR TITLE
Set disk to at least 10 gb in VaPoR tasks

### DIFF
--- a/wdl/TasksBenchmark.wdl
+++ b/wdl/TasksBenchmark.wdl
@@ -20,11 +20,9 @@ task ConcatVaPoR {
   # be held in memory or disk while working, potentially in a form that takes up more space)
   Float input_size = size(shard_bed_files, "GB")
   Float compression_factor = 5.0
-  Float base_disk_gb = 5.0
-  Float base_mem_gb = 2.0
   RuntimeAttr runtime_default = object {
-                                  mem_gb: base_mem_gb + compression_factor * input_size,
-                                  disk_gb: ceil(base_disk_gb + input_size * (2.0 + compression_factor)),
+                                  mem_gb: 2.0 + compression_factor * input_size,
+                                  disk_gb: ceil(10.0 + input_size * (2.0 + compression_factor)),
                                   cpu_cores: 1,
                                   preemptible_tries: 3,
                                   max_retries: 1,
@@ -81,7 +79,7 @@ task ConcatVaPoR {
 
 #localize a specific contig of a bam/cram file
 task LocalizeCram {
-  input{
+  input {
     String contig
     File ref_fasta
     File ref_fai
@@ -105,7 +103,7 @@ task LocalizeCram {
   Float mem_gb = select_first([runtime_attr.mem_gb, default_attr.mem_gb])
   Int java_mem_mb = ceil(mem_gb * 1000 * 0.8)
 
-  output{
+  output {
     File local_bam = "~{contig}.bam"
     File local_bai = "~{contig}.bam.bai"
   }
@@ -129,10 +127,10 @@ task LocalizeCram {
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }
-  }
+}
 
-task LocalizeCramRequestPay{
-  input{
+task LocalizeCramRequestPay {
+  input {
     String contig
     File ref_fasta
     File ref_fai
@@ -182,7 +180,7 @@ task LocalizeCramRequestPay{
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }
-  }
+}
 
 #extract specific contig from vcf
 task SplitBed {

--- a/wdl/VaPoR.wdl
+++ b/wdl/VaPoR.wdl
@@ -71,7 +71,7 @@ workflow VaPoR {
                 runtime_attr_ConcatBeds = runtime_attr_ConcatBeds
         }
     }
-    output{
+    output {
             File? vcf_out = VaPoR_vcf.bed
             File? bed_out = VaPoR_bed.bed
             File? vcf_plots = VaPoR_vcf.plots

--- a/wdl/VaPoRBedPerContig.wdl
+++ b/wdl/VaPoRBedPerContig.wdl
@@ -69,8 +69,8 @@ workflow VaPoRBed {
   }
 
 
-task RunVaPoR{
-  input{
+task RunVaPoR {
+  input {
     String prefix
     String contig
     File bam_or_cram_file
@@ -86,7 +86,7 @@ task RunVaPoR{
   RuntimeAttr default_attr = object {
     cpu_cores: 1, 
     mem_gb: 3.75, 
-    disk_gb: 5,
+    disk_gb: 10,
     boot_disk_gb: 10,
     preemptible_tries: 0,
     max_retries: 1
@@ -127,8 +127,8 @@ task RunVaPoR{
   }
 }
 
-task RunVaPoRWithCram{
-  input{
+task RunVaPoRWithCram {
+  input {
     String prefix
     String contig
     String bam_or_cram_file

--- a/wdl/VaPoRVcf.wdl
+++ b/wdl/VaPoRVcf.wdl
@@ -92,7 +92,7 @@ task RunVaPoR{
   RuntimeAttr default_attr = object {
     cpu_cores: 1, 
     mem_gb: 3.75, 
-    disk_gb: 5,
+    disk_gb: 10,
     boot_disk_gb: 10,
     preemptible_tries: 0,
     max_retries: 1


### PR DESCRIPTION
### Updates
* Set disk to at least 10 GB instead of 5 GB for tasks in VaPoR workflow, because of out-of-disk issues as well as slower I/O for disks < 10 GB
* Spacing edits

### Testing
* Samples with out-of-disk failures were able to run successfully when disk was set to 10 GB via runtime attribute overrides
* Validated with womtool
* Did not run any test workflows on this branch since the changes were so small