### PR TITLE
Add VisualizeCnvs

### DIFF
--- a/inputs/templates/test/VisualizeCnvs/VisualizeCnvs.json.tmpl
+++ b/inputs/templates/test/VisualizeCnvs/VisualizeCnvs.json.tmpl
@@ -1,5 +1,5 @@
 {
-  "VisualizeCnvs.vcf": {{ test_batch.clean_vcf | tojson }},
+  "VisualizeCnvs.vcf_or_bed": {{ test_batch.clean_vcf | tojson }},
   "VisualizeCnvs.prefix": {{ test_batch.name | tojson }},
   "VisualizeCnvs.median_files": [{{ test_batch.medianfile | tojson }}],
   "VisualizeCnvs.rd_files": [{{ test_batch.merged_coverage_file | tojson }}],

--- a/inputs/templates/test/VisualizeCnvs/VisualizeCnvs.json.tmpl
+++ b/inputs/templates/test/VisualizeCnvs/VisualizeCnvs.json.tmpl
@@ -1,0 +1,10 @@
+{
+  "VisualizeCnvs.vcf": {{ test_batch.clean_vcf | tojson }},
+  "VisualizeCnvs.prefix": {{ test_batch.name | tojson }},
+  "VisualizeCnvs.median_files": [{{ test_batch.medianfile | tojson }}],
+  "VisualizeCnvs.rd_files": [{{ test_batch.merged_coverage_file | tojson }}],
+  "VisualizeCnvs.ped_file": {{ test_batch.ped_file | tojson }},
+  "VisualizeCnvs.min_size": 50000,
+  "VisualizeCnvs.flags": "",
+  "VisualizeCnvs.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }}
+}

--- a/wdl/VisualizeCnvs.wdl
+++ b/wdl/VisualizeCnvs.wdl
@@ -1,0 +1,139 @@
+version 1.0
+
+import "Structs.wdl"
+
+# Plots CNV depth profiles across batches
+
+workflow VisualizeCnvs {
+  input{
+    File? vcf  # Option 1
+    File? bed  # Option 2, columns: chrom,start,end,name,svtype,samples
+
+    String prefix
+    Array[File] median_files
+    Array[File] rd_files
+    File ped_file
+    Int min_size
+    String flags
+    String sv_pipeline_docker
+    RuntimeAttr? runtime_attr_rdtest
+  }
+
+  scatter (file in rd_files) {
+    File rd_file_indexes = file + ".tbi"
+  }
+
+  call RdTestPlot {
+    input:
+      vcf=vcf,
+      bed=bed,
+      median_files=median_files,
+      ped_file=ped_file,
+      rd_files=rd_files,
+      rd_file_indexes=rd_file_indexes,
+      prefix=prefix,
+      min_size=min_size,
+      flags=flags,
+      sv_pipeline_docker=sv_pipeline_docker,
+      runtime_attr_override = runtime_attr_rdtest
+  }
+  output{
+    File rdtest_plots = RdTestPlot.plots
+  }
+}
+
+task RdTestPlot {
+  input{
+    File? vcf
+    File? bed
+    Array[File] rd_files
+    Array[File] rd_file_indexes
+    Array[File] median_files
+    Int min_size
+    File ped_file
+    String prefix
+    String sv_pipeline_docker
+    String flags
+    RuntimeAttr? runtime_attr_override
+  }
+  RuntimeAttr default_attr = object {
+                               cpu_cores: 1,
+                               mem_gb: 7.5,
+                               disk_gb: ceil(100 + size(vcf, "GB") * 10 + size(rd_files, "GB")),
+                               boot_disk_gb: 10,
+                               preemptible_tries: 3,
+                               max_retries: 1
+                             }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+  command <<<
+    set -euxo pipefail
+
+    if ~{defined(vcf)}; then
+      # Subset to DEL/DUP above min size and covert to bed format
+      bcftools view -i '(SVTYPE=="DEL" || SVTYPE=="DUP") && SVLEN>=~{min_size}' ~{vcf} \
+        | svtk vcf2bed stdin raw.bed
+      # Swap columns 5/6 for RdTest
+      awk -F '\t' -v OFS="\t" '{print $1,$2,$3,$4,$6,$5}' raw.bed > cnvs.bed
+      rm raw.bed
+      # Get list of all sample IDs
+      bcftools query -l ~{vcf} > samples.txt
+    elif ~{defined(bed)}; then
+      if [[ ~{bed} == *.gz ]]; then
+        DECOMPRESSED_BED="raw.bed"
+        zcat ~{bed} > $DECOMPRESSED_BED
+      else
+        DECOMPRESSED_BED="~{bed}"
+      fi
+      # Subset to DEL/DUP above min size and swap columns 5/6 for RdTest
+      awk -F '\t' -v OFS="\t" '{ if ($0!~"#" && $3-$2>=~{min_size} && ($5=="DEL" || $5=="DUP")) {print $1,$2,$3,$4,$6,$5} }' $DECOMPRESSED_BED > cnvs.bed
+      # Get list of all sample IDs
+      awk -F '\t' -v OFS="\t" '{ if ($0!~"#") {print $6} }' $DECOMPRESSED_BED \
+        | sed 's/\,/\n/g' \
+        | sort -u \
+        > samples.txt
+    else
+      echo "No calls provided"
+      exit 1
+    fi
+
+    paste ~{sep=" " median_files} > median_file.txt
+    bedtools merge -i cnvs.bed | cut -f1-3 > merged.bed
+
+    i=0
+    mkdir rd_subsets
+    while read FILE; do
+      OUT="rd_subsets/$i.bed.gz"
+      tabix -h $FILE -R merged.bed | bgzip > $OUT
+      tabix -p bed $OUT
+      i=$((i+1))
+    done<~{write_lines(rd_files)}
+
+    Rscript /opt/RdTest/RdTestV2.R \
+      -b cnvs.bed \
+      -n ~{prefix} \
+      -x rd_subsets \
+      -m median_file.txt \
+      -f ~{ped_file} \
+      -p TRUE \
+      -w samples.txt \
+      ~{flags}
+
+    mkdir ~{prefix}_rd_plots
+    mv *jpg ~{prefix}_rd_plots
+    tar -czvf ~{prefix}_rd_plots.tar.gz ~{prefix}_rd_plots/
+  >>>
+
+  output {
+    File plots = "~{prefix}_rd_plots.tar.gz"
+  }
+
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: sv_pipeline_docker
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
+  }
+}


### PR DESCRIPTION
Adds a new WDL that generate depth plots for DEL/DUP variants from a VCF file using RdTest. Depth profiles across batches are plotted, and a min size cutoff parameter is included. Tested on the 1KGP reference panel with 50 kbp cutoff.