### PR TITLE
Add support for the seeking option

### DIFF
--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -23,6 +23,7 @@ workflow ExpansionHunter {
         String sample_id
         Boolean? generate_realigned_bam
         Boolean? generate_vcf
+        Boolean? seeking_analysis_mode
         File? ped_file
         String expansion_hunter_docker
         String python_docker
@@ -48,6 +49,12 @@ workflow ExpansionHunter {
 
     Boolean generate_realigned_bam_ = select_first([generate_realigned_bam, false])
     Boolean generate_vcf_ = select_first([generate_vcf, false])
+    Boolean seeking_analysis_mode_ = select_first([seeking_analysis_mode, true])
+    String analysis_mode =
+        if select_first([seeking_analysis_mode, true]) then
+            "seeking"
+        else
+            "streaming"
 
     scatter (i in range(length(split_variant_catalogs))) {
         call RunExpansionHunter {
@@ -60,6 +67,7 @@ workflow ExpansionHunter {
                 sample_id = sample_id,
                 generate_realigned_bam = generate_realigned_bam_,
                 generate_vcf = generate_vcf_,
+                analysis_mode = analysis_mode,
                 ped_file = ped_file,
                 expansion_hunter_docker = expansion_hunter_docker,
                 runtime_override = runtime_eh
@@ -99,6 +107,7 @@ task RunExpansionHunter {
         String sample_id
         Boolean generate_realigned_bam
         Boolean generate_vcf
+        String analysis_mode
         File? ped_file
         String expansion_hunter_docker
         RuntimeAttr? runtime_override
@@ -140,6 +149,7 @@ task RunExpansionHunter {
             --reference $REF \
             --variant-catalog ~{variant_catalog} \
             --output-prefix ~{sample_id} \
+            --analysis-mode ~{analysis_mode} \
             --cache-mates \
             --record-timing \
             $sex

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -16,6 +16,7 @@ workflow ExpansionHunterScatter {
         Int? variant_catalog_batch_size
         Boolean? generate_realigned_bam
         Boolean? generate_vcf
+        Boolean? seeking_analysis_mode
         String expansion_hunter_docker
         String python_docker
         RuntimeAttr? runtime_split_var_catalog
@@ -64,6 +65,7 @@ workflow ExpansionHunterScatter {
                 ped_file=ped_file,
                 generate_realigned_bam=generate_realigned_bam,
                 generate_vcf=generate_vcf,
+                seeking_analysis_mode=seeking_analysis_mode,
                 expansion_hunter_docker=expansion_hunter_docker,
                 python_docker=python_docker,
                 runtime_eh=runtime_eh,


### PR DESCRIPTION
EH has two options for reading a cram: seeking, streaming. I suppose the former is advantages when access a few sites (i.e., the variant catalog is covering only a small portion of the cram) and the later is a linear scan on the cram which can be advantageous when the variant catalog is covering a considerable portion of the cram. 

We are still experimenting with how these options can improve cost-efficiency of running EH in our application; regardless having this option in the WDL can improve its application for wider use-cases. 