### PR TITLE
Replace EH version with its current latest release 

### DIFF
--- a/dockerfiles/str/Dockerfile
+++ b/dockerfiles/str/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install --no-install-recommends -qqy \
     build-essential \
     libssl-dev \
     libffi-dev \
-    python3-dev \
+    python3.10-dev \
     python3-pip \
     python3-wheel \
     python3-venv \
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install --no-install-recommends -qqy \
     wget \
     ca-certificates && \
     update-ca-certificates && \
-    alias python=python3
+    ln -s /usr/bin/python3 /usr/bin/python
 
 RUN pip install --upgrade setuptools
 # Combining the following two `RUN`s under a single `RUN` cause image build failure.

--- a/dockerfiles/str/Dockerfile
+++ b/dockerfiles/str/Dockerfile
@@ -1,17 +1,18 @@
 # This docker image contains the following
 # list of tools and their dependencies:
-# - ExpansionHunter (custom-built);
+# - ExpansionHunter v5;
 # - htslib, bcftools, and samtools;
 # - python3.6, pip
+# - numpy, and pandas
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ARG HTSLIB_VER=1.15.1
 ARG BCFTOOLS_VER=1.15.1
 ARG SAMTOOLS_VER=1.15.1
+ARG EH_VER=5.0.0
 
 RUN apt-get update && apt-get install --no-install-recommends -qqy \
-    libcurl3 \
     tabix \
     git \
     make \
@@ -23,7 +24,7 @@ RUN apt-get update && apt-get install --no-install-recommends -qqy \
     libcurl4-gnutls-dev \
     libncurses5-dev \
     libncursesw5-dev \
-    python3.6-dev \
+    python3.8-dev \
     python3-pip \
     python3-wheel \
     python3-venv \
@@ -32,8 +33,7 @@ RUN apt-get update && apt-get install --no-install-recommends -qqy \
     wget \
     ca-certificates && \
     update-ca-certificates && \
-    ln -s /usr/bin/python3.6 /usr/bin/python && \
-    ln -s /usr/bin/pip3 /usr/bin/pip
+    alias python=python3
 
 RUN pip install --upgrade setuptools
 # Combining the following two `RUN`s under a single `RUN` cause image build failure.
@@ -42,8 +42,10 @@ RUN pip install -q -U Cython==0.29.30 numpy==1.19.5
 RUN pip install -q -U pandas==1.1.5
 
 RUN cd /opt/ && mkdir eh && cd eh/ && \
-    wget -O ExpansionHunter https://github.com/bw2/ExpansionHunter/raw/master/bin/linux/ExpansionHunter && \
-    chmod 0755 ExpansionHunter
+    wget -O eh.tar.gz https://github.com/Illumina/ExpansionHunter/releases/download/v$EH_VER/ExpansionHunter-v$EH_VER-linux_x86_64.tar.gz && \
+    mkdir eh && tar -xf eh.tar.gz -C eh --strip-components=1 && \
+    mv eh/bin/ExpansionHunter . && \
+    rm eh.tar.gz && rm -r eh && cd ..
 ENV PATH="/opt/eh/:$PATH"
 
 # Install htslib, bcftools, & samtools.

--- a/dockerfiles/str/Dockerfile
+++ b/dockerfiles/str/Dockerfile
@@ -5,7 +5,7 @@
 # - python3.6, pip
 # - numpy, and pandas
 
-FROM ubuntu:20.04
+FROM ubuntu:22.10
 
 ARG HTSLIB_VER=1.15.1
 ARG BCFTOOLS_VER=1.15.1
@@ -13,6 +13,8 @@ ARG SAMTOOLS_VER=1.15.1
 ARG EH_VER=5.0.0
 
 RUN apt-get update && apt-get install --no-install-recommends -qqy \
+# libcurl3 is needed for EH.
+    libcurl3-nss \
     tabix \
     git \
     make \
@@ -24,7 +26,10 @@ RUN apt-get update && apt-get install --no-install-recommends -qqy \
     libcurl4-gnutls-dev \
     libncurses5-dev \
     libncursesw5-dev \
-    python3.8-dev \
+    build-essential \
+    libssl-dev \
+    libffi-dev \
+    python3-dev \
     python3-pip \
     python3-wheel \
     python3-venv \

--- a/dockerfiles/str/Dockerfile
+++ b/dockerfiles/str/Dockerfile
@@ -13,8 +13,7 @@ ARG SAMTOOLS_VER=1.15.1
 ARG EH_VER=5.0.0
 
 RUN apt-get update && apt-get install --no-install-recommends -qqy \
-# libcurl3 is needed for EH.
-    libcurl3-nss \
+    curl \
     tabix \
     git \
     make \
@@ -43,8 +42,9 @@ RUN apt-get update && apt-get install --no-install-recommends -qqy \
 RUN pip install --upgrade setuptools
 # Combining the following two `RUN`s under a single `RUN` cause image build failure.
 # RUN pip3 install -q -U wheel Cython==0.29.30 numpy==1.19.5 pandas==1.1.5
-RUN pip install -q -U Cython==0.29.30 numpy==1.19.5
-RUN pip install -q -U pandas==1.1.5
+RUN pip install -q numpy==1.23.4
+RUN pip install -q Cython==0.29.32
+RUN pip install -q pandas==1.5.0
 
 RUN cd /opt/ && mkdir eh && cd eh/ && \
     wget -O eh.tar.gz https://github.com/Illumina/ExpansionHunter/releases/download/v$EH_VER/ExpansionHunter-v$EH_VER-linux_x86_64.tar.gz && \

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -24,6 +24,7 @@ workflow ExpansionHunter {
         Boolean? generate_realigned_bam
         Boolean? generate_vcf
         Boolean? seeking_analysis_mode
+        Int? thread_count
         File? ped_file
         String expansion_hunter_docker
         String python_docker
@@ -47,6 +48,7 @@ workflow ExpansionHunter {
         reference_fasta_index,
         reference_fasta + ".fai"])
 
+    Int thread_count_ = select_first([thread_count, 2])
     Boolean generate_realigned_bam_ = select_first([generate_realigned_bam, false])
     Boolean generate_vcf_ = select_first([generate_vcf, false])
     Boolean seeking_analysis_mode_ = select_first([seeking_analysis_mode, true])
@@ -68,6 +70,7 @@ workflow ExpansionHunter {
                 generate_realigned_bam = generate_realigned_bam_,
                 generate_vcf = generate_vcf_,
                 analysis_mode = analysis_mode,
+                thread_count = thread_count_,
                 ped_file = ped_file,
                 expansion_hunter_docker = expansion_hunter_docker,
                 runtime_override = runtime_eh
@@ -80,7 +83,6 @@ workflow ExpansionHunter {
             variants_tsvs = RunExpansionHunter.variants_tsv,
             alleles_tsvs = RunExpansionHunter.alleles_tsv,
             realigned_bams = RunExpansionHunter.realigned_bam,
-            timings = RunExpansionHunter.timing,
             generate_realigned_bam = generate_realigned_bam_,
             generate_vcf = generate_vcf_,
             output_prefix = sample_id,
@@ -93,7 +95,7 @@ workflow ExpansionHunter {
         File alleles_tsv = ConcatEHOutputs.alleles_tsv
         File vcf_gz = ConcatEHOutputs.vcf_gz
         File realigned_bam = ConcatEHOutputs.realigned_bam
-        File timing = ConcatEHOutputs.timing
+        Array[File] jsons_gz = RunExpansionHunter.json_gz
     }
 }
 
@@ -108,6 +110,7 @@ task RunExpansionHunter {
         Boolean generate_realigned_bam
         Boolean generate_vcf
         String analysis_mode
+        Int thread_count
         File? ped_file
         String expansion_hunter_docker
         RuntimeAttr? runtime_override
@@ -117,8 +120,8 @@ task RunExpansionHunter {
         File variants_tsv = "${sample_id}_variants.tsv"
         File alleles_tsv = "${sample_id}_alleles.tsv"
         File vcf_gz = "${sample_id}.vcf.gz"
+        File json_gz = "${sample_id}.json.gz"
         File realigned_bam = "${sample_id}_realigned.bam"
-        File timing = "${sample_id}_timing.tsv"
     }
 
     command <<<
@@ -144,15 +147,13 @@ task RunExpansionHunter {
             fi
         fi
 
-        touch ~{sample_id}_timing.tsv
         ExpansionHunter \
             --reads ~{bam_or_cram} \
             --reference $REF \
             --variant-catalog ~{variant_catalog} \
             --output-prefix ~{sample_id} \
             --analysis-mode ~{analysis_mode} \
-            --cache-mates \
-            --record-timing \
+            --threads ~{thread_count} \
             $sex
 
         if [ ~{generate_realigned_bam} = false ]; then
@@ -170,6 +171,8 @@ task RunExpansionHunter {
         python /opt/str/combine_expansion_hunter_json_to_tsv.py -o ~{sample_id} ~{sample_id}.json
         mv ~{sample_id}.*_json_files_alleles.tsv ~{sample_id}_alleles.tsv
         mv ~{sample_id}.*_json_files_variants.tsv ~{sample_id}_variants.tsv
+
+        bgzip ~{sample_id}.json
     >>>
 
     RuntimeAttr runtime_default = object {
@@ -178,11 +181,12 @@ task RunExpansionHunter {
         boot_disk_gb: 10,
         preemptible_tries: 3,
         max_retries: 1,
-        disk_gb: 10 + ceil(size([
-            bam_or_cram,
-            bam_or_cram_index,
-            reference_fasta,
-            reference_fasta_index], "GiB"))
+        disk_gb: 10 + (
+            2 * ceil(size([
+                bam_or_cram,
+                bam_or_cram_index,
+                reference_fasta,
+                reference_fasta_index], "GiB")))
     }
     RuntimeAttr runtime_attr = select_first([runtime_override, runtime_default])
 
@@ -203,7 +207,6 @@ task ConcatEHOutputs {
         Array[File] variants_tsvs
         Array[File] alleles_tsvs
         Array[File] realigned_bams
-        Array[File] timings
         Boolean generate_realigned_bam
         Boolean generate_vcf
         String? output_prefix
@@ -216,7 +219,6 @@ task ConcatEHOutputs {
         File alleles_tsv = "${output_prefix}_alleles.tsv"
         File vcf_gz = "${output_prefix}.vcf.gz"
         File realigned_bam = "${output_prefix}.bam"
-        File timing = "${output_prefix}_timing.tsv"
     }
 
     command <<<
@@ -247,7 +249,6 @@ task ConcatEHOutputs {
             done < $INPUTS
         }
 
-        merge_tsv "~{write_lines(timings)}" "~{output_prefix}_timing.tsv"
         merge_tsv "~{write_lines(alleles_tsvs)}" "~{output_prefix}_alleles.tsv"
         merge_tsv "~{write_lines(variants_tsvs)}" "~{output_prefix}_variants.tsv"
     >>>
@@ -263,8 +264,7 @@ task ConcatEHOutputs {
                 size(vcfs_gz, "GiB") +
                 size(variants_tsvs, "GiB") +
                 size(alleles_tsvs, "GiB") +
-                size(realigned_bams, "GiB") +
-                size(timings, "GiB")))
+                size(realigned_bams, "GiB")))
     }
     RuntimeAttr runtime_attr = select_first([runtime_override, runtime_default])
 

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -194,7 +194,7 @@ task RunExpansionHunter {
         docker: expansion_hunter_docker
         cpu: select_first([runtime_attr.cpu_cores, runtime_default.cpu_cores])
         memory: select_first([runtime_attr.mem_gb, runtime_default.mem_gb]) + " GiB"
-        disks: "local-disk " + select_first([runtime_attr.disk_gb, runtime_default.disk_gb])  + " HDD"
+        disks: "local-disk " + select_first([runtime_attr.disk_gb, runtime_default.disk_gb])  + " SSD"
         bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, runtime_default.boot_disk_gb])
         preemptible: select_first([runtime_attr.preemptible_tries, runtime_default.preemptible_tries])
         maxRetries: select_first([runtime_attr.max_retries, runtime_default.max_retries])
@@ -272,7 +272,7 @@ task ConcatEHOutputs {
         docker: expansion_hunter_docker
         cpu: select_first([runtime_attr.cpu_cores, runtime_default.cpu_cores])
         memory: select_first([runtime_attr.mem_gb, runtime_default.mem_gb]) + " GiB"
-        disks: "local-disk " + select_first([runtime_attr.disk_gb, runtime_default.disk_gb]) + " HDD"
+        disks: "local-disk " + select_first([runtime_attr.disk_gb, runtime_default.disk_gb]) + " SSD"
         bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, runtime_default.boot_disk_gb])
         preemptible: select_first([runtime_attr.preemptible_tries, runtime_default.preemptible_tries])
         maxRetries: select_first([runtime_attr.max_retries, runtime_default.max_retries])

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -172,7 +172,7 @@ task RunExpansionHunter {
         mv ~{sample_id}.*_json_files_alleles.tsv ~{sample_id}_alleles.tsv
         mv ~{sample_id}.*_json_files_variants.tsv ~{sample_id}_variants.tsv
 
-        bgzip ~{sample_id}.json
+        gzip ~{sample_id}.json
     >>>
 
     RuntimeAttr runtime_default = object {

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -17,6 +17,7 @@ workflow ExpansionHunterScatter {
         Boolean? generate_realigned_bam
         Boolean? generate_vcf
         Boolean? seeking_analysis_mode
+        Int? thread_count
         String expansion_hunter_docker
         String python_docker
         RuntimeAttr? runtime_split_var_catalog
@@ -56,20 +57,21 @@ workflow ExpansionHunterScatter {
 
         call ExpansionHunter.ExpansionHunter  {
             input:
-                bam_or_cram=bam_or_cram_,
-                bam_or_cram_index=bam_or_cram_index_,
-                reference_fasta=reference_fasta,
-                reference_fasta_index=reference_fasta_index_,
-                split_variant_catalogs=SplitVariantCatalog.catalogs_json,
-                sample_id=sample_id,
-                ped_file=ped_file,
-                generate_realigned_bam=generate_realigned_bam,
-                generate_vcf=generate_vcf,
-                seeking_analysis_mode=seeking_analysis_mode,
-                expansion_hunter_docker=expansion_hunter_docker,
-                python_docker=python_docker,
-                runtime_eh=runtime_eh,
-                runtime_concat=runtime_concat
+                bam_or_cram = bam_or_cram_,
+                bam_or_cram_index = bam_or_cram_index_,
+                reference_fasta = reference_fasta,
+                reference_fasta_index = reference_fasta_index_,
+                split_variant_catalogs = SplitVariantCatalog.catalogs_json,
+                sample_id = sample_id,
+                ped_file = ped_file,
+                generate_realigned_bam = generate_realigned_bam,
+                generate_vcf = generate_vcf,
+                seeking_analysis_mode = seeking_analysis_mode,
+                thread_count = thread_count,
+                expansion_hunter_docker = expansion_hunter_docker,
+                python_docker = python_docker,
+                runtime_eh = runtime_eh,
+                runtime_concat = runtime_concat
         }
     }
 
@@ -78,7 +80,7 @@ workflow ExpansionHunterScatter {
         Array[File] alleles_tsv = ExpansionHunter.alleles_tsv
         Array[File] vcfs_gz = ExpansionHunter.vcf_gz
         Array[File] realigned_bam = ExpansionHunter.realigned_bam
-        Array[File] timing = ExpansionHunter.timing
+        Array[Array[File]] jsons_gz = ExpansionHunter.jsons_gz
     }
 }
 


### PR DESCRIPTION
Updates the ExpansionHunter (EH) workflow to use Illumina's current latest release, replacing an in-house built version. Specifically: 

- [x] Update the Dockerfile;
- [x] Add a `thread_count` workflow option since EH's current latest release is multi-threaded;
- [x] Remove `timings` since it the output of the in-house built;
- [x] Export all the JSON outputs of EH in addition to converting them to TSV and combining the output of multiple shards;
- [x] Change the default disk type from `HDD` to `SSD` since the process is I/O-bound. In a follow up PR, we can extend the `RuntimeAttr` so it takes the type of disk and applies accordingly. 