### PR TITLE
Update WDLs to adhere with  implicit coercions requirement

### DIFF
--- a/wdl/ExpansionHunterDenovo.wdl
+++ b/wdl/ExpansionHunterDenovo.wdl
@@ -8,16 +8,7 @@
 
 version 1.0
 
-#import "Structs.wdl"
-# Carrot currently does not support imports.
-struct RuntimeAttr {
-  Float? mem_gb
-  Int? cpu_cores
-  Int? disk_gb
-  Int? boot_disk_gb
-  Int? preemptible_tries
-  Int? max_retries
-}
+import "Structs.wdl"
 
 struct FilenamePostfixes {
   String locus
@@ -184,7 +175,7 @@ task ComputeSTRProfile {
 
   >>>
 
-  RuntimeAttr runtime_attr_str_profile_default = object {
+  RuntimeAttr default_attr = object {
     cpu_cores: 1,
     mem_gb: 4,
     boot_disk_gb: 10,
@@ -198,13 +189,13 @@ task ComputeSTRProfile {
   }
   RuntimeAttr runtime_attr = select_first([
     runtime_attr_override,
-    runtime_attr_str_profile_default])
+    default_attr])
 
   runtime {
     docker: ehdn_docker
     cpu: runtime_attr.cpu_cores
-    memory: runtime_attr.mem_gb + " GiB"
-    disks: "local-disk " + runtime_attr.disk_gb + " HDD"
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: runtime_attr.boot_disk_gb
     preemptible: runtime_attr.preemptible_tries
     maxRetries: runtime_attr.max_retries
@@ -324,7 +315,7 @@ task STRAnalyze {
     done
   >>>
 
-  RuntimeAttr runtime_attr_analysis_default = object {
+  RuntimeAttr default_attr = object {
   cpu_cores: 1,
   mem_gb: 4,
   boot_disk_gb: 10,
@@ -336,13 +327,13 @@ task STRAnalyze {
   }
   RuntimeAttr runtime_attr = select_first([
     runtime_attr_override,
-    runtime_attr_analysis_default])
+    default_attr])
 
   runtime {
     docker: ehdn_docker
     cpu: runtime_attr.cpu_cores
-    memory: runtime_attr.mem_gb + " GiB"
-    disks: "local-disk " + runtime_attr.disk_gb + " HDD"
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: runtime_attr.boot_disk_gb
     preemptible: runtime_attr.preemptible_tries
     maxRetries: runtime_attr.max_retries

--- a/wdl/GangSTR.wdl
+++ b/wdl/GangSTR.wdl
@@ -98,7 +98,7 @@ task CallGangSTR {
       --out ~{output_prefix}
   >>>
 
-  RuntimeAttr runtime_attr_str_profile_default = object {
+  RuntimeAttr default_attr = object {
     cpu_cores: 1,
     mem_gb: 4,
     boot_disk_gb: 10,
@@ -111,13 +111,13 @@ task CallGangSTR {
   }
   RuntimeAttr runtime_attr = select_first([
     runtime_attr_override,
-    runtime_attr_str_profile_default])
+    default_attr])
 
   runtime {
     docker: str_docker
     cpu: runtime_attr.cpu_cores
-    memory: runtime_attr.mem_gb + " GiB"
-    disks: "local-disk " + runtime_attr.disk_gb + " HDD"
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: runtime_attr.boot_disk_gb
     preemptible: runtime_attr.preemptible_tries
     maxRetries: runtime_attr.max_retries

--- a/wdl/MakeBincovMatrix.wdl
+++ b/wdl/MakeBincovMatrix.wdl
@@ -144,7 +144,7 @@ task SetBins {
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
-    disks: "local-disk " + runtime_attr.disk_gb + " HDD"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
     docker: sv_base_mini_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
@@ -210,7 +210,7 @@ task MakeBincovMatrixColumns {
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
-    disks: "local-disk " + runtime_attr.disk_gb + " HDD"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
     docker: sv_base_mini_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
@@ -271,7 +271,7 @@ task ZPaste {
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
-    disks: "local-disk " + runtime_attr.disk_gb + " HDD"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
     docker: sv_base_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])

--- a/wdl/ShardedCluster.wdl
+++ b/wdl/ShardedCluster.wdl
@@ -59,7 +59,7 @@ workflow ShardedCluster {
 
   File vcf_idx = vcf + ".tbi"
   if (defined(exclude_list)) {
-    File exclude_list_idx = exclude_list + ".tbi"
+    File exclude_list_idx = select_first([exclude_list]) + ".tbi"
   }
 
   call MiniTasks.MakeSitesOnlyVcf {


### PR DESCRIPTION
This PR updates WDLs to adhere to the requirements of concatenating optional and required variables. For instance, 

- Instead of:
   ```
   String? firstname
   String name = firstname + " lastname"
   ```

- Use:
   ```
   String? firstname
   String name = select_first([firstname]) + " lastname"
   ```

This assertion was enforced in the recent [miniwdl release](https://github.com/chanzuckerberg/miniwdl/releases/tag/v1.9.0). This PR updates the WDLs to adhere to the implicit coercion requirement. Specifically resolving miniwdl validation errors such as the following.

```
# from WDL, where `disk_gb` is optional:
disks: "local-disk " + runtime_attr.disk_gb + " HDD"

# error:
Validation Error: 'Cannot add/concatenate String and Int?'
```