### PR TITLE
Create an empty timing file in case it is not created in EH

### DIFF
--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -144,6 +144,7 @@ task RunExpansionHunter {
             fi
         fi
 
+        touch ~{sample_id}_timing.tsv
         ExpansionHunter \
             --reads ~{bam_or_cram} \
             --reference $REF \


### PR DESCRIPTION
Creating an empty timing file in case EH fails to create this. This could be related to the cases where EH fails with errors such as the following and does not create the `sample_id_timing.tsv` file, while the delocalization script is trying to delocalize the file. 

> Error on locus spec chrY-57210762-57210771-AGA: Error loading locus chrY-57210762-57210771-AGA: Flanks can contain at most 5 characters N but found 2000 Ns 