### PR TITLE
Add SVG files to git-lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This PR extends `.gitattributes` to track SVG files via git-lfs. 