### PR TITLE
Remove vcf header contig sorting in CleanVcf5

### DIFF
--- a/wdl/CleanVcf5.wdl
+++ b/wdl/CleanVcf5.wdl
@@ -257,7 +257,7 @@ task Polish {
         # Don't sort contigs lexicographically, which would result in incorrect chr1, chr10, chr11, ... ordering
         cat original_header.vcf | fgrep '##contig' >> new_header.vcf
         cat original_header.vcf | fgrep '#CHROM' >> new_header.vcf
-        bcftools reheader polished.need_reheader.vcf.gz -h new_header.vcf -o reheadered.vcf.gz
+        bcftools reheader polished.need_reheader.vcf.gz -h new_header.vcf -o ~{prefix}.vcf.gz
     >>>
 
     output {

--- a/wdl/CleanVcf5.wdl
+++ b/wdl/CleanVcf5.wdl
@@ -251,8 +251,7 @@ task Polish {
         bcftools view -h polished.need_reheader.vcf.gz > original_header.vcf
         cat original_header.vcf | fgrep '##fileformat' > new_header.vcf
         cat original_header.vcf \
-            | awk 'NR > 1' \
-            | egrep -v "CIPOS|CIEND|RMSSTD|EVENT|INFO=<ID=UNRESOLVED,|source|varGQ|bcftools|ALT=<ID=UNR|INFO=<ID=MULTIALLELIC|GATKCommandLine|#CHROM|##contig" \
+            | egrep -v "CIPOS|CIEND|RMSSTD|EVENT|INFO=<ID=UNRESOLVED,|source|varGQ|bcftools|ALT=<ID=UNR|INFO=<ID=MULTIALLELIC|GATKCommandLine|#CHROM|##contig|##fileformat" \
             | sort >> new_header.vcf
         # Don't sort contigs lexicographically, which would result in incorrect chr1, chr10, chr11, ... ordering
         cat original_header.vcf | fgrep '##contig' >> new_header.vcf

--- a/wdl/CleanVcf5.wdl
+++ b/wdl/CleanVcf5.wdl
@@ -248,12 +248,16 @@ task Polish {
                 --output-type z -o polished.need_reheader.vcf.gz --threads ~{threads}
 
         # do the last bit of header cleanup
-        bcftools view -h polished.need_reheader.vcf.gz | awk 'NR == 1' > new_header.vcf
-        bcftools view -h polished.need_reheader.vcf.gz \
+        bcftools view -h polished.need_reheader.vcf.gz > original_header.vcf
+        cat original_header.vcf | fgrep '##fileformat' > new_header.vcf
+        cat original_header.vcf \
             | awk 'NR > 1' \
-            | egrep -v "CIPOS|CIEND|RMSSTD|EVENT|INFO=<ID=UNRESOLVED,|source|varGQ|bcftools|ALT=<ID=UNR|INFO=<ID=MULTIALLELIC," \
-            | sort -k1,1 >> new_header.vcf
-        bcftools reheader polished.need_reheader.vcf.gz -h new_header.vcf -o ~{prefix}.vcf.gz
+            | egrep -v "CIPOS|CIEND|RMSSTD|EVENT|INFO=<ID=UNRESOLVED,|source|varGQ|bcftools|ALT=<ID=UNR|INFO=<ID=MULTIALLELIC|GATKCommandLine|#CHROM|##contig" \
+            | sort >> new_header.vcf
+        # Don't sort contigs lexicographically, which would result in incorrect chr1, chr10, chr11, ... ordering
+        cat original_header.vcf | fgrep '##contig' >> new_header.vcf
+        cat original_header.vcf | fgrep '#CHROM' >> new_header.vcf
+        bcftools reheader polished.need_reheader.vcf.gz -h new_header.vcf -o reheadered.vcf.gz
     >>>
 
     output {


### PR DESCRIPTION
Fixes an issue in CleanVcf5 where the use of `sort` results in re-ordering of contigs in the vcf header (i.e. to chr1, chr10, chr11, chr12, etc. instead of keeping chr1, chr2, chr3, …). This causes problems with GATK tools downstream in particular.

Also rewrites parts of the reheadering commands to be easier to understand.