### PR TITLE
Bits and bobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ The following inputs will need to be updated with the transformed sample IDs:
 * Sample ID list for [GatherSampleEvidence](#gather-sample-evidence) or [GatherBatchEvidence](#gather-batch-evidence)
 * PED file
 
-If using a SNP VCF in [GatherBatchEvidence](#gather-batch-evidence), it does not need to be re-headered; simply provide the `vcf_samples` argument.
-
 
 ## <a name="citation">Citation</a>
 Please cite the following publication:
@@ -180,7 +178,7 @@ Repository structure:
 
 
 ## <a name="cohort-mode">Cohort mode</a>
-A minimum cohort size of 100 with roughly equal number of males and females is recommended. For modest cohorts (~100-500 samples), the pipeline can be run as a single batch using `GATKSVPipelineBatch.wdl`.
+A minimum cohort size of 100 is required, and a roughly equal number of males and females is recommended. For modest cohorts (~100-500 samples), the pipeline can be run as a single batch using `GATKSVPipelineBatch.wdl`.
 
 For larger cohorts, samples should be split up into batches of about 100-500 samples. Refer to the [Batching](#batching) section for further guidance on creating batches.
 
@@ -201,7 +199,7 @@ For larger cohorts, samples should be split up into batches of about 100-500 sam
 
 
 ## <a name="sample-sample-mode">Single-sample mode</a>
-`GATKSVPipelineSingleSample.wdl` runs the pipeline on a single sample using a fixed reference panel. An example run with reference panel containing 156 samples from the [NYGC 1000G Terra workspace](https://app.terra.bio/#workspaces/anvil-datastorage/1000G-high-coverage-2019) can be found in `inputs/build/NA12878/test` after [building inputs](#Building inputs)).
+`GATKSVPipelineSingleSample.wdl` runs the pipeline on a single sample using a fixed reference panel. An example run with reference panel containing 156 samples from the [NYGC 1000G Terra workspace](https://app.terra.bio/#workspaces/anvil-datastorage/1000G-high-coverage-2019) can be found in `inputs/build/NA12878/test` after [building inputs](#building-inputs)).
 
 ## <a name="gcnv-training-overview">gCNV Training</a>
 Both the cohort and single-sample modes use the GATK gCNV depth calling pipeline, which requires a [trained model](#gcnv-training) as input. The samples used for training should be technically homogeneous and similar to the samples to be processed (i.e. same sample type, library prep protocol, sequencer, sequencing center, etc.). The samples to be processed may comprise all or a subset of the training set. For small, relatively homogenous cohorts, a single gCNV model is usually sufficient. If a cohort contains multiple data sources, we recommend training a separate model for each [batch](#batching) or group of batches with similar dosage score (WGD). The model may be trained on all or a subset of the samples to which it will be applied; a reasonable default is 100 randomly-selected samples from the batch (the random selection can be done as part of the workflow by specifying a number of samples to the `n_samples_subsample` input parameter in `/wdl/TrainGCNV.wdl`).
@@ -290,6 +288,7 @@ The purpose of sample filtering at this stage after EvidenceQC is to prevent ver
 * Look at the dosage score (WGD) distribution and check that it is centered around 0 (the distribution of WGD for PCR- samples is expected to be slightly lower than 0, and the distribution of WGD for PCR+ samples is expected to be slightly greater than 0. Refer to the [gnomAD-SV paper](https://doi.org/10.1038/s41586-020-2287-8) for more information on WGD score). Optionally filter outliers.
 * Look at the low outliers for each SV caller (samples with much lower than typical numbers of SV calls per contig for each caller). An empty low outlier file means there were no outliers below the median and no filtering is necessary. Check that no samples had zero calls.
 * Look at the high outliers for each SV caller and optionally filter outliers; samples with many more SV calls than average may be poor quality.
+* Remove samples with autosomal aneuploidies based on the per-batch binned coverage plots of each chromosome.
 
 
 ## <a name="gcnv-training">TrainGCNV</a>
@@ -372,7 +371,7 @@ Generates variant metrics for filtering.
 Filters poor quality variants and filters outlier samples. This workflow can be run all at once with the WDL at `wdl/FilterBatch.wdl`, or it can be run in three steps to enable tuning of outlier filtration cutoffs. The three subworkflows are:
 1. FilterBatchSites: Per-batch variant filtration
 2. PlotSVCountsPerSample: Visualize SV counts per sample per type to help choose an IQR cutoff for outlier filtering, and preview outlier samples for a given cutoff
-3. FilterBatchSamples: Per-batch outlier sample filtration; provide an appropriate `outlier_cutoff_nIQR` based on the SV count plots and outlier previews from step 2.
+3. FilterBatchSamples: Per-batch outlier sample filtration; provide an appropriate `outlier_cutoff_nIQR` based on the SV count plots and outlier previews from step 2. Note that not removing high outliers can result in increased compute cost and a higher false positive rate in later steps.
 
 #### Prerequisites:
 * [GenerateBatchMetrics](#generate-batch-metrics)

--- a/inputs/templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
@@ -63,7 +63,7 @@ The following workflows are included in this workspace, to be executed in this o
 14. `14-ResolveComplexVariants`: Complex variant resolution. Use `14-ResolveComplexVariants_SingleBatch` if you only have one batch.
 15. `15-GenotypeComplexVariants`: Complex variant re-genotyping. Use `15-GenotypeComplexVariants_SingleBatch` if you only have one batch.
 16. `16-CleanVcf`: VCF cleanup. Use `16-CleanVcf_SingleBatch` if you only have one batch.
-17. `17-MasterVcfQc`: Generates VCF QC reports. Use `17-MasterVcfQc_SingleBatch` if you only have one batch.
+17. `17-MainVcfQc`: Generates VCF QC reports. Use `17-MainVcfQc_SingleBatch` if you only have one batch.
 18. `18-AnnotateVcf`: Cohort VCF annotations, including functional annotation, allele frequency (AF) annotation, and AF annotation with external population callsets. Use `18-AnnotateVcf_SingleBatch` if you only have one batch.
 
 Additional downstream modules, such as those for filtering and visualization, are under development. They are not included in this workspace at this time, but the source code can be found in the [GATK-SV GitHub repository](https://github.com/broadinstitute/gatk-sv). See **Downstream steps** towards the bottom of this page for more information.
@@ -86,7 +86,7 @@ There are three modes for this pipeline according to the number of samples you n
 
 #### What is the maximum number of samples the pipeline can handle?
 
-In Terra, we have tested batch sizes of up to 500 samples and cohort sizes of up to 1000 samples. On a separate cromwell server, we have tested the pipeline on cohorts of up to ~140,000 samples, but Terra's metadata handling will likely limit cohort sizes further.
+In Terra, we have tested batch sizes of up to 500 samples and cohort sizes of up to 11,000 samples (and 40,000 samples with the final steps split by chromosome). On a separate cromwell server, we have tested the pipeline on cohorts of up to ~140,000 samples, but Terra's metadata handling will likely limit cohort sizes further.
 
 
 ### Time and cost estimates
@@ -108,12 +108,10 @@ Refer to [the Sample ID Requirements section of the README](https://github.com/b
 
 The same requirements apply to family IDs in the PED file, batch IDs (`sample_set_id`), and the cohort ID (`sample_set_set_id`).
 
-Sample IDs are provided to `01-GatherSampleEvidence` directly and need not match sample names from the BAM/CRAM headers or GVCFs. We recommend transforming sample IDs using [this script](https://github.com/talkowski-lab/gnomad_sv_v3/blob/master/sample_id/convert_sample_ids.py) prior to uploading your sample data table. (Currently, sample IDs can be replaced again in `04-GatherBatchEvidence`.) The following files will need to be updated with the transformed sample IDs:
+Sample IDs are provided to `01-GatherSampleEvidence` directly and need not match sample names from the BAM/CRAM headers. We recommend transforming sample IDs using [this script](https://github.com/talkowski-lab/gnomad_sv_v3/blob/master/sample_id/convert_sample_ids.py) prior to uploading your sample data table. (Currently, sample IDs can be replaced again in `04-GatherBatchEvidence`.) The following files will need to be updated with the transformed sample IDs:
 * Sample data table (for Terra)
 * PED file
 * Sample set membership file (for Terra)
-
-If using a SNP VCF in `04-GatherBatchEvidence`, it does not need to be re-headered; simply provide the `vcf_samples` argument. An easy way to provide these sample IDs is to add a column `vcf_sample_id` to the sample TSV you upload to the workspace (see **Workspace setup** step 2 below), then reference this column as `this.samples.vcf_sample_id` in the `04-GatherBatchEvidence` inputs.
 
 
 ### Workspace setup
@@ -177,6 +175,7 @@ Read the full TrainGCNV documentation [here](https://github.com/broadinstitute/g
 
 Read the full GatherBatchEvidence documentation [here](https://github.com/broadinstitute/gatk-sv#gather-batch-evidence).
 * Use the same `sample_set` definitions you used for `03-TrainGCNV`.
+* Before running this workflow, ensure that you have updated the `cohort_ped_file` attribute in Workspace Data with your cohort's PED file, with sex assignments updated based on ploidy detection from `02-EvidenceQC`.
 
 #### 05-ClusterBatch and 06-GenerateBatchMetrics
 
@@ -206,9 +205,9 @@ Read the full GenotypeBatch documentation [here](https://github.com/broadinstitu
 * Use the same `sample_set` definitions you used for `03-TrainGCNV` through `09-FilterBatchSamples`.
 * If you only have one batch, use the `11-GenotypeBatch_SingleBatch` version of the workflow.
 
-#### 12-RegenotypeCNVs, 13-CombineBatches, 14-ResolveComplexVariants, 15-GenotypeComplexVariants, 16-CleanVcf, 17-MasterVcfQc, and 18-AnnotateVcf
+#### 12-RegenotypeCNVs, 13-CombineBatches, 14-ResolveComplexVariants, 15-GenotypeComplexVariants, 16-CleanVcf, 17-MainVcfQc, and 18-AnnotateVcf
 
-Read the full documentation for [RegenotypeCNVs](https://github.com/broadinstitute/gatk-sv#regenotype-cnvs), [MakeCohortVcf](https://github.com/broadinstitute/gatk-sv#make-cohort-vcf) (which includes `CombineBatches`, `ResolveComplexVariants`, `GenotypeComplexVariants`, `CleanVcf`, `MasterVcfQc`), and [AnnotateVcf](https://github.com/broadinstitute/gatk-sv#annotate-vcf) on the README.
+Read the full documentation for [RegenotypeCNVs](https://github.com/broadinstitute/gatk-sv#regenotype-cnvs), [MakeCohortVcf](https://github.com/broadinstitute/gatk-sv#make-cohort-vcf) (which includes `CombineBatches`, `ResolveComplexVariants`, `GenotypeComplexVariants`, `CleanVcf`, `MainVcfQc`), and [AnnotateVcf](https://github.com/broadinstitute/gatk-sv#annotate-vcf) on the README.
 * For a multi-batch cohort, use the same cohort `sample_set_set` you created and used for `10-MergeBatchSites`.
 * If you only have one batch, use the `[...]_SingleBatch` version of the workflow.
 

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ClusterBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ClusterBatch.json.tmpl
@@ -28,5 +28,5 @@
   "ClusterBatch.manta_vcf_tar": "${this.std_manta_vcf_tar}",
   "ClusterBatch.melt_vcf_tar": "${this.std_melt_vcf_tar}",
   "ClusterBatch.scramble_vcf_tar": "${this.std_scramble_vcf_tar}",
-  "ClusterBatch.ped_file": "${this.cohort_ped_file}"
+  "ClusterBatch.ped_file": "${workspace.cohort_ped_file}"
 }

--- a/inputs/templates/terra_workspaces/single_sample/GATKSVPipelineSingleSample.no_melt.json.tmpl
+++ b/inputs/templates/terra_workspaces/single_sample/GATKSVPipelineSingleSample.no_melt.json.tmpl
@@ -106,8 +106,6 @@
   "GATKSVPipelineSingleSample.annotation_max_shards_per_chrom_step1" : 200,
   "GATKSVPipelineSingleSample.annotation_min_records_per_shard_step1" : 5000,
 
-  "GATKSVPipelineSingleSample.cnmops_mem_gb_override_sample3": 24,
-
   "GATKSVPipelineSingleSample.ref_samples_list" : "${workspace.ref_panel_samples_list}",
   "GATKSVPipelineSingleSample.ref_std_manta_vcf_tar" : "${workspace.ref_panel_std_manta_vcf_tar}",
   "GATKSVPipelineSingleSample.ref_std_wham_vcf_tar" : "${workspace.ref_panel_std_wham_vcf_tar}",

--- a/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.json.tmpl
@@ -105,8 +105,6 @@
   "GATKSVPipelineSingleSample.annotation_max_shards_per_chrom_step1" : 200,
   "GATKSVPipelineSingleSample.annotation_min_records_per_shard_step1" : 5000,
 
-  "GATKSVPipelineSingleSample.cnmops_mem_gb_override_sample3": 24,
-
   "GATKSVPipelineSingleSample.ref_samples_list" : {{ ref_panel.samples_list | tojson }},
   "GATKSVPipelineSingleSample.ref_std_manta_vcf_tar" : {{ ref_panel.std_manta_vcf_tar | tojson }},
   "GATKSVPipelineSingleSample.ref_std_melt_vcf_tar" : {{ ref_panel.std_melt_vcf_tar | tojson }},

--- a/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.no_melt.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.no_melt.json.tmpl
@@ -106,8 +106,6 @@
   "GATKSVPipelineSingleSample.annotation_max_shards_per_chrom_step1" : 200,
   "GATKSVPipelineSingleSample.annotation_min_records_per_shard_step1" : 5000,
 
-  "GATKSVPipelineSingleSample.cnmops_mem_gb_override_sample3": 24,
-
   "GATKSVPipelineSingleSample.ref_samples_list" : {{ ref_panel.samples_list | tojson }},
   "GATKSVPipelineSingleSample.ref_std_manta_vcf_tar" : {{ ref_panel.std_manta_vcf_tar | tojson }},
   "GATKSVPipelineSingleSample.ref_std_wham_vcf_tar" : {{ ref_panel.std_wham_vcf_tar | tojson }},

--- a/wdl/CNMOPS.wdl
+++ b/wdl/CNMOPS.wdl
@@ -21,8 +21,6 @@ workflow CNMOPS {
     String prefix
     Int? min_size
     Boolean? stitch_and_clean_large_events = false
-    Float? mem_gb_override_sample10
-    Float? mem_gb_override_sample3
     String linux_docker
     String sv_pipeline_docker
     String cnmops_docker
@@ -45,7 +43,6 @@ workflow CNMOPS {
         ref_dict = ref_dict,
         bincov_matrix = bincov_matrix,
         bincov_matrix_index = bincov_matrix_index,
-        mem_gb_override = mem_gb_override_sample10,
         cnmops_docker = cnmops_docker,
         runtime_attr_override = runtime_attr_sample10
     }
@@ -60,7 +57,6 @@ workflow CNMOPS {
         ref_dict = ref_dict,
         bincov_matrix = bincov_matrix,
         bincov_matrix_index = bincov_matrix_index,
-        mem_gb_override = mem_gb_override_sample3,
         cnmops_docker = cnmops_docker,
         runtime_attr_override = runtime_attr_sample3
     }
@@ -77,7 +73,6 @@ workflow CNMOPS {
         ref_dict = ref_dict,
         bincov_matrix = bincov_matrix,
         bincov_matrix_index = bincov_matrix_index,
-        mem_gb_override = mem_gb_override_sample10,
         cnmops_docker = cnmops_docker,
         runtime_attr_override = runtime_attr_sample10
     }
@@ -92,7 +87,6 @@ workflow CNMOPS {
         ref_dict = ref_dict,
         bincov_matrix = bincov_matrix,
         bincov_matrix_index = bincov_matrix_index,
-        mem_gb_override = mem_gb_override_sample3,
         cnmops_docker = cnmops_docker,
         runtime_attr_override = runtime_attr_sample3
     }
@@ -108,7 +102,6 @@ workflow CNMOPS {
       ref_dict = ref_dict,
       bincov_matrix = bincov_matrix,
       bincov_matrix_index = bincov_matrix_index,
-      mem_gb_override = mem_gb_override_sample10,
       cnmops_docker = cnmops_docker,
       runtime_attr_override = runtime_attr_sample10
   }
@@ -123,7 +116,6 @@ workflow CNMOPS {
       ref_dict = ref_dict,
       bincov_matrix = bincov_matrix,
       bincov_matrix_index = bincov_matrix_index,
-      mem_gb_override = mem_gb_override_sample3,
       cnmops_docker = cnmops_docker,
       runtime_attr_override = runtime_attr_sample3
   }
@@ -301,7 +293,6 @@ task CNSampleNormal {
     File ref_dict
     File bincov_matrix
     File bincov_matrix_index
-    Float? mem_gb_override
     String cnmops_docker
     RuntimeAttr? runtime_attr_override
   }

--- a/wdl/GATKSVPipelinePhase1.wdl
+++ b/wdl/GATKSVPipelinePhase1.wdl
@@ -123,10 +123,8 @@ workflow GATKSVPipelinePhase1 {
 
     RuntimeAttr? evidence_merging_bincov_runtime_attr # Disk space ignored, use evidence_merging_bincov_size_mb
 
-    RuntimeAttr? cnmops_sample10_runtime_attr   # Memory ignored if cnmops_mem_gb_override_sample10 given
-    RuntimeAttr? cnmops_sample3_runtime_attr    # Memory ignored if cnmops_mem_gb_override_sample3 given
-    Float? cnmops_mem_gb_override_sample10
-    Float? cnmops_mem_gb_override_sample3
+    RuntimeAttr? cnmops_sample10_runtime_attr
+    RuntimeAttr? cnmops_sample3_runtime_attr
 
     RuntimeAttr? median_cov_runtime_attr        # Memory ignored, use median_cov_mem_gb_per_sample
     Float? median_cov_mem_gb_per_sample
@@ -317,8 +315,6 @@ workflow GATKSVPipelinePhase1 {
       evidence_merging_bincov_runtime_attr=evidence_merging_bincov_runtime_attr,
       cnmops_sample10_runtime_attr=cnmops_sample10_runtime_attr,
       cnmops_sample3_runtime_attr=cnmops_sample3_runtime_attr,
-      cnmops_mem_gb_override_sample10=cnmops_mem_gb_override_sample10,
-      cnmops_mem_gb_override_sample3=cnmops_mem_gb_override_sample3,
       median_cov_runtime_attr=median_cov_runtime_attr,
       median_cov_mem_gb_per_sample=median_cov_mem_gb_per_sample,
       preprocess_calls_runtime_attr=preprocess_calls_runtime_attr,

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -232,10 +232,8 @@ workflow GATKSVPipelineSingleSample {
 
     RuntimeAttr? evidence_merging_bincov_runtime_attr # Disk space ignored, use evidence_merging_bincov_size_mb
 
-    RuntimeAttr? cnmops_sample10_runtime_attr   # Memory ignored if cnmops_mem_gb_override_sample10 given
-    RuntimeAttr? cnmops_sample3_runtime_attr    # Memory ignored if cnmops_mem_gb_override_sample3 given
-    Float? cnmops_mem_gb_override_sample10
-    Float? cnmops_mem_gb_override_sample3
+    RuntimeAttr? cnmops_sample10_runtime_attr
+    RuntimeAttr? cnmops_sample3_runtime_attr
 
     RuntimeAttr? add_sample_to_ped_runtime_attr
     RuntimeAttr? preprocess_calls_runtime_attr
@@ -799,8 +797,6 @@ workflow GATKSVPipelineSingleSample {
       evidence_merging_bincov_runtime_attr=evidence_merging_bincov_runtime_attr,
       cnmops_sample10_runtime_attr=cnmops_sample10_runtime_attr,
       cnmops_sample3_runtime_attr=cnmops_sample3_runtime_attr,
-      cnmops_mem_gb_override_sample10=cnmops_mem_gb_override_sample10,
-      cnmops_mem_gb_override_sample3=cnmops_mem_gb_override_sample3,
       preprocess_calls_runtime_attr=preprocess_calls_runtime_attr,
       depth_merge_set_runtime_attr=depth_merge_set_runtime_attr,
       depth_merge_sample_runtime_attr=depth_merge_sample_runtime_attr,

--- a/wdl/GatherBatchEvidence.wdl
+++ b/wdl/GatherBatchEvidence.wdl
@@ -153,10 +153,8 @@ workflow GatherBatchEvidence {
     RuntimeAttr? evidence_merging_bincov_runtime_attr
     RuntimeAttr? runtime_attr_bem
 
-    RuntimeAttr? cnmops_sample10_runtime_attr   # Memory ignored if cnmops_mem_gb_override_sample10 given
-    RuntimeAttr? cnmops_sample3_runtime_attr    # Memory ignored if cnmops_mem_gb_override_sample3 given
-    Float? cnmops_mem_gb_override_sample10
-    Float? cnmops_mem_gb_override_sample3
+    RuntimeAttr? cnmops_sample10_runtime_attr
+    RuntimeAttr? cnmops_sample3_runtime_attr
 
     RuntimeAttr? ploidy_score_runtime_attr
     RuntimeAttr? ploidy_build_runtime_attr
@@ -263,8 +261,6 @@ workflow GatherBatchEvidence {
       ref_dict = ref_dict,
       prefix = "header",
       stitch_and_clean_large_events = false,
-      mem_gb_override_sample10 = cnmops_mem_gb_override_sample10,
-      mem_gb_override_sample3 = cnmops_mem_gb_override_sample3,
       linux_docker = linux_docker,
       sv_pipeline_docker = sv_pipeline_docker,
       cnmops_docker = cnmops_docker,
@@ -290,8 +286,6 @@ workflow GatherBatchEvidence {
       prefix = "large",
       min_size=cnmops_large_min_size,
       stitch_and_clean_large_events = true,
-      mem_gb_override_sample10 = cnmops_mem_gb_override_sample10,
-      mem_gb_override_sample3 = cnmops_mem_gb_override_sample3,
       linux_docker = linux_docker,
       sv_pipeline_docker = sv_pipeline_docker,
       cnmops_docker = cnmops_docker,

--- a/wdl/PlotSVCountsPerSample.wdl
+++ b/wdl/PlotSVCountsPerSample.wdl
@@ -6,7 +6,7 @@ import "Structs.wdl"
 workflow PlotSVCountsPerSample {
   input {
     String prefix
-    Array[File?] vcfs  # in order of vcf_identifiers array. To skip one, use null keyword
+    Array[File?] vcfs
     Int N_IQR_cutoff
     String sv_pipeline_docker
     RuntimeAttr? runtime_attr_count_svs


### PR DESCRIPTION
### Updates
* remove CNMOPS mem_gb_override inputs since they are not used to override memory within the task
* clarify that minimum 100 samples are required not recommended for cohort mode
* add note to FilterBatchSamples that not filtering can increase cost and false positives
* add autosomal aneuploidy removal to preliminary sample QC docs
* remind Terra users about PED file before GatherBatchEvidence
* remove lingering references to gVCFs or SNP VCFs
* update Terra dashboard cohort sizes to date
* fix broken link to building inputs under single sample mode
* remove outdated comment about vcf_identifiers in PlotSvCountsPerSample
* ClusterBatch Terra JSON should refer to workspace.cohort_ped_file not this.cohort_ped_file
* update Terra dashboard to say MainVcfQc instead of MasterVcfQc

### Testing
* Validated WDLs and JSONs with womtool & Terra validation script