### PR TITLE
Fix referencing HailMerge task instead of the workflow.

### DIFF
--- a/wdl/CombineBatches.wdl
+++ b/wdl/CombineBatches.wdl
@@ -336,7 +336,7 @@ workflow CombineBatches {
 
     #Merge PESR & RD VCFs
     if (use_hail) {
-      call HailMerge.HailMergeTask as ConcatPesrDepthHail {
+      call HailMerge.HailMerge as ConcatPesrDepthHail {
         input:
           vcfs=[MergeDeletions.out, MergeDuplications.out, HarmonizeHeaders.out[2], HarmonizeHeaders.out[3], HarmonizeHeaders.out[4]],
           prefix="~{cohort_name}.~{contig}.concat_pesr_depth",

--- a/wdl/MergePesrDepth.wdl
+++ b/wdl/MergePesrDepth.wdl
@@ -72,7 +72,7 @@ workflow MergePesrDepth {
     }
 
     if (use_hail) {
-        call HailMerge.HailMergeTask as ConcatLargePesrDepthHail {
+        call HailMerge.HailMerge as ConcatLargePesrDepthHail {
             input:
                 vcfs=[SubsetLarge.filtered_vcf, subtyped_depth_vcf],
                 prefix="~{prefix}.large_pesr_depth",
@@ -157,7 +157,7 @@ workflow MergePesrDepth {
     }
 
     if (use_hail) {
-        call HailMerge.HailMergeTask as ConcatShardsHail {
+        call HailMerge.HailMerge as ConcatShardsHail {
             input:
                 vcfs=flatten([[SubsetSmall.filtered_vcf], SortVcf.out]),
                 prefix="~{prefix}.concat_shards",

--- a/wdl/ShardedCluster.wdl
+++ b/wdl/ShardedCluster.wdl
@@ -143,7 +143,7 @@ workflow ShardedCluster {
   }
   if (length(SvtkVcfCluster.out) > 0) {
     if (use_hail) {
-      call HailMerge.HailMergeTask as ConcatVcfsHail {
+      call HailMerge.HailMerge as ConcatVcfsHail {
         input:
           vcfs=SortVcf.out,
           prefix="~{prefix}.clustered",


### PR DESCRIPTION
In https://github.com/broadinstitute/gatk-sv/pull/440, some references to the `HailMerge` workflow were incorrectly replaced by a reference to the `HailMergeTask` task; this refactoring issue is fixed in this PR. 