### PR TITLE
Add sample renaming for SD files in GatherBatchEvidence

### DIFF
--- a/wdl/BatchEvidenceMerging.wdl
+++ b/wdl/BatchEvidenceMerging.wdl
@@ -102,7 +102,7 @@ task MergeEvidence {
 
   Float file_size = size(files, "GiB")
   Float subset_disk = if (subset_primary_contigs || rename_samples) then file_size else 0
-  Int disk_size = 10 + ceil(file_size * 2 + subset_disk)
+  Int disk_size = 10 + ceil(file_size * 3 + subset_disk)
   Int java_heap_size_mb = round(42.0 * length(files) + 1024.0)
   Float mem_size_gb = java_heap_size_mb / 1024.0 + 2.5
 
@@ -190,7 +190,7 @@ task SDtoBAF {
 
   Float file_size = size(SD_files, "GiB")
   Float subset_disk = if rename_samples then file_size else 0
-  Int disk_size = ceil(10 + file_size * 2 + subset_disk)
+  Int disk_size = ceil(10 + file_size * 3 + subset_disk)
   Int java_heap_size_mb = round(42.0 * length(SD_files) + 1024.0)
   Float mem_size_gb = java_heap_size_mb / 1024.0 + 2.5
 

--- a/wdl/BatchEvidenceMerging.wdl
+++ b/wdl/BatchEvidenceMerging.wdl
@@ -69,6 +69,7 @@ workflow BatchEvidenceMerging {
         sd_locs_vcf = select_first([sd_locs_vcf]),
         batch = batch,
         samples = samples,
+        rename_samples=rename_samples,
         reference_dict = reference_dict,
         gatk_docker = gatk_docker,
         runtime_attr_override = runtime_attr_override
@@ -100,7 +101,7 @@ task MergeEvidence {
   }
 
   Float file_size = size(files, "GiB")
-  Float subset_disk = if subset_primary_contigs then file_size else 0
+  Float subset_disk = if (subset_primary_contigs || rename_samples) then file_size else 0
   Int disk_size = 10 + ceil(file_size * 2 + subset_disk)
   Int java_heap_size_mb = round(42.0 * length(files) + 1024.0)
   Float mem_size_gb = java_heap_size_mb / 1024.0 + 2.5
@@ -180,13 +181,16 @@ task SDtoBAF {
     File sd_locs_vcf
     String batch
     Array[String] samples
+    Boolean rename_samples
     File reference_dict
     Float min_het_probability = 0.05
     String gatk_docker
     RuntimeAttr? runtime_attr_override
   }
 
-  Int disk_size = 10 + ceil(size(SD_files, "GiB") * 2)
+  Float file_size = size(SD_files, "GiB")
+  Float subset_disk = if rename_samples then file_size else 0
+  Int disk_size = ceil(10 + file_size * 2 + subset_disk)
   Int java_heap_size_mb = round(42.0 * length(SD_files) + 1024.0)
   Float mem_size_gb = java_heap_size_mb / 1024.0 + 2.5
 
@@ -196,7 +200,7 @@ task SDtoBAF {
     disk_gb: disk_size,
     boot_disk_gb: 10,
     preemptible_tries: 3,
-    max_retries: 0
+    max_retries: 1
   }
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 
@@ -211,6 +215,21 @@ task SDtoBAF {
 
     mv ~{write_lines(SD_files)} inputs.list
     mv ~{write_lines(samples)} samples.list
+
+    # Rename samples
+    if ~{rename_samples}; then
+      mkdir evidence
+      touch evidence.tmp
+      while read fil sample; do
+        FILENAME=$(basename $fil)
+        OUT="evidence/$FILENAME"
+        zcat $fil \
+          | awk -F'\t' -v OFS='\t' -v SAMPLE="$sample" '{print $1,$2,SAMPLE,$4,$5,$6,$7}' - \
+          | bgzip > $OUT
+        echo "$OUT" >> evidence.tmp
+      done < <(paste inputs.list samples.list)
+      mv evidence.tmp inputs.list
+    fi
 
     awk '/txt\.gz$/' inputs.list | while read fil; do
       tabix -f -s1 -b2 -e2 $fil


### PR DESCRIPTION
- Adds optional renaming of sample IDs for BAF generation from SD files in GatherBatchEvidence. This is often useful when incorrect, invalid, or unsafe IDs were used during GatherSampleEvidence. This functionality exists for PE, SR, and RD files already.
- Rescale disk size in SDtoBAF
- Bump up max_retries to 1 in SDtoBaf, in case of transient failures
- Minor fix to disk scaling for MergeEvidence task