### PR TITLE
Keep mCNVs when removing private sites during SubsetVcfBySamplesList

### DIFF
--- a/wdl/Utils.wdl
+++ b/wdl/Utils.wdl
@@ -661,7 +661,7 @@ task SubsetVcfBySamplesList {
   String vcf_subset_filename = select_first([outfile_name, basename(vcf, ".vcf.gz") + ".subset.vcf.gz"])
   String vcf_subset_idx_filename = vcf_subset_filename + ".tbi"
 
-  String remove_private_sites_flag = if remove_private_sites then " | bcftools view --min-ac 1 " else ""
+  String remove_private_sites_flag = if remove_private_sites then " | bcftools +fill-tags -- -t AC | bcftools view -i 'SVTYPE==\"CNV\" || AC>0' " else ""
   String complement_flag = if remove_samples then "^" else ""
 
   # Disk must be scaled proportionally to the size of the VCF


### PR DESCRIPTION
### Updates
Previously, SubsetVcfBySamplesList applied `--min-ac 1` during `bcftools view` to remove sites that were private to samples that got removed from the VCF during the task. But that removed all mCNVs, which have `./.` GT for all samples. This update instead computes the site's AC and then removes non-`CNV` type sites with `AC` less than 1. 

Caveat: Sites of type `CNV` that are not variant in any remaining samples will not be removed from the VCF by this method. In most cases, that is likely to be fine as mCNV sites are common in the population.

Note that any cohorts processed through FilterBatchSamples while the previous version was in place should be fine, because no `CNV` sites are present at that point in the pipeline.

### Testing
* Womtool validation of all WDLs and JSONs
* Ran SubsetVcfBySamples WDL on ref panel successfully and verified that site counts matched previous run + the number of CNVs retained

