### PR TITLE
Change the default max depth of inheritance & update help

### DIFF
--- a/scripts/test/miniwdl_validation.py
+++ b/scripts/test/miniwdl_validation.py
@@ -49,7 +49,15 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("files", nargs="+", help="The WDL files to be checked.")
     parser.add_argument("--imports-dir", required=True, help="The directory to search for WDLs to be imported.")
-    parser.add_argument("--max-import-depth", default=2, help="Maximum depth of imports to check for validating WDLs.")
+    parser.add_argument(
+        "--max-import-depth",
+        default=15,
+        help="Set the maximum allowed depth of imports in the WDLs. "
+             "For a given WDL, miniwdl first asserts the imports, and "
+             "it will error-out if it reaches the given max depth "
+             "and the WDL has imports. For instance, with max depth set "
+             "to 2, it will error-out validating "
+             "Foo.wdl -> (import Bar.wdl -> (import Baz.wdl)).")
     args = parser.parse_args()
 
     wdl_filenames = args.files


### PR DESCRIPTION
Miniwdl implements max depth of import as how nested WDLs can be, and errors out if the WDL at the given max depth is not a leaf node in the inheritance tree. [Miniwdl's default for this parameter is `10`](https://github.com/chanzuckerberg/miniwdl/blob/06088e195a382684e5c6b1455d1753880de30127/WDL/__init__.py#L42), and I am increasing it to `15` to allow deeper nested imports. 