### PR TITLE
update terra dashboard pipeline diagram to v0.26.3-beta

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
@@ -43,7 +43,7 @@ The following are the main pipeline outputs. For more information on the outputs
 
 ### Pipeline overview
 
-<img alt="pipeline_diagram" title="Pipeline diagram" src="https://github.com/broadinstitute/gatk-sv/blob/v0.18.1-beta/terra_pipeline_diagram.jpg?raw=true" width="1000">
+<img alt="pipeline_diagram" title="Pipeline diagram" src="https://raw.githubusercontent.com/broadinstitute/gatk-sv/v0.26.4-beta/terra_pipeline_diagram.jpg" width="1000">
 
 The following workflows are included in this workspace, to be executed in this order:
 


### PR DESCRIPTION
### Updates
Update pipeline diagram on Terra cohort mode dashboard to v0.26.3-beta 

### Testing
New image is live in 1kgp workspace