### PR TITLE
GATK vcf formatting script fixes

### DIFF
--- a/src/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py
+++ b/src/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py
@@ -32,7 +32,7 @@ def _parse_bnd_ends(vcf_path: Text) -> Dict[Text, int]:
             columns = line.split('\t', 8)
             vid = columns[2]
             info = columns[7]
-            if 'SVTYPE=BND' not in info:
+            if 'SVTYPE=BND' not in info and 'SVTYPE=CTX' not in info and 'SVTYPE=CPX' not in info:
                 continue
             info_tokens = info.split(';')
             end_field_list = [x for x in info_tokens if x.startswith("END=")]
@@ -91,7 +91,6 @@ def create_header(header_in: pysam.VariantHeader,
         gatk-style header
     """
     header = pysam.VariantHeader()
-    remove_formats.add('EV')
     for sample in header_in.samples:
         header.add_sample(sample)
     for line in header_in.records:


### PR DESCRIPTION
Fixes an issue where the `EV` FORMAT field was incorrectly removed from the header. Also adds `END2` tag propagation for CPX/CTX types.