### PR TITLE
Set target images for Azure based on commit SHA

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -230,7 +230,8 @@ jobs:
       - name: Build and Publish Docker Images to ACR
         run: |
           python ./scripts/docker/build_docker.py \
-            --targets manta \
+            --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \
+            --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} \
             --docker-repo ${{ secrets.AZ_CR }} \
             --image-tag ${{ needs.build_args_job.outputs.image_tag }} \
             --input-json $DOCKERS_AZURE \


### PR DESCRIPTION
In https://github.com/broadinstitute/gatk-sv/pull/477 the target images were manually set to a small image rebuit for development and testing purposes, which was not corrected before the PR was merged. This PR fixes that by setting the target images of the ACR action based on the commit SHA .  