### PR TITLE
Fix issue in Genotype batch script with low PE_log_pval causing zero …

### DIFF
--- a/src/sv-pipeline/04_variant_resolution/scripts/convert_poisson_p.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/convert_poisson_p.py
@@ -22,7 +22,7 @@ def convert_poisson_p(log_pval):
         pval_cmp = -np.log10(ss.poisson.cdf(0, count))
 
         if pval_cmp > log_pval:
-            return count - 1
+            return max(1, count - 1)
 
         count += 1
 


### PR DESCRIPTION
This commit addresses a problem where batches with low PE_log_pval were resulting in PE_count of zero, which could cause issues. To fix this, the commit sets the minimum count value to max(1, count-1), ensuring that a count of at least 1 is always returned.

The changes made in this PR were tested using the batch that was holding a PE_count = 0, which was causing the GenotypePESRPart1 task to fail. The result of the test was that the task succeeded, confirming that the fix is effective and resolving the issue. A screenshot of the test result is attached for reference.

<img width="991" alt="Screen Shot 2023-05-02 at 8 24 21 AM" src="https://user-images.githubusercontent.com/74751641/235665200-9dac7422-9bae-4f5b-9deb-b75c593ca7b3.png">
