### PR TITLE
Include mCNVs in per-sample QC plots in MainVcfQc

### DIFF
--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -1,5 +1,6 @@
 version 1.0
 
+import "ApplyManualVariantFilter.wdl" as manualfilter
 import "CollectQcVcfWide.wdl" as vcfwideqc
 import "CollectQcPerSample.wdl" as persample
 import "CollectSiteLevelBenchmarking.wdl" as sitebench
@@ -26,6 +27,7 @@ workflow MainVcfQc {
     File primary_contigs_fai
     Int? random_seed
     Int? max_gq  # Max GQ for plotting. Default = 99, ie. GQ is on a scale of [0,99]. Prior to CleanVcf, use 999
+    String? bcftools_hard_filter_query
 
     String sv_base_mini_docker
     String sv_pipeline_docker
@@ -38,6 +40,7 @@ workflow MainVcfQc {
     RuntimeAttr? runtime_override_plot_qc_per_family
     RuntimeAttr? runtime_override_per_sample_benchmark_plot
     RuntimeAttr? runtime_override_sanitize_outputs
+    RuntimeAttr? runtime_override_hard_filter
 
     # overrides for MiniTasks or Utils
     RuntimeAttr? runtime_override_subset_vcf
@@ -86,7 +89,23 @@ workflow MainVcfQc {
     }
   }
 
-  Array[File] vcfs_for_qc = select_first([SubsetVcfBySamplesList.vcf_subset, vcfs])
+  # Apply an optional hard filter to the VCF before QC, ie. restrict to only PASS/MULTIALLELIC sites
+  if (defined(bcftools_hard_filter_query)) {
+    scatter (vcf in select_first([SubsetVcfBySamplesList.vcf_subset, vcfs])) {
+      call manualfilter.HardFilterVcf {
+        input:
+          prefix = basename(vcf, ".vcf.gz"),
+          vcf = vcf,
+          vcf_index = vcf + ".tbi",
+          filter_name = "hard_filter",
+          bcftools_filter = select_first([bcftools_hard_filter_query]),
+          sv_base_mini_docker = sv_base_mini_docker,
+          runtime_attr_override = runtime_override_hard_filter
+      }
+    }
+  }
+
+  Array[File] vcfs_for_qc = select_first([HardFilterVcf.hard_filtered_vcf, SubsetVcfBySamplesList.vcf_subset, vcfs])
 
   # Scatter raw variant data collection per chromosome
   scatter ( contig in contigs ) {

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -27,6 +27,7 @@ workflow MainVcfQc {
     File primary_contigs_fai
     Int? random_seed
     Int? max_gq  # Max GQ for plotting. Default = 99, ie. GQ is on a scale of [0,99]. Prior to CleanVcf, use 999
+    Int? downsample_qc_per_sample  # Number of samples to use for per-sample QC. Default: 1000
     String? bcftools_hard_filter_query
 
     String sv_base_mini_docker
@@ -231,6 +232,7 @@ workflow MainVcfQc {
       per_sample_tarball=TarShardVidLists.vid_lists,
       prefix=prefix,
       max_gq=max_gq_,
+      downsample_qc_per_sample=downsample_qc_per_sample,
       sv_pipeline_qc_docker=sv_pipeline_qc_docker,
       runtime_attr_override=runtime_override_plot_qc_per_sample
   }
@@ -471,6 +473,7 @@ task PlotQcPerSample {
     File per_sample_tarball
     String prefix
     Int max_gq
+    Int? downsample_qc_per_sample
     String sv_pipeline_qc_docker
     RuntimeAttr? runtime_attr_override
   }
@@ -515,7 +518,8 @@ task PlotQcPerSample {
       ~{samples_list} \
       ~{prefix}_perSample/ \
       ~{prefix}_perSample_plots/ \
-      --maxgq ~{max_gq}
+      --maxgq ~{max_gq} \
+      ~{"--downsample " + downsample_qc_per_sample}
 
     # Prepare output
     tar -czvf ~{prefix}.plotQC_perSample.tar.gz \


### PR DESCRIPTION
### Updates
* Include mCNVs in per-sample QC plots in MainVcfQc. Previously they were excluded due to a call to `bcftools view --min-ac 1` so this was revised to keep them
* Expose parameter `downsample` to control the number of samples used for per-sample QC plots

### Testing
* Validate all WDLs and JSONs with womtool & Terra input validation
* Test MainVcfQc with ref panel with downsample parameter. CNVs were included in the per-sample plots