### PR TITLE
Build and publish images to multiple registries in one job, & update the dependencies of the action

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,9 +11,9 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -30,7 +30,7 @@ jobs:
       image_tag: ${{ steps.image_tag.outputs.IMAGE_TAG }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # By default, this checks out only the current commit;
           # however, since a diff between the current commit and
@@ -79,8 +79,8 @@ jobs:
           echo "::debug::HEAD_SHA: $HEAD_SHA"
 
           # Avail the determined commit SHAs to other steps.
-          echo "::set-output name=BASE_SHA::$BASE_SHA"
-          echo "::set-output name=HEAD_SHA::$HEAD_SHA"
+          echo "BASE_SHA=$BASE_SHA" >> $GITHUB_OUTPUT
+          echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_OUTPUT
 
       - name: Compose Image Tag
         id: image_tag
@@ -106,7 +106,7 @@ jobs:
           
           IMAGE_TAG=$DATE-$RELEASE_TAG-${COMMIT_SHA::8}
           echo "::debug::Image tag: $IMAGE_TAG"
-          echo "::set-output name=IMAGE_TAG::$IMAGE_TAG"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   build_job:
     runs-on: ubuntu-20.04
@@ -118,7 +118,7 @@ jobs:
         python-version: ['3.8']
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # See the comment on build_args_job.
           fetch-depth: 0
@@ -127,11 +127,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install termcolor
 
       - name: Run build_docker.py
         run: |
@@ -160,7 +155,7 @@ jobs:
       DOCKERS_GCP: "./inputs/values/dockers.json"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # See the comment on build_args_job.
           fetch-depth: 0
@@ -168,14 +163,9 @@ jobs:
           token: ${{ secrets.BOT_PAT }}
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install termcolor
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v0.3.0

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -167,6 +167,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Azure login
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.AZ_CR }}
+          username: ${{ secrets.AZ_USERNAME }}
+          password: ${{ secrets.AZ_PASSWORD }}
+
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v0.3.0
         with:
@@ -196,7 +203,7 @@ jobs:
           sudo mv "$tmp" /etc/docker/daemon.json
           sudo systemctl restart docker.service
 
-      - name: Build and Publish Docker Images to GCR
+      - name: Build and Publish Docker Images to ACR & GCR
         id: build_and_publish
         run: |
           python ./scripts/docker/build_docker.py \
@@ -204,30 +211,12 @@ jobs:
             --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} \
             --docker-repo us.gcr.io/${{ secrets.GCP_PROJECT_ID }}/gatk-sv \
             --image-tag ${{ needs.build_args_job.outputs.image_tag }} \
-            --input-json $DOCKERS_GCP \
-            --output-json $DOCKERS_GCP
+            --input-json $DOCKERS_AZURE $DOCKERS_GCP \
+            --output-json $DOCKERS_AZURE $DOCKERS_GCP \
+            --disable-git-protect
           
           CHANGED=$(git diff --quiet $DOCKERS_GCP || echo True)
           echo "::set-output name=CHANGED::$CHANGED"
-
-      - name: Azure login
-        uses: azure/docker-login@v1
-        with:
-          login-server: ${{ secrets.AZ_CR }}
-          username: ${{ secrets.AZ_USERNAME }}
-          password: ${{ secrets.AZ_PASSWORD }}
-
-      - name: Build and Publish Docker Images to ACR
-        run: |
-          python ./scripts/docker/build_docker.py \
-            --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \
-            --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} \
-            --docker-repo ${{ secrets.AZ_CR }} \
-            --image-tag ${{ needs.build_args_job.outputs.image_tag }} \
-            --input-json $DOCKERS_AZURE \
-            --output-json $DOCKERS_AZURE \
-            --prune-after-each-image \
-            --disable-git-protect
 
       - name: Commit Changes to dockers_*.json
         if: steps.build_and_publish.outputs.CHANGED
@@ -237,4 +226,9 @@ jobs:
           git config --global user.email '101641599+gatk-sv-bot@users.noreply.github.com'
           git commit $DOCKERS_AZURE $DOCKERS_GCP -m "Update docker images list, triggered by "${COMMIT_SHA::8}
           git pull --rebase origin main
-          git push
+          
+          # In the following, force-push is required when the above rebase updates the branch;
+          # otherwise, the push will be rejected with the following error: 
+          # > Updates were rejected because the tip of your current branch is behind ts remote counterpart.
+          # See this thread for details: https://stackoverflow.com/q/39399804
+          git push -f

--- a/.github/workflows/testwdls.yaml
+++ b/.github/workflows/testwdls.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
To build and publish Docker images to GCR and ACR, previously, we needed to run `build_docker.py` once for each of the registries; hence, the `Docker Images` workflow was implemented accordingly. However, we observed a few ephemeral errors with this approach where with the changes to the git status in the first run of `build_docker.py`, the second run cannot read git HEAD. We could solve this issue by re-running the failed action.  

To improve the reliability of the action and decrease its runtime, I added multi-registry support to `build_docker.py` in https://github.com/broadinstitute/gatk-sv/pull/507, which allows building and publishing Docker images to multiple container registries in one run.

This PR updates the `Docker Images` workflow to build and publish images to GCR and ACR in one _step_; specifically:

- [x] Login to Azure and GCP at the same time. The login order, first Azure, then GCP, is important since the Azure login process first logs out a previous login session; hence, if login with GCP first, then Azure, it results in logging out from GCP.
- [x] Build images, tag them with both ACR and GCR labels, push to both container registries, and update `dockers_gcp.json` and `dockers_azure.json` in one _step_. In addition to the advantages and motivations discussed above, this approach also makes the runtime faster since the images are built only once. Note that while `build_docker.py` can reuse images between multiple runs, we need to prune after each run because we have cases where we run out of disk space by not deleting images after they are built and pushed. 
- [x] Force-push the commit made by the bot to the _main_ branch, since we have seen cases where `git push` was rejected because of the changes on the branch after `git rebase`. (See the comment in the action file for details.) 


Additionally, this PR updates a few dependencies of the GitHub actions to address the deprecation warnings. Specifically, the following changes are implemented. 

- [x] Updates the checkout action to their current latest version to solve the node version deprecation warning; 
- [x] Updates setting output variables by replacing `set-output` with `GITHUB_OUTPUT`;
- [x] Remove the actions for installing `termcolor` as the current version of `build_docker.py` does not need this package;
- [x] Update the version of the python setup action to its current latest version. 

Some test runs of this branch on a separate fork are: 
- [`sv_pipeline_docker`](https://github.com/Genometric/gatk-sv/actions/runs/4349148966);
- [`testwdls`](https://github.com/Genometric/gatk-sv/actions/runs/4349148987);
- [`pytest`](https://github.com/Genometric/gatk-sv/actions/runs/4349148958).
