### PR TITLE
Add support for building dockers for multiple registries.

### DIFF
--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -263,7 +263,7 @@ class ProjectBuilder:
 
     def update_dockers_json(self, registry: ContainerRegistry):
         output_json = registry.output_dockers_json
-        if not output_json: # is None or not output_json or output_json == Paths.dev_null:
+        if not output_json:
             return  # no update is desired
         new_dockers_json = {
             json_key: (self.get_current_image(registry, ProjectBuilder.get_target_from_image(docker_image))
@@ -527,7 +527,7 @@ class ImageBuilder:  # class for building and pushing a single image
         return f"{self.name}:{self.tag}"
 
     @property
-    def remote_docker_repos(self) -> Dict[str, ContainerRegistry]: # Tuple[str, ...]:
+    def remote_docker_repos(self) -> Dict[str, ContainerRegistry]:
         return self.project_builder.remote_docker_repos
 
     @property

--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -209,7 +209,7 @@ class ProjectBuilder:
         self.working_dir = None
         self.build_priority = {}
         self.registries = {}
-        for i in range(len(self.project_arguments.docker_repo)):
+        for i in range(len(self.project_arguments.docker_repo or [])):
             name = self.project_arguments.docker_repo[i]
             self.registries[name] = ContainerRegistry(
                 name=name,

--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -209,19 +209,12 @@ class ProjectBuilder:
         self.working_dir = None
         self.build_priority = {}
         self.registries = {}
-        for i in range(len(self.project_arguments.docker_repo or [])):
+        for i in range(len(self.project_arguments.docker_repo)):
             name = self.project_arguments.docker_repo[i]
             self.registries[name] = ContainerRegistry(
                 name=name,
                 input_dockers_json=self.project_arguments.input_json[i],
                 output_dockers_json=self.project_arguments.output_json[i]
-            )
-        if len(self.registries) == 0:
-            name = self.local_reg_name
-            self.registries[name] = ContainerRegistry(
-                name=name,
-                input_dockers_json=self.project_arguments.input_json[0],
-                output_dockers_json=self.project_arguments.output_json[0]
             )
 
     @staticmethod
@@ -737,7 +730,7 @@ def __parse_arguments(args_list: List[str]) -> argparse.Namespace:
     )
 
     docker_remote_args_group.add_argument(
-        "--docker-repo", type=str, nargs="+",
+        "--docker-repo", type=str, nargs="+", default=[ProjectBuilder.local_reg_name],
         help="Docker repo to push images to. This will push images that are built "
              "this run of build_docker.py, or that currently have only a local image "
              "in --input-json. You may provide any number of docker repositories. "

--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -409,7 +409,7 @@ class ProjectBuilder:
                 print(f"changed_project_files: {changed_project_files}", file=sys.stderr)
                 self.project_arguments.targets = [
                     target for target, image_dependencies in self.dependencies.items()
-                    if image_dependencies.has_change(changed_project_files)
+                    if image_dependencies.has_change(changed_project_files) and target not in self.non_public_images
                 ]
                 print(f"targets = {self.project_arguments.targets}")
             elif "all" in self.project_arguments.targets:

--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -744,7 +744,10 @@ def __parse_arguments(args_list: List[str]) -> argparse.Namespace:
              "If you provide one repository, you may skip specifying the --input-json"
              "and --output-json arguments, in which case, their default values will be used."
              "However, if you specify more than one repository, then each of the repositories "
-             "should have a corresponding --input-json and --output-json."
+             "should have a corresponding --input-json and --output-json. "
+             "It is currently required that the JSON files contain the same keys. "
+             "For instance, we do not currently support the case where `dockers_gcp.json` contains "
+             "`sv_base_docker: us.gcr.io/sv-base:latest` while `dockers_azure.json` misses `sv_base_docker`. "
     )
 
     docker_remote_args_group.add_argument(
@@ -759,7 +762,8 @@ def __parse_arguments(args_list: List[str]) -> argparse.Namespace:
              "the most up-to-date docker tag for each docker image."
              "If you provide more than one docker repo, you would need to provide "
              "one input JSON file for each. The input JSON files will be used for the "
-             "docker repositories in their corresponding order."
+             "docker repositories in their corresponding order. All the JSON files "
+             "are currently required to contain the same list of docker image names."
     )
 
     docker_remote_args_group.add_argument(

--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -420,7 +420,8 @@ class ProjectBuilder:
             # For simplicity, we are using the first item instead of iterating through all the registries
             # in the dictionary. However, this results in requiring the input-json of multiple
             # repositories to be in sync in terms of the images they contain.
-            expanded_build_targets = self.get_ordered_build_chain_list(self.registries[next(iter(self.registries))])
+            arbitrary_registry = next(iter(self.registries.values()))
+            expanded_build_targets = self.get_ordered_build_chain_list(arbitrary_registry)
 
             # build each required dependency
             print("Building and pushing the following targets in order:" if self.remote_docker_repos else

--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -528,8 +528,8 @@ class ImageBuilder:  # class for building and pushing a single image
         remote_tags = (self.tag, ProjectBuilder.latest_tag) if self.project_builder.project_arguments.update_latest \
             else (self.tag,)
         return tuple(
-            (name, f"{name}/{self.name}:{remote_tag}")
-            for name, registry in self.remote_docker_repos.items()
+            (registry_name, f"{registry_name}/{self.name}:{remote_tag}")
+            for registry_name, registry in self.remote_docker_repos.items()
             for remote_tag in remote_tags
         )
 

--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -409,7 +409,7 @@ class ProjectBuilder:
                 print(f"changed_project_files: {changed_project_files}", file=sys.stderr)
                 self.project_arguments.targets = [
                     target for target, image_dependencies in self.dependencies.items()
-                    if image_dependencies.has_change(changed_project_files) and target not in self.non_public_images
+                    if image_dependencies.has_change(changed_project_files)
                 ]
                 print(f"targets = {self.project_arguments.targets}")
             elif "all" in self.project_arguments.targets:


### PR DESCRIPTION
- [x] This PR extends the `build_docker.py` to label the docker images it builds with multiple container registries. For instance, it labels the `sv-pipeline` image with `vahid.azurecr.io/gatk-sv/sv-pipeline:tag` and `us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:tag` for ACR and GCR respectively. Accordingly, the script is extended to take a list of container registries with a separate input and output JSON file for each, build and label images for each registry, and update their individual JSON file. For instance, if one container registry is provided (i.e., `--docker-repo`), it uses the default `--input-json` and `--output-json` unless they are provided; if `n` container registries are provided, it needs `n` input and `n` output JSON files. The following is an example of the new invocation where it labels the images it builds for ACR and GCR. 

```shell
python scripts/docker/build_docker.py \
    --docker-repo us.gcr.io/broad-dsde-methods/vjalili vahid.azurecr.io \
    --input-json ./inputs/values/dockers_gcr.json ./inputs/values/dockers_azure.json \
    --targets wham --disable-git-protect --output-json ./inputs/values/dockers.json ./inputs/values/dockers_azure.json
``` 

- [x] Removes the deprecated `--gcr-project` argument. This argument was only used in the GitHub actions, and since the actions are updated and do not leverage this argument, we can safely remove it. 

### Current limitations
- When using multiple container registries, it is necessary for the JSON files of the registries to match the list of images they reference. For example, if one JSON file contains `sv_base_docker`, the other JSON file should also contain it. Introducing support for JSON files with different lists of docker images would add additional complexity to this PR, which is currently undesirable.