### PR TITLE
Add missing space in functional annotation

### DIFF
--- a/wdl/AnnotateFunctionalConsequences.wdl
+++ b/wdl/AnnotateFunctionalConsequences.wdl
@@ -83,7 +83,7 @@ task SVAnnotate {
       --protein-coding-gtf ~{protein_coding_gtf} \
       ~{"--non-coding-bed " + noncoding_bed} \
       ~{"--promoter-window-length " + promoter_window} \
-      ~{"--max-breakend-as-cnv-length" + max_breakend_as_cnv_length} \
+      ~{"--max-breakend-as-cnv-length " + max_breakend_as_cnv_length} \
       ~{additional_args}
 
   >>>


### PR DESCRIPTION
This is an ultra-simple PR that adds a missing space to the `SVAnnotate` task in `AnnotateFunctionalConsequences.wdl`.

The current version in the main branch includes the following line (on line 86):
```
~{"--max-breakend-as-cnv-length" + max_breakend_as_cnv_length} \
```

This causes an error when the optional `max_breakend_as_cnv_length` input is supplied because there is no space between `"--max-breakend-as-cnv-length"` and the user input value.