### PR TITLE
Refactor HailMerge task to HailMergeTask

### DIFF
--- a/wdl/CleanVcf.wdl
+++ b/wdl/CleanVcf.wdl
@@ -164,7 +164,7 @@ workflow CleanVcf {
   }
 
   if (use_hail) {
-    call HailMerge.HailMerge as ConcatVcfsHail {
+    call HailMerge.HailMergeTask as ConcatVcfsHail {
       input:
         vcfs=CleanVcfChromosome.out,
         prefix="~{cohort_name}.cleaned",

--- a/wdl/CleanVcfChromosome.wdl
+++ b/wdl/CleanVcfChromosome.wdl
@@ -108,7 +108,7 @@ workflow CleanVcfChromosome {
   }
 
   if (use_hail) {
-    call HailMerge.HailMerge as CombineStep1VcfsHail {
+    call HailMerge.HailMergeTask as CombineStep1VcfsHail {
       input:
         vcfs=CleanVcf1a.intermediate_vcf,
         prefix="~{prefix}.combine_step_1_vcfs",
@@ -254,7 +254,7 @@ workflow CleanVcfChromosome {
   }
 
   if (use_hail) {
-    call HailMerge.HailMerge as SortDropRedundantCnvsHail {
+    call HailMerge.HailMergeTasks as SortDropRedundantCnvsHail {
       input:
         vcfs=[DropRedundantCnvs.out],
         prefix="~{prefix}.drop_redundant_cnvs.sorted",

--- a/wdl/CombineBatches.wdl
+++ b/wdl/CombineBatches.wdl
@@ -336,7 +336,7 @@ workflow CombineBatches {
 
     #Merge PESR & RD VCFs
     if (use_hail) {
-      call HailMerge.HailMerge as ConcatPesrDepthHail {
+      call HailMerge.HailMergeTask as ConcatPesrDepthHail {
         input:
           vcfs=[MergeDeletions.out, MergeDuplications.out, HarmonizeHeaders.out[2], HarmonizeHeaders.out[3], HarmonizeHeaders.out[4]],
           prefix="~{cohort_name}.~{contig}.concat_pesr_depth",

--- a/wdl/HailMerge.wdl
+++ b/wdl/HailMerge.wdl
@@ -30,7 +30,7 @@ workflow HailMerge {
     }
   }
 
-  call HailMerge {
+  call HailMergeTask {
     input:
       vcfs = [select_first([Preconcat.concat_vcf, vcfs[0]])],
       prefix = prefix,
@@ -41,7 +41,7 @@ workflow HailMerge {
 
   call FixHeader {
     input:
-      merged_vcf = HailMerge.merged_vcf,
+      merged_vcf = HailMergeTask.merged_vcf,
       example_vcf = vcfs[0],
       prefix = prefix + ".reheadered",
       reset_cnv_gts = select_first([reset_cnv_gts, false]),
@@ -55,7 +55,7 @@ workflow HailMerge {
   }
 }
 
-task HailMerge {
+task HailMergeTask {
   input {
     Array[File] vcfs
     String prefix

--- a/wdl/MergePesrDepth.wdl
+++ b/wdl/MergePesrDepth.wdl
@@ -72,7 +72,7 @@ workflow MergePesrDepth {
     }
 
     if (use_hail) {
-        call HailMerge.HailMerge as ConcatLargePesrDepthHail {
+        call HailMerge.HailMergeTask as ConcatLargePesrDepthHail {
             input:
                 vcfs=[SubsetLarge.filtered_vcf, subtyped_depth_vcf],
                 prefix="~{prefix}.large_pesr_depth",
@@ -157,7 +157,7 @@ workflow MergePesrDepth {
     }
 
     if (use_hail) {
-        call HailMerge.HailMerge as ConcatShardsHail {
+        call HailMerge.HailMergeTask as ConcatShardsHail {
             input:
                 vcfs=flatten([[SubsetSmall.filtered_vcf], SortVcf.out]),
                 prefix="~{prefix}.concat_shards",

--- a/wdl/ResolveCpxSv.wdl
+++ b/wdl/ResolveCpxSv.wdl
@@ -137,7 +137,7 @@ workflow ResolveComplexSv {
 
     #Merge across shards
     if (use_hail) {
-      call HailMerge.HailMerge as ConcatResolvedPerShardHail {
+      call HailMerge.HailMergeTask as ConcatResolvedPerShardHail {
         input:
           vcfs=RestoreUnresolvedCnv.res,
           prefix="~{prefix}.resolved",

--- a/wdl/ScatterCpxGenotyping.wdl
+++ b/wdl/ScatterCpxGenotyping.wdl
@@ -100,7 +100,7 @@ workflow ScatterCpxGenotyping {
   }
 
   if (use_hail) {
-    call HailMerge.HailMerge as ConcatCpxCnvVcfsHail {
+    call HailMerge.HailMergeTask as ConcatCpxCnvVcfsHail {
       input:
         vcfs=GenotypeShard.cpx_depth_gt_resolved_vcf,
         prefix="~{prefix}.regenotyped",

--- a/wdl/ShardedCluster.wdl
+++ b/wdl/ShardedCluster.wdl
@@ -143,7 +143,7 @@ workflow ShardedCluster {
   }
   if (length(SvtkVcfCluster.out) > 0) {
     if (use_hail) {
-      call HailMerge.HailMerge as ConcatVcfsHail {
+      call HailMerge.HailMergeTask as ConcatVcfsHail {
         input:
           vcfs=SortVcf.out,
           prefix="~{prefix}.clustered",


### PR DESCRIPTION
Miniwdl does not allow a workflow and its tasks to have colliding names. The workflow `HailMerge` has a task named `HairMerge`, which is against miniwdl validation. This PR refactors the `HailMerge` task to `HailMergeTask`. 