### PR TITLE
Add option to subset to primary contigs during BatchEvidenceMerging

### DIFF
--- a/wdl/BatchEvidenceMerging.wdl
+++ b/wdl/BatchEvidenceMerging.wdl
@@ -128,6 +128,7 @@ task MergeEvidence {
     mv ~{write_lines(samples)} samples.list
 
     # For legacy evidence files that were not dictionary sorted, removing non-primary contigs fixes the GATK error
+    # BAF records will be deduplicated by contig/coordinate
     if ~{subset_primary_contigs} || ~{rename_samples}; then
       mkdir evidence
       touch evidence.tmp

--- a/wdl/BatchEvidenceMerging.wdl
+++ b/wdl/BatchEvidenceMerging.wdl
@@ -144,9 +144,10 @@ task MergeEvidence {
             | awk -F'\t' -v OFS='\t' -v SAMPLE="$sample" '!second_file{chroms[$1]; next} {~{if subset_primary_contigs then "if ($1 in chroms)" else ""} print ~{if rename_samples then "$1,$2,$3,$4,SAMPLE" else "$0"} }' contigs.list second_file=1 - \
             | bgzip > $OUT
         else
-          # baf
+          # baf - also uniquify records from old files
           zcat $fil \
             | awk -F'\t' -v OFS='\t' -v SAMPLE="$sample" '!second_file{chroms[$1]; next} {~{if subset_primary_contigs then "if ($1 in chroms)" else ""} print ~{if rename_samples then "$1,$2,$3,SAMPLE" else "$0"} }' contigs.list second_file=1 - \
+            | awk -F'\t' -v OFS='\t' '!_[$1"_"$2]++' - \
             | bgzip > $OUT
         fi
         echo "$OUT" >> evidence.tmp

--- a/wdl/GatherBatchEvidence.wdl
+++ b/wdl/GatherBatchEvidence.wdl
@@ -45,6 +45,7 @@ workflow GatherBatchEvidence {
     File? bincov_matrix
     File? bincov_matrix_index
     Boolean subset_primary_contigs = false  # If true, input PE/SR/BAF files will be subsetted to primary contigs only
+    Boolean rename_samples = false  # If true, rename samples to IDs in the input array
     Array[File?]? BAF_files         # Required for MatrixQC
     Array[File] PE_files
     Array[File]? ref_panel_PE_files
@@ -243,7 +244,8 @@ workflow GatherBatchEvidence {
       sd_locs_vcf = sd_locs_vcf,
       reference_dict = ref_dict,
       primary_contigs_fai = primary_contigs_fai,
-      subset_primary_contigs=subset_primary_contigs,
+      subset_primary_contigs = subset_primary_contigs,
+      rename_samples = rename_samples,
       batch = batch,
       gatk_docker = gatk_docker,
       runtime_attr_override = runtime_attr_bem

--- a/wdl/GatherBatchEvidence.wdl
+++ b/wdl/GatherBatchEvidence.wdl
@@ -44,8 +44,8 @@ workflow GatherBatchEvidence {
     File? ref_panel_bincov_matrix
     File? bincov_matrix
     File? bincov_matrix_index
-    Boolean subset_primary_contigs = false  # If true, input PE/SR/BAF files will be subsetted to primary contigs only
-    Boolean rename_samples = false  # If true, rename samples to IDs in the input array
+    Boolean subset_primary_contigs = false  # PE/SR/BAF files will be subsetted to primary contigs only (for legacy files with bad sorting)
+    Boolean rename_samples = false  # Rename samples in PE/SR/BAF to IDs in the "samples" array (always done for RD)
     Array[File?]? BAF_files         # Required for MatrixQC
     Array[File] PE_files
     Array[File]? ref_panel_PE_files

--- a/wdl/GatherBatchEvidence.wdl
+++ b/wdl/GatherBatchEvidence.wdl
@@ -44,6 +44,7 @@ workflow GatherBatchEvidence {
     File? ref_panel_bincov_matrix
     File? bincov_matrix
     File? bincov_matrix_index
+    Boolean subset_primary_contigs = false  # If true, input PE/SR/BAF files will be subsetted to primary contigs only
     Array[File?]? BAF_files         # Required for MatrixQC
     Array[File] PE_files
     Array[File]? ref_panel_PE_files
@@ -241,6 +242,8 @@ workflow GatherBatchEvidence {
       SD_files = all_SD_files,
       sd_locs_vcf = sd_locs_vcf,
       reference_dict = ref_dict,
+      primary_contigs_fai = primary_contigs_fai,
+      subset_primary_contigs=subset_primary_contigs,
       batch = batch,
       gatk_docker = gatk_docker,
       runtime_attr_override = runtime_attr_bem


### PR DESCRIPTION
This is a feature for legacy PE/SR files generated with a version of the pipeline that did not properly sort them. The files, which included non-primary contigs (e.g. HLA sequences), were sorted with `sort -k1,1V` which results in ordering inconsistent with the reference dictionary. This causes a GATK error in `PrintSVEvidence`. 

To correct the issue, it is faster to just subset the files rather than try to sort them in dictionary order since the pipeline does not evaluate evidence on non-primary contigs.

Tested on GatherBatchEvidence with the 1kgp reference panel.

Update: now also includes the option to update sample IDs in PE/SR/BAF files. This functionality was previously lost with the introduction of merging with PrintSVEvidence.