### PR TITLE
Remove non-public images from the git-sha-based target determination

### DIFF
--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -323,7 +323,7 @@ class ProjectBuilder:
                         for image, dependencies in self.dependencies.items()
                         if dependencies.depends_on(new_targets_to_build) and
                         not ImageBuilder(image, self).do_not_rebuild
-                    }.difference(targets_to_build)
+                    }.difference(targets_to_build, self.non_public_images)
                 )
 
         # noinspection PyTypeChecker

--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -387,11 +387,19 @@ class ProjectBuilder:
             if self.project_arguments.base_git_commit is not None:
                 changed_project_files = self.changed_project_files
                 print(f"changed_project_files: {changed_project_files}", file=sys.stderr)
-                self.project_arguments.targets = [
-                    target for target, image_dependencies in self.dependencies.items()
-                    if image_dependencies.has_change(changed_project_files) and target not in self.non_public_images
-                ]
-                print(f"targets = {self.project_arguments.targets}")
+                self.project_arguments.targets = []
+                for target, image_dependencies in self.dependencies.items():
+                    if image_dependencies.has_change(changed_project_files):
+                        if target not in self.non_public_images:
+                            self.project_arguments.targets.append(target)
+                        else:
+                            print_colored(
+                                f"Skipping building the Docker image `{target}` since it cannot be hosted publicly. "
+                                f"This image needs to be rebuilt, please consider building using the "
+                                f"`--targets` tag and hosting it in a non-public registry.",
+                                Colors.YELLOW
+                            )
+                print_colored(f"targets = {self.project_arguments.targets}", Colors.GREEN)
             elif "all" in self.project_arguments.targets:
                 self.project_arguments.targets = ProjectBuilder.images_built_by_all
             # get targets + their dependencies in order (so that builds succeed)

--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -389,7 +389,7 @@ class ProjectBuilder:
                 print(f"changed_project_files: {changed_project_files}", file=sys.stderr)
                 self.project_arguments.targets = [
                     target for target, image_dependencies in self.dependencies.items()
-                    if image_dependencies.has_change(changed_project_files)
+                    if image_dependencies.has_change(changed_project_files) and target not in self.non_public_images
                 ]
                 print(f"targets = {self.project_arguments.targets}")
             elif "all" in self.project_arguments.targets:

--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -323,8 +323,20 @@ class ProjectBuilder:
                         for image, dependencies in self.dependencies.items()
                         if dependencies.depends_on(new_targets_to_build) and
                         not ImageBuilder(image, self).do_not_rebuild
-                    }.difference(targets_to_build, self.non_public_images)
+                    }.difference(targets_to_build)
                 )
+
+                # Implementation note: it would be less verbose to add `self.non_public_images` to the `difference`
+                # method above. However, the following implementation enables simpler logging of the skipped images.
+                for non_public_image in self.non_public_images:
+                    if non_public_image in new_targets_to_build:
+                        new_targets_to_build.remove(non_public_image)
+                        print_colored(
+                            f"Skipping building the Docker image `{non_public_image}` since it cannot be hosted "
+                            f"publicly. This image needs to be rebuilt, please consider building using the "
+                            f"`--targets` tag and hosting it in a non-public registry.",
+                            Colors.YELLOW
+                        )
 
         # noinspection PyTypeChecker
         return sorted(targets_to_build, key=self.get_build_priority)


### PR DESCRIPTION
This PR excludes the non-public docker images (`melt` specifically`) from the git-sha-based target images determination. 

These images can still be built if listed explicitly via the `--targets` argument. 