### PR TITLE
Add reclustering WDLs (do not merge)

### DIFF
--- a/wdl/AnnotateGenomicContext.wdl
+++ b/wdl/AnnotateGenomicContext.wdl
@@ -1,0 +1,296 @@
+version 1.0
+
+# Author: Xuefang Zhao <XZHAO12@mgh.harvard.edu>
+
+import "Structs.wdl"
+
+# Workflow to annotate vcf file with genomic context
+workflow AnnotateSVsWithGenomicContext {
+    input {
+        File vcf
+        File vcf_index
+        File Repeat_Masks
+        File Simple_Repeats
+        File Segmental_Duplicates
+
+        String sv_base_mini_docker
+        String sv_benchmark_docker
+        String sv_pipeline_docker
+
+        # overrides for MiniTasks
+        RuntimeAttr? runtime_override_extract_SV_sites
+        RuntimeAttr? runtime_override_vcf_to_bed
+        RuntimeAttr? runtime_attr_override_anno_gc
+        RuntimeAttr? runtime_attr_override_inte_gc
+    }
+
+    call ExtractSitesFromVcf {
+        input:
+            vcf = vcf,
+            vcf_index = vcf_index,
+            sv_base_mini_docker=sv_base_mini_docker,
+            runtime_attr_override=runtime_override_extract_SV_sites
+    }
+
+    call Vcf2Bed{
+        input:
+            vcf = ExtractSitesFromVcf.out,
+            vcf_index = ExtractSitesFromVcf.out_idx, 
+            sv_pipeline_docker=sv_pipeline_docker,
+            runtime_attr_override=runtime_override_vcf_to_bed
+    }
+
+    call AnnotateGenomicContext{
+        input:
+            bed_gz = Vcf2Bed.out,
+            simp_rep = Simple_Repeats,
+            seg_dup = Segmental_Duplicates,
+            rep_mask = Repeat_Masks,
+            sv_base_mini_docker = sv_base_mini_docker,
+            runtime_attr_override = runtime_attr_override_anno_gc
+    }
+
+    call IntegrateGenomicContext{
+        input:
+            bed_gz = Vcf2Bed.out,
+            le_bp_vs_sr = AnnotateGenomicContext.le_bp_vs_sr,
+            le_bp_vs_sd = AnnotateGenomicContext.le_bp_vs_sd,
+            le_bp_vs_rm = AnnotateGenomicContext.le_bp_vs_rm,
+            ri_bp_vs_sr = AnnotateGenomicContext.ri_bp_vs_sr,
+            ri_bp_vs_sd = AnnotateGenomicContext.ri_bp_vs_sd,
+            ri_bp_vs_rm = AnnotateGenomicContext.ri_bp_vs_rm,
+            lg_cnv_vs_sr = AnnotateGenomicContext.lg_cnv_vs_sr,
+            lg_cnv_vs_sd = AnnotateGenomicContext.lg_cnv_vs_sd,
+            lg_cnv_vs_rm = AnnotateGenomicContext.lg_cnv_vs_rm,
+            sv_benchmark_docker = sv_benchmark_docker,
+            runtime_attr_override = runtime_attr_override_inte_gc
+    }
+
+    output{
+        File annotated_SVs = IntegrateGenomicContext.anno
+    }
+}
+
+task ExtractSitesFromVcf {
+    input {
+        File vcf
+        File vcf_index
+        String sv_base_mini_docker
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Float vcf_size = size(vcf, "GiB")
+    Int vm_disk_size = ceil(vcf_size * 1.2)
+
+    RuntimeAttr runtime_default = object {
+        mem_gb: 2,
+        disk_gb: vm_disk_size,
+        cpu_cores: 1,
+        preemptible_tries: 1,
+        max_retries: 1,
+        boot_disk_gb: 10
+    }
+    RuntimeAttr runtime_override = select_first([runtime_attr_override, runtime_default])
+
+    runtime {
+        memory: "~{select_first([runtime_override.mem_gb, runtime_default.mem_gb])} GiB"
+        disks: "local-disk ~{select_first([runtime_override.disk_gb, runtime_default.disk_gb])} HDD"
+        cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
+        preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
+        maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
+        docker: sv_base_mini_docker
+        bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
+    }
+
+    String prefix = basename(vcf, ".vcf.gz")
+    command <<<
+        set -euxo pipefail
+
+        zcat ~{vcf} | cut -f1-10 |bgzip > ~{prefix}.sites.vcf.gz
+        tabix ~{prefix}.sites.vcf.gz
+    >>>
+
+    output {
+        File out = "~{prefix}.sites.vcf.gz"
+        File out_idx = "~{prefix}.sites.vcf.gz.tbi"
+    }
+}
+
+task Vcf2Bed{
+    input {
+        File vcf
+        File vcf_index
+        String sv_pipeline_docker
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Float vcf_size = size(vcf, "GiB")
+    Int vm_disk_size = ceil(vcf_size * 1.2)
+
+    RuntimeAttr runtime_default = object {
+        mem_gb: 2,
+        disk_gb: vm_disk_size,
+        cpu_cores: 1,
+        preemptible_tries: 1,
+        max_retries: 1,
+        boot_disk_gb: 10
+    }
+    RuntimeAttr runtime_override = select_first([runtime_attr_override, runtime_default])
+
+    runtime {
+        memory: "~{select_first([runtime_override.mem_gb, runtime_default.mem_gb])} GiB"
+        disks: "local-disk ~{select_first([runtime_override.disk_gb, runtime_default.disk_gb])} HDD"
+        cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
+        preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
+        maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
+        docker: sv_pipeline_docker
+        bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
+    }
+
+    String prefix = basename(vcf, ".vcf.gz")
+    command <<<
+        set -euxo pipefail
+
+        svtk vcf2bed -i SVTYPE -i SVLEN ~{vcf} ~{prefix}.bed
+        cut -f1-4,7,8 ~{prefix}.bed | bgzip > ~{prefix}.bed.gz
+    >>>
+
+    output {
+        File out = "~{prefix}.bed.gz"
+    }        
+}
+
+task AnnotateGenomicContext{
+    input {
+        File bed_gz
+        File simp_rep
+        File seg_dup
+        File rep_mask
+        String sv_base_mini_docker
+        RuntimeAttr? runtime_attr_override
+    }
+    RuntimeAttr runtime_default = object {
+        mem_gb: 3,
+        disk_gb: 10,
+        cpu_cores: 1,
+        preemptible_tries: 1,
+        max_retries: 1,
+        boot_disk_gb: 10
+    }
+    RuntimeAttr runtime_override = select_first([runtime_attr_override, runtime_default])
+
+    runtime {
+        memory: "~{select_first([runtime_override.mem_gb, runtime_default.mem_gb])} GiB"
+        disks: "local-disk ~{select_first([runtime_override.disk_gb, runtime_default.disk_gb])} HDD"
+        cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
+        preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
+        maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
+        docker: sv_base_mini_docker
+        bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
+    }
+
+    String prefix = basename(bed_gz, ".bed.gz")
+    command <<<
+        set -euxo pipefail
+
+        zcat ~{bed_gz} | awk '{print $1,$2,$2,$4,$5}'    | sed -e 's/ /\t/g' > ~{prefix}.le_bp
+        zcat ~{bed_gz} | awk '{print $1,$3,$3,$4,$5}'    | sed -e 's/ /\t/g' > ~{prefix}.ri_bp
+        zcat ~{bed_gz} | awk '{if ($5=="DEL" || $5=="DUP" || $5=="CNV" ) print}' | awk '{if ($3-$2>5000) print}' | cut -f1-5 >    ~{prefix}.lg_cnv
+
+        bedtools coverage -a ~{prefix}.le_bp -b ~{simp_rep} | awk '{if ($9>0) print}'> ~{prefix}.le_bp.vs.SR
+        bedtools coverage -a ~{prefix}.le_bp -b ~{seg_dup}    | awk '{if ($9>0) print}'> ~{prefix}.le_bp.vs.SD
+        bedtools coverage -a ~{prefix}.le_bp -b ~{rep_mask}    | awk '{if ($9>0) print}'> ~{prefix}.le_bp.vs.RM
+
+        bedtools coverage -a ~{prefix}.ri_bp -b ~{simp_rep} | awk '{if ($9>0) print}'> ~{prefix}.ri_bp.vs.SR
+        bedtools coverage -a ~{prefix}.ri_bp -b ~{seg_dup}    | awk '{if ($9>0) print}'> ~{prefix}.ri_bp.vs.SD
+        bedtools coverage -a ~{prefix}.ri_bp -b ~{rep_mask}    | awk '{if ($9>0) print}'> ~{prefix}.ri_bp.vs.RM
+
+        bedtools coverage -a ~{prefix}.lg_cnv -b ~{simp_rep}    > ~{prefix}.lg_cnv.vs.SR
+        bedtools coverage -a ~{prefix}.lg_cnv -b ~{seg_dup}    > ~{prefix}.lg_cnv.vs.SD
+        bedtools coverage -a ~{prefix}.lg_cnv -b ~{rep_mask}    > ~{prefix}.lg_cnv.vs.RM
+
+    >>>
+
+    output {
+        File le_bp_vs_sr = "~{prefix}.le_bp.vs.SR"
+        File le_bp_vs_sd = "~{prefix}.le_bp.vs.SD"
+        File le_bp_vs_rm = "~{prefix}.le_bp.vs.RM"
+        File ri_bp_vs_sr = "~{prefix}.ri_bp.vs.SR"
+        File ri_bp_vs_sd = "~{prefix}.ri_bp.vs.SD"
+        File ri_bp_vs_rm = "~{prefix}.ri_bp.vs.RM"
+        File lg_cnv_vs_sr = "~{prefix}.lg_cnv.vs.SR"
+        File lg_cnv_vs_sd = "~{prefix}.lg_cnv.vs.SD"
+        File lg_cnv_vs_rm = "~{prefix}.lg_cnv.vs.RM"
+    }        
+}
+
+task IntegrateGenomicContext{
+    input {
+        File bed_gz
+        File le_bp_vs_sr
+        File le_bp_vs_sd
+        File le_bp_vs_rm
+        File ri_bp_vs_sr
+        File ri_bp_vs_sd
+        File ri_bp_vs_rm
+        File lg_cnv_vs_sr
+        File lg_cnv_vs_sd
+        File lg_cnv_vs_rm
+
+        String sv_benchmark_docker
+        RuntimeAttr? runtime_attr_override
+    }
+    RuntimeAttr runtime_default = object {
+        mem_gb: 1,
+        disk_gb: 10,
+        cpu_cores: 1,
+        preemptible_tries: 1,
+        max_retries: 1,
+        boot_disk_gb: 10
+    }
+    
+    RuntimeAttr runtime_override = select_first([runtime_attr_override, runtime_default])
+
+    runtime {
+        memory: "~{select_first([runtime_override.mem_gb, runtime_default.mem_gb])} GiB"
+        disks: "local-disk ~{select_first([runtime_override.disk_gb, runtime_default.disk_gb])} HDD"
+        cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
+        preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
+        maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
+        docker: sv_benchmark_docker
+        bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
+    }
+
+    String prefix = basename(bed_gz, ".bed.gz")
+    command <<<
+        set -euxo pipefail
+
+        Rscript /src/integrate_Genomic_Content_annotations.R \
+        --bed ~{bed_gz} \
+        --out ~{prefix}.GC \
+        --le_bp_vs_sr ~{le_bp_vs_sr} \
+        --le_bp_vs_sd ~{le_bp_vs_sd} \
+        --le_bp_vs_rm ~{le_bp_vs_rm} \
+        --ri_bp_vs_sr ~{ri_bp_vs_sr} \
+        --ri_bp_vs_sd ~{ri_bp_vs_sd} \
+        --ri_bp_vs_rm ~{ri_bp_vs_rm} \
+        --lg_cnv_vs_sr ~{lg_cnv_vs_sr} \
+        --lg_cnv_vs_sd ~{lg_cnv_vs_sd} \
+        --lg_cnv_vs_rm ~{lg_cnv_vs_rm}
+
+    >>>
+
+    output {
+        File anno = "~{prefix}.GC"
+    }        
+}
+
+
+
+
+
+
+
+
+
+

--- a/wdl/ReClusterCleanVcfAcrossGenomicContext.wdl
+++ b/wdl/ReClusterCleanVcfAcrossGenomicContext.wdl
@@ -1,0 +1,132 @@
+version 1.0
+
+# Author: Xuefang Zhao <XZHAO12@mgh.harvard.edu>
+
+import "Structs.wdl"
+import "AnnotateGenomicContext.wdl" as AnnotateGenomicContext
+import "ReClusterCleanVcfSVsUnit.wdl" as ReClusterCleanVcfSVsUnit
+import "TasksBenchmark.wdl" as tasks_benchmark
+import "TasksMakeCohortVcf.wdl" as tasks_mcv
+
+# Workflow to annotate vcf file with genomic context
+workflow ReClusterCleanVcfAcrossGenomicContext {
+    input {
+        File vcf
+        File vcf_index
+        File Repeat_Masks
+        File Simple_Repeats
+        File Segmental_Duplicates
+        File? annotated_SV_origin
+
+        String prefix
+        String vid_prefix
+        String svtype
+        Array[String] Genomic_Context_list
+        Array[Array[Int]] size_list
+
+        Int num_vids
+        Int num_samples
+        Int dist
+        Int svsize
+        Float frac
+        Float sample_overlap
+
+        String sv_base_mini_docker
+        String sv_benchmark_docker
+        String sv_pipeline_docker
+
+        # overrides for MiniTasks
+        RuntimeAttr? runtime_override_vcf_to_bed
+        RuntimeAttr? runtime_attr_override_anno_gc
+        RuntimeAttr? runtime_attr_override_inte_gc
+        RuntimeAttr? runtime_override_extract_SV_sites
+        RuntimeAttr? runtime_attr_override_svtk_vcfcluster
+        RuntimeAttr? runtime_attr_override_extract_svid
+        RuntimeAttr? runtime_attr_override_integrate_vcfs
+        RuntimeAttr? runtime_attr_override_concat_vcfs
+        RuntimeAttr? runtime_attr_override_sort_reclustered_vcf
+        RuntimeAttr? runtime_attr_override_concat_clustered_SVID
+
+    }
+
+    if(!defined(annotated_SV_origin)){
+        call AnnotateGenomicContext.AnnotateSVsWithGenomicContext as AnnotateSVsWithGenomicContext {
+            input:
+                vcf = vcf,
+                vcf_index = vcf_index,
+                Repeat_Masks = Repeat_Masks,
+                Simple_Repeats = Simple_Repeats,
+                Segmental_Duplicates = Segmental_Duplicates,
+
+                sv_base_mini_docker  =sv_base_mini_docker,
+                sv_benchmark_docker = sv_benchmark_docker,
+                sv_pipeline_docker = sv_pipeline_docker,
+
+                runtime_override_extract_SV_sites = runtime_override_extract_SV_sites,
+                runtime_override_vcf_to_bed = runtime_override_vcf_to_bed,
+                runtime_attr_override_anno_gc = runtime_attr_override_anno_gc,
+                runtime_attr_override_inte_gc = runtime_attr_override_inte_gc
+        }
+    }
+
+    File annotated_SVs = select_first([annotated_SV_origin, AnnotateSVsWithGenomicContext.annotated_SVs])
+
+    scatter (i in range(length(Genomic_Context_list))) {
+        call ReClusterCleanVcfSVsUnit.ReClusterCleanVcfSVs as ReClusterCleanVcfSVs{
+            input:
+                vcf = vcf,
+                vcf_index = vcf_index,
+                annotated_SV_origin = annotated_SVs,
+
+                Repeat_Masks = Repeat_Masks,
+                Simple_Repeats = Simple_Repeats,
+                Segmental_Duplicates = Segmental_Duplicates,
+                
+                prefix = "~{prefix}_~{Genomic_Context_list[i]}",
+                vid_prefix = "~{vid_prefix}_~{Genomic_Context_list[i]}",
+                svtype = svtype,
+                Genomic_Context = Genomic_Context_list[i],
+                min_size = size_list[i][0],
+                max_size = size_list[i][1],
+
+                num_vids = num_vids,
+                num_samples = num_samples,
+                dist = dist,
+                svsize = svsize,
+                frac = frac,
+                sample_overlap = sample_overlap,
+
+                sv_base_mini_docker  =sv_base_mini_docker,
+                sv_benchmark_docker = sv_benchmark_docker,
+                sv_pipeline_docker = sv_pipeline_docker,
+
+                runtime_attr_override_extract_svid = runtime_attr_override_extract_svid,
+                runtime_override_vcf_to_bed = runtime_override_vcf_to_bed,
+
+                runtime_override_vcf_to_bed = runtime_override_vcf_to_bed,
+                runtime_attr_override_anno_gc = runtime_attr_override_anno_gc,
+                runtime_attr_override_inte_gc = runtime_attr_override_inte_gc,
+                runtime_override_extract_SV_sites = runtime_override_extract_SV_sites,
+                runtime_attr_override_svtk_vcfcluster = runtime_attr_override_svtk_vcfcluster,
+                runtime_attr_override_extract_svid = runtime_attr_override_extract_svid,
+                runtime_attr_override_integrate_vcfs = runtime_attr_override_integrate_vcfs,
+                runtime_attr_override_sort_reclustered_vcf= runtime_attr_override_sort_reclustered_vcf
+        }
+    }
+
+    call tasks_mcv.ConcatVcfs as ConcatVcfs{
+        input:
+            vcfs = ReClusterCleanVcfSVs.reclustered_SV,
+            vcfs_idx = ReClusterCleanVcfSVs.reclustered_SV_idx,
+            outfile_prefix = prefix,
+            sv_base_mini_docker = sv_base_mini_docker,
+            runtime_attr_override = runtime_attr_override_concat_vcfs
+    }
+
+    output{
+        File reclustered_SV_genomic_context = ConcatVcfs.concat_vcf
+        File reclustered_SV_genomic_context_idx = ConcatVcfs.concat_vcf_idx
+    }
+}
+
+

--- a/wdl/ReClusterCleanVcfAcrossSVTYPE.wdl
+++ b/wdl/ReClusterCleanVcfAcrossSVTYPE.wdl
@@ -1,0 +1,155 @@
+version 1.0
+
+# Author: Xuefang Zhao <XZHAO12@mgh.harvard.edu>
+
+import "Structs.wdl"
+import "AnnotateGenomicContext.wdl" as AnnotateGenomicContext
+import "ReClusterCleanVcfAcrossGenomicContext.wdl" as ReClusterCleanVcfAcrossGenomicContext
+import "TasksBenchmark.wdl" as tasks_benchmark
+import "TasksMakeCohortVcf.wdl" as tasks_mcv
+
+# Workflow to annotate vcf file with genomic context
+workflow ReClusterCleanVcfAcrossSVTYPE {
+    input {
+        File vcf
+        File vcf_index
+        File Repeat_Masks
+        File Simple_Repeats
+        File Segmental_Duplicates
+        File? annotated_SV_origin
+
+        String prefix
+        String vid_prefix
+        Array[String] svtype_list
+        Array[Array[String]] Genomic_Context_list_list
+        Array[Array[Array[Int]]] size_list_list
+
+        Int num_vids
+        Int num_samples
+        Int dist
+        Int svsize
+        Float frac
+        Float sample_overlap
+
+        String sv_base_mini_docker
+        String sv_benchmark_docker
+        String sv_pipeline_docker
+
+        # overrides for MiniTasks
+        RuntimeAttr? runtime_override_vcf_to_bed
+        RuntimeAttr? runtime_attr_override_anno_gc
+        RuntimeAttr? runtime_attr_override_inte_gc
+        RuntimeAttr? runtime_override_extract_SV_sites
+        RuntimeAttr? runtime_attr_override_svtk_vcfcluster
+        RuntimeAttr? runtime_attr_override_extract_svid
+        RuntimeAttr? runtime_attr_override_integrate_vcfs
+        RuntimeAttr? runtime_attr_override_concat_vcfs
+        RuntimeAttr? runtime_attr_override_sort_reclustered_vcf
+        RuntimeAttr? runtime_attr_override_concat_clustered_SVID
+    }
+
+    if(!defined(annotated_SV_origin)){
+        call AnnotateGenomicContext.AnnotateSVsWithGenomicContext as AnnotateSVsWithGenomicContext {
+            input:
+                vcf = vcf,
+                vcf_index = vcf_index,
+                Repeat_Masks = Repeat_Masks,
+                Simple_Repeats = Simple_Repeats,
+                Segmental_Duplicates = Segmental_Duplicates,
+
+                sv_base_mini_docker  =sv_base_mini_docker,
+                sv_benchmark_docker = sv_benchmark_docker,
+                sv_pipeline_docker = sv_pipeline_docker,
+
+                runtime_override_extract_SV_sites = runtime_override_extract_SV_sites,
+                runtime_override_vcf_to_bed = runtime_override_vcf_to_bed,
+                runtime_attr_override_anno_gc = runtime_attr_override_anno_gc,
+                runtime_attr_override_inte_gc = runtime_attr_override_inte_gc
+        }
+    }
+
+    File annotated_SVs = select_first([annotated_SV_origin, AnnotateSVsWithGenomicContext.annotated_SVs])
+
+    scatter (i in range(length(svtype_list))) {
+        call ReClusterCleanVcfAcrossGenomicContext.ReClusterCleanVcfAcrossGenomicContext as ReClusterCleanVcfAcrossGenomicContext{
+            input:
+                vcf = vcf,
+                vcf_index = vcf_index,
+                annotated_SV_origin = annotated_SVs,
+
+                Repeat_Masks = Repeat_Masks,
+                Simple_Repeats = Simple_Repeats,
+                Segmental_Duplicates = Segmental_Duplicates,
+                
+                prefix = "~{prefix}_~{svtype_list[i]}",
+                vid_prefix = "~{vid_prefix}_~{svtype_list[i]}",
+                svtype = svtype_list[i],
+                Genomic_Context_list = Genomic_Context_list_list[i],
+                size_list = size_list_list[i],
+
+                num_vids = num_vids,
+                num_samples = num_samples,
+                dist = dist,
+                svsize = svsize,
+                frac = frac,
+                sample_overlap = sample_overlap,
+
+                sv_base_mini_docker  =sv_base_mini_docker,
+                sv_benchmark_docker = sv_benchmark_docker,
+                sv_pipeline_docker = sv_pipeline_docker,
+
+                runtime_attr_override_extract_svid = runtime_attr_override_extract_svid,
+                runtime_override_vcf_to_bed = runtime_override_vcf_to_bed,
+
+                runtime_override_vcf_to_bed = runtime_override_vcf_to_bed,
+                runtime_attr_override_anno_gc = runtime_attr_override_anno_gc,
+                runtime_attr_override_inte_gc = runtime_attr_override_inte_gc,
+                runtime_override_extract_SV_sites = runtime_override_extract_SV_sites,
+                runtime_attr_override_svtk_vcfcluster = runtime_attr_override_svtk_vcfcluster,
+                runtime_attr_override_extract_svid = runtime_attr_override_extract_svid,
+                runtime_attr_override_integrate_vcfs = runtime_attr_override_integrate_vcfs,
+                runtime_attr_override_sort_reclustered_vcf= runtime_attr_override_sort_reclustered_vcf
+
+        }
+    }
+
+ 
+    call tasks_mcv.ConcatVcfs as ConcatVcfs{
+        input:
+            vcfs = ReClusterCleanVcfAcrossGenomicContext.reclustered_SV_genomic_context,
+            vcfs_idx = ReClusterCleanVcfAcrossGenomicContext.reclustered_SV_genomic_context_idx,
+            outfile_prefix = prefix,
+            sv_base_mini_docker = sv_base_mini_docker,
+            runtime_attr_override = runtime_attr_override_concat_vcfs
+    }
+
+    call tasks_benchmark.IntegrateReClusterdVcfs{
+        input:
+            vcf_all = vcf,
+            vcf_all_idx = vcf_index,
+            vcf_recluster = ConcatVcfs.concat_vcf,
+            vcf_recluster_idx = ConcatVcfs.concat_vcf_idx,
+            sv_pipeline_docker = sv_pipeline_docker,
+            runtime_attr_override = runtime_attr_override_integrate_vcfs
+    }
+
+    call tasks_benchmark.SortReClusterdVcfs{
+        input:
+            vcf_1 = IntegrateReClusterdVcfs.reclustered_Part1,
+            vcf_2 = IntegrateReClusterdVcfs.reclustered_Part2,
+            vcf_1_idx = IntegrateReClusterdVcfs.reclustered_Part1_idx,
+            vcf_2_idx = IntegrateReClusterdVcfs.reclustered_Part2_idx,
+            sv_pipeline_docker = sv_pipeline_docker,
+            runtime_attr_override = runtime_attr_override_sort_reclustered_vcf
+    }
+
+
+
+    output{
+        File svid_annotation = IntegrateReClusterdVcfs.SVID_anno
+        File reclustered_SV_svtype = SortReClusterdVcfs.sorted_vcf
+        File reclustered_SV_svtype_idx = SortReClusterdVcfs.sorted_vcf_idx
+    }
+}
+
+

--- a/wdl/ReClusterCleanVcfSVsUnit.wdl
+++ b/wdl/ReClusterCleanVcfSVsUnit.wdl
@@ -1,0 +1,235 @@
+version 1.0
+
+# Author: Xuefang Zhao <XZHAO12@mgh.harvard.edu>
+
+import "Structs.wdl"
+import "AnnotateGenomicContext.wdl" as AnnotateGenomicContext
+import "TasksBenchmark.wdl" as mini_tasks
+
+# Workflow to annotate vcf file with genomic context
+workflow ReClusterCleanVcfSVs {
+    input {
+        File vcf
+        File vcf_index
+        File Repeat_Masks
+        File Simple_Repeats
+        File Segmental_Duplicates
+        File? annotated_SV_origin
+
+        String prefix
+        String vid_prefix
+        String svtype
+        String Genomic_Context
+        Int min_size
+        Int max_size
+
+        Int num_vids
+        Int num_samples
+        Int dist
+        Int svsize
+        Float frac
+        Float sample_overlap
+
+        String sv_base_mini_docker
+        String sv_benchmark_docker
+        String sv_pipeline_docker
+
+        # overrides for MiniTasks
+        RuntimeAttr? runtime_override_vcf_to_bed
+        RuntimeAttr? runtime_attr_override_anno_gc
+        RuntimeAttr? runtime_attr_override_inte_gc
+        RuntimeAttr? runtime_override_extract_SV_sites
+        RuntimeAttr? runtime_attr_override_svtk_vcfcluster
+        RuntimeAttr? runtime_attr_override_extract_svid
+        RuntimeAttr? runtime_attr_override_integrate_vcfs
+        RuntimeAttr? runtime_attr_override_sort_reclustered_vcf
+    }
+
+    if(!defined(annotated_SV_origin)){
+        call AnnotateGenomicContext.AnnotateSVsWithGenomicContext as AnnotateSVsWithGenomicContext {
+            input:
+                vcf = vcf,
+                vcf_index = vcf_index,
+                Repeat_Masks = Repeat_Masks,
+                Simple_Repeats = Simple_Repeats,
+                Segmental_Duplicates = Segmental_Duplicates,
+
+                sv_base_mini_docker  =sv_base_mini_docker,
+                sv_benchmark_docker = sv_benchmark_docker,
+                sv_pipeline_docker = sv_pipeline_docker,
+
+                runtime_override_extract_SV_sites = runtime_override_extract_SV_sites,
+                runtime_override_vcf_to_bed = runtime_override_vcf_to_bed,
+                runtime_attr_override_anno_gc = runtime_attr_override_anno_gc,
+                runtime_attr_override_inte_gc = runtime_attr_override_inte_gc
+        }
+    }
+
+    File annotated_SVs = select_first([annotated_SV_origin, AnnotateSVsWithGenomicContext.annotated_SVs])
+
+    call Extract_SVID_by_GC {
+        input:
+            vcf = vcf,
+            vcf_index = vcf_index,
+            SVID_GC = annotated_SVs,
+            Genomic_Context = Genomic_Context,
+            svtype = svtype,
+            min_size = min_size,
+            max_size = max_size,
+
+            sv_benchmark_docker = sv_benchmark_docker,
+            runtime_attr_override = runtime_attr_override_extract_svid
+    }
+
+    call SvtkVcfCluster {
+        input:
+            vcf = Extract_SVID_by_GC.out_vcf,
+            vcf_idx = Extract_SVID_by_GC.out_idx,
+            prefix = prefix,
+            vid_prefix = vid_prefix,
+            num_vids = num_vids,
+            num_samples = num_samples,
+            dist = dist,
+            frac = frac,
+            sample_overlap = sample_overlap,
+            svsize = svsize,
+            svtype = svtype, 
+            sv_pipeline_docker = sv_pipeline_docker,
+            runtime_attr_override = runtime_attr_override_svtk_vcfcluster
+    }
+
+    output{
+        File reclustered_SV = SvtkVcfCluster.vcf_out
+        File reclustered_SV_idx = SvtkVcfCluster.vcf_out_idx
+    }
+}
+
+
+
+task SvtkVcfCluster {
+    input {
+        File vcf
+        File vcf_idx
+        String prefix
+        String vid_prefix
+        Int num_vids
+        Int num_samples
+        Int dist
+        Float frac
+        Float sample_overlap
+        File? exclude_list
+        File? exclude_list_idx
+        Int svsize
+        String svtype
+        String sv_pipeline_docker
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Float default_mem_gb = 10 + (120.0 * (num_vids / 19000.0) * (num_samples / 140000.0))
+    RuntimeAttr runtime_default = object {
+        mem_gb: default_mem_gb,
+        disk_gb: ceil(30.0 + size(vcf, "GiB") * 30.0),
+        cpu_cores: 1,
+        preemptible_tries: 1,
+        max_retries: 1,
+        boot_disk_gb: 10
+        }
+    RuntimeAttr runtime_override = select_first([runtime_attr_override, runtime_default])
+    runtime {
+        memory: "~{select_first([runtime_override.mem_gb, runtime_default.mem_gb])} GiB"
+        disks: "local-disk ~{select_first([runtime_override.disk_gb, runtime_default.disk_gb])} HDD"
+        cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
+        preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
+        maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
+        docker: sv_pipeline_docker
+        bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
+    }
+
+    command <<<
+        set -euo pipefail
+        ~{if defined(exclude_list) && !defined(exclude_list_idx) then "tabix -p bed ~{exclude_list}" else ""}
+
+        #Run clustering
+        svtk vcfcluster <(echo "~{vcf}") - \
+                -d ~{dist} \
+                -f ~{frac} \
+                ~{if defined(exclude_list) then "-x ~{exclude_list}" else ""} \
+                -z ~{svsize} \
+                -p ~{vid_prefix} \
+                -t ~{svtype} \
+                -o ~{sample_overlap} \
+                --preserve-ids \
+                --preserve-genotypes \
+                --preserve-header \
+                | bcftools sort -O z -o ~{prefix}.vcf.gz - 
+        tabix -p vcf ~{prefix}.vcf.gz
+    >>>
+
+    output {
+        File vcf_out = "~{prefix}.vcf.gz"
+        File vcf_out_idx = "~{prefix}.vcf.gz.tbi"
+    }
+}
+
+
+task Extract_SVID_by_GC{
+    input {
+        File? SVID_GC
+        File vcf
+        File vcf_index
+        String Genomic_Context
+        String svtype
+        Int min_size
+        Int max_size
+        String sv_benchmark_docker
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Float vcf_size = size(vcf, "GiB")
+    Int vm_disk_size = ceil(vcf_size * 2)
+
+    RuntimeAttr runtime_default = object {
+        mem_gb: 1,
+        disk_gb: vm_disk_size,
+        cpu_cores: 1,
+        preemptible_tries: 1,
+        max_retries: 1,
+        boot_disk_gb: 10
+    }
+    RuntimeAttr runtime_override = select_first([runtime_attr_override, runtime_default])
+
+    runtime {
+        memory: "~{select_first([runtime_override.mem_gb, runtime_default.mem_gb])} GiB"
+        disks: "local-disk ~{select_first([runtime_override.disk_gb, runtime_default.disk_gb])} HDD"
+        cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
+        preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
+        maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
+        docker: sv_benchmark_docker
+        bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
+    }
+
+    String prefix = basename(vcf, ".vcf.gz")
+
+    command <<<
+        set -euxo pipefail
+
+        python /src/extract_SVs_by_svtype_genomiccontect.py \
+        ~{vcf} \
+        ~{prefix}.~{svtype}.~{Genomic_Context}.vcf.gz \
+        ~{SVID_GC} \
+        ~{svtype} \
+        ~{Genomic_Context} \
+        ~{min_size} \
+        ~{max_size}
+
+        tabix -p vcf ~{prefix}.~{svtype}.~{Genomic_Context}.vcf.gz 
+
+    >>>
+
+    output {
+        File out_vcf = "~{prefix}.~{svtype}.~{Genomic_Context}.vcf.gz"
+        File out_idx = "~{prefix}.~{svtype}.~{Genomic_Context}.vcf.gz.tbi"
+    } 
+}
+
+

--- a/wdl/ReClusterCleanVcfWholeGenome.wdl
+++ b/wdl/ReClusterCleanVcfWholeGenome.wdl
@@ -1,0 +1,95 @@
+version 1.0
+
+# Author: Xuefang Zhao <XZHAO12@mgh.harvard.edu>
+
+import "Structs.wdl"
+import "ReClusterCleanVcfAcrossSVTYPE.wdl" as ReClusterCleanVcfAcrossSVTYPE
+# Workflow to annotate vcf file with genomic context
+
+workflow ReClusterCleanVcfWholeGenome {
+    input {
+        Array[File] vcf_list
+        Array[File] vcf_index_list
+        Array[String] chromosome_name_list
+        String prefix
+        String vid_prefix
+
+        File Repeat_Masks
+        File Simple_Repeats
+        File Segmental_Duplicates
+
+        Array[String] svtype_list
+        Array[Array[String]] Genomic_Context_list_list
+        Array[Array[Array[Int]]] size_list_list
+
+        Int num_vids
+        Int num_samples
+        Int dist
+        Int svsize
+        Float frac
+        Float sample_overlap
+
+        String sv_base_mini_docker
+        String sv_benchmark_docker
+        String sv_pipeline_docker
+
+        # overrides for MiniTasks
+        RuntimeAttr? runtime_override_vcf_to_bed
+        RuntimeAttr? runtime_attr_override_anno_gc
+        RuntimeAttr? runtime_attr_override_inte_gc
+        RuntimeAttr? runtime_override_extract_SV_sites
+        RuntimeAttr? runtime_attr_override_svtk_vcfcluster
+        RuntimeAttr? runtime_attr_override_extract_svid
+        RuntimeAttr? runtime_attr_override_integrate_vcfs
+        RuntimeAttr? runtime_attr_override_concat_clustered_SVID
+        RuntimeAttr? runtime_attr_override_sort_reclustered_vcf
+        RuntimeAttr? runtime_attr_override_concat_vcfs
+    }
+
+    scatter(i in range(length(vcf_list))){
+        call ReClusterCleanVcfAcrossSVTYPE.ReClusterCleanVcfAcrossSVTYPE as ReClusterCleanVcfAcrossSVTYPE{
+            input:
+                vcf = vcf_list[i],
+                vcf_index = vcf_index_list[i],
+                prefix = "~{prefix}_~{chromosome_name_list[i]}",
+                vid_prefix = "~{vid_prefix}_~{chromosome_name_list[i]}",
+
+                Repeat_Masks  = Repeat_Masks,
+                Simple_Repeats = Simple_Repeats,
+                Segmental_Duplicates  = Segmental_Duplicates,
+
+                svtype_list = svtype_list,
+                Genomic_Context_list_list = Genomic_Context_list_list,
+                size_list_list = size_list_list,
+
+                num_vids  = num_vids,
+                num_samples = num_samples,
+                dist  = dist,
+                svsize = svsize,
+                frac  = frac,
+                sample_overlap = sample_overlap,
+                sv_base_mini_docker = sv_base_mini_docker,
+                sv_benchmark_docker = sv_benchmark_docker,
+                sv_pipeline_docker = sv_pipeline_docker,
+                runtime_override_vcf_to_bed = runtime_override_vcf_to_bed,
+                runtime_attr_override_anno_gc = runtime_attr_override_anno_gc,
+                runtime_attr_override_inte_gc = runtime_attr_override_inte_gc,
+                runtime_override_extract_SV_sites = runtime_override_extract_SV_sites,
+                runtime_attr_override_svtk_vcfcluster = runtime_attr_override_svtk_vcfcluster,
+                runtime_attr_override_extract_svid = runtime_attr_override_extract_svid,
+                runtime_attr_override_integrate_vcfs  = runtime_attr_override_integrate_vcfs,
+                runtime_attr_override_concat_vcfs = runtime_attr_override_concat_vcfs,
+                runtime_attr_override_sort_reclustered_vcf = runtime_attr_override_sort_reclustered_vcf,
+                runtime_attr_override_concat_clustered_SVID = runtime_attr_override_concat_clustered_SVID
+       }
+    }
+
+    output{
+        Array[File] svid_annotation = ReClusterCleanVcfAcrossSVTYPE.svid_annotation
+        Array[File] out_vcfs = ReClusterCleanVcfAcrossSVTYPE.reclustered_SV_svtype
+        Array[File] out_vcf_idxes = ReClusterCleanVcfAcrossSVTYPE.reclustered_SV_svtype_idx
+    }
+}
+
+
+

--- a/wdl/TasksBenchmark.wdl
+++ b/wdl/TasksBenchmark.wdl
@@ -329,9 +329,141 @@ task vcf2bed {
 }
 
 
+#for the tasks to recluster SVs of specific type and fell within specific genomic regions
+task IntegrateReClusterdVcfs{
+    input{
+        File vcf_all
+        File vcf_all_idx
+        File vcf_recluster
+        File vcf_recluster_idx
+
+        String sv_pipeline_docker
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    RuntimeAttr runtime_default = object {
+        mem_gb: 7.5,
+        disk_gb: ceil(10.0 + size(vcf_all, "GiB")*4),
+        cpu_cores: 1,
+        preemptible_tries: 1,
+        max_retries: 1,
+        boot_disk_gb: 10
+    }
+
+    RuntimeAttr runtime_override = select_first([runtime_attr_override, runtime_default])
+    
+    runtime {
+        memory: "~{select_first([runtime_override.mem_gb, runtime_default.mem_gb])} GiB"
+        disks: "local-disk ~{select_first([runtime_override.disk_gb, runtime_default.disk_gb])} HDD"
+        cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
+        preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
+        maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
+        docker: sv_pipeline_docker
+        bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
+    }
+
+    String prefix = basename(vcf_recluster, ".vcf.gz")
+    String prefix_all = basename(vcf_all, ".vcf.gz")
+    
+    command <<<
+        svtk vcf2bed -i MEMBERS ~{vcf_recluster} ~{prefix}.bed
+        cut -f4,7 ~{prefix}.bed > ~{prefix}.SVID_anno
+        
+        python3 <<CODE
+
+        import os
+        import pysam
+
+        clustered_vs_origin_SVID = {}
+        SVID_list = []
+        fin=open("~{prefix}.SVID_anno")
+        for line in fin:
+            pin=line.strip().split()
+            if not pin[0]=='name' and len(pin[1].split(','))>1:
+                SVID_list.append(pin[0])
+                for i in pin[1].split(','):
+                    if not i in clustered_vs_origin_SVID.keys():
+                        clustered_vs_origin_SVID[i] = pin[0]
+        fin.close()
+
+        fin = pysam.VariantFile("~{vcf_all}")
+        fin2 = pysam.VariantFile("~{vcf_recluster}")
+        fo = pysam.VariantFile("~{prefix_all}.ReClustered_unsort.vcf.gz", 'w', header = fin2.header)
+        fo2 = pysam.VariantFile("~{prefix}.ReClustered_unsort.vcf.gz", 'w', header = fin2.header)
+        for record in fin:
+            if not record.id in clustered_vs_origin_SVID.keys():
+                fo.write(record)
+        fin.close()
+
+        for record in fin2:
+            if record.id in SVID_list:
+                print(record.id)
+                fo2.write(record)
+        fin2.close()
+        fo.close()
+        fo2.close()
+        print("done")
+        CODE
+
+        tabix -p vcf "~{prefix_all}.ReClustered_unsort.vcf.gz"
+        tabix -p vcf "~{prefix}.ReClustered_unsort.vcf.gz"
+    >>>
+
+    output{
+        File SVID_anno = "~{prefix}.SVID_anno"
+        File reclustered_Part1 = "~{prefix_all}.ReClustered_unsort.vcf.gz"
+        File reclustered_Part2 = "~{prefix}.ReClustered_unsort.vcf.gz"
+        File reclustered_Part1_idx = "~{prefix_all}.ReClustered_unsort.vcf.gz.tbi"
+        File reclustered_Part2_idx = "~{prefix}.ReClustered_unsort.vcf.gz.tbi"
+    }
+}
 
 
+task SortReClusterdVcfs{
+  input{
+    File vcf_1
+    File vcf_2
+    File vcf_1_idx
+    File vcf_2_idx
 
+    String sv_pipeline_docker
+    RuntimeAttr? runtime_attr_override
+  }
 
+  RuntimeAttr runtime_default = object {
+                                  mem_gb: 7.5,
+                                  disk_gb: ceil(10.0 + size(vcf_1, "GiB")*2 + size(vcf_2, "GiB")*2),
+                                  cpu_cores: 1,
+                                  preemptible_tries: 1,
+                                  max_retries: 1,
+                                  boot_disk_gb: 10
+                                }
 
+  RuntimeAttr runtime_override = select_first([runtime_attr_override, runtime_default])
 
+  runtime {
+    memory: "~{select_first([runtime_override.mem_gb, runtime_default.mem_gb])} GiB"
+    disks: "local-disk ~{select_first([runtime_override.disk_gb, runtime_default.disk_gb])} HDD"
+    cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
+    preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
+    maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
+    docker: sv_pipeline_docker
+    bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
+  }
+
+  String prefix_all = basename(vcf_1, ".ReClustered_unsort.vcf.gz")
+
+  command <<<
+    echo "~{vcf_1}" >> vcf_list
+    echo "~{vcf_2}" >> vcf_list
+    bcftools concat --allow-overlaps --output-type z --file-list vcf_list --output ~{prefix_all}.ReClustered.vcf.gz
+    tabix -p vcf ~{prefix_all}.ReClustered.vcf.gz
+
+  >>>
+
+  output{
+    File sorted_vcf = "~{prefix_all}.ReClustered.vcf.gz"
+    File sorted_vcf_idx = "~{prefix_all}.ReClustered.vcf.gz.tbi"
+  }
+}


### PR DESCRIPTION
Workflows for reclustering CNVs in repetitive regions. This is intended as a temporary solution for cleaning up redundant calls post-filtering, but I'm providing it here for use with ongoing projects until we can implement a permanent solution.

Credit to @xuefzhao for authoring the methods here.