### PR TITLE
Add TransferVcfAnnotations workflow

### DIFF
--- a/dockerfiles/sv-pipeline-virtual-env/Dockerfile
+++ b/dockerfiles/sv-pipeline-virtual-env/Dockerfile
@@ -49,7 +49,7 @@ RUN export SETUPTOOLS_VERSION=$(python -c 'import setuptools; print(setuptools._
 
 # pybedtools needs to be installed via pip because it doesn't like the updated python
 # hail's latest version is only available via pip or local build
-ARG PIP_PKGS="pybedtools==0.9.0 hail==0.2.93"
+ARG PIP_PKGS="pybedtools==0.9.0 hail==0.2.93 more-itertools==9.0.0"
 RUN pip3 --no-cache-dir install $PIP_PKGS
 
 # clean unneeded stuff

--- a/src/sv-pipeline/scripts/shard_vcf_pair.py
+++ b/src/sv-pipeline/scripts/shard_vcf_pair.py
@@ -1,0 +1,252 @@
+#!/bin/env python
+
+import argparse
+import os
+import pysam
+import re
+import sys
+from typing import Optional, List, Text, Set, Dict, Tuple, Iterable
+
+from more_itertools import peekable
+
+
+class ContigComparator(str):
+    """
+    Comparator for contig name sorting, equivalent to 'sort -V'
+    """
+    def __lt__(self, other):
+        num_self = re.sub("[^0-9]", "", self)
+        num_other = re.sub("[^0-9]", "", other)
+        if num_self == "" and num_other == "":
+            return str(self) < str(other)  # e.g. chrX, chrY
+        elif num_self == "":
+            return False
+        elif num_other == "":
+            return True
+        else:
+            return int(num_self) < int(num_other)
+
+
+def pairs(vcf_a: pysam.VariantFile,
+          vcf_b: pysam.VariantFile,
+          header: pysam.VariantHeader) -> Iterable[Tuple]:
+    """
+    Zips records from vcf_a and vcf_b, matching by variant ID. Input vcfs must be sorted
+
+    Parameters
+    ----------
+    vcf_a: pysam.VariantFile
+        first vcf
+    vcf_b: pysam.VariantFile
+        second vcf
+    header: pysam.VariantHeader
+        header defining reference contigs
+
+    Returns
+    -------
+    Iterable[Tuple]
+        paired records (record_a, record_b); one record may be None if no match was found
+    """
+
+    def _cmp_coord(a_chrom: Text,
+                   a_pos: int,
+                   b_chrom: Text,
+                   b_pos: int,
+                   contig_indices: Dict[Text, int]) -> int:
+        """
+        Comparing function for two genomic coordinates
+            a_chrom: Text
+                First contig
+            a_pos: int
+                First position
+            b_chrom: Text
+                Second contig
+            b_pos: int
+                Second position
+            contig_indices: Dict[Text, int]
+                Specifies contig order
+        """
+        x_chrom_i = contig_indices[a_chrom]
+        y_chrom_i = contig_indices[b_chrom]
+        if x_chrom_i < y_chrom_i:
+            return -1
+        elif x_chrom_i > y_chrom_i:
+            return 1
+        elif a_pos < b_pos:
+            return -1
+        elif a_pos > b_pos:
+            return 1
+        else:
+            return 0
+
+    vcf_a = peekable(vcf_a)
+    vcf_b = peekable(vcf_b)
+
+    # Sometimes contigs aren't sorted properly in the header
+    sorted_contig_list = [c for c in header.contigs]
+    sorted_contig_list.sort(key=ContigComparator)
+    contig_indices = {c: sorted_contig_list.index(c) for c in sorted_contig_list}
+
+    chrom = None
+    pos = None
+    a_buff = dict()  # buffer records at the current coordinate (chrom, pos)
+    b_buff = dict()
+    while vcf_a and vcf_b:
+        x = vcf_a.peek()
+        y = vcf_b.peek()
+        if chrom is None:
+            cxy = _cmp_coord(x.chrom, x.pos, y.chrom, y.pos, contig_indices)
+            if cxy <= 0:
+                chrom = x.chrom
+                pos = x.pos
+            else:
+                chrom = y.chrom
+                pos = y.pos
+        else:
+            cxy = _cmp_coord(x.chrom, x.pos, y.chrom, y.pos, contig_indices)
+            cx = _cmp_coord(x.chrom, x.pos, chrom, pos, contig_indices)
+            cy = _cmp_coord(y.chrom, y.pos, chrom, pos, contig_indices)
+            if cx < 0:
+                raise ValueError(f"Position of {x.id} precedes current position {chrom}:{pos}. "
+                                 f"Check that input vcf is sorted.")
+            elif cy < 0:
+                raise ValueError(f"Position of {y.id} precedes current position {chrom}:{pos}. "
+                                 f"Check that annotations vcf is sorted.")
+            if cx == 0:
+                a_buff[x.id] = next(vcf_a)
+            if cy == 0:
+                b_buff[y.id] = next(vcf_b)
+            if cx > 0 and cy > 0:
+                for key, val in a_buff.items():
+                    yield val, b_buff.get(key, None)
+                a_buff = dict()
+                b_buff = dict()
+                if cxy <= 0:
+                    chrom = x.chrom
+                    pos = x.pos
+                else:
+                    chrom = y.chrom
+                    pos = y.pos
+    for key, val in a_buff.items():
+        yield val, b_buff.get(key, None)
+    for x in vcf_a:
+        yield x, None
+    for y in vcf_b:
+        yield None, y
+
+
+def shard_vcfs(vcf_a: pysam.VariantFile,
+               vcf_b: pysam.VariantFile,
+               out_dir: Text,
+               prefix_a: Text,
+               prefix_b: Text,
+               shard_size: int,
+               drop_a: bool,
+               drop_b: bool) -> None:
+    """
+    Transfers annotations from one vcf to another, matching on variant ID. Result is written to the given output vcf.
+
+    Parameters
+    ----------
+    vcf_in: pysam.VariantFile
+        Base vcf to add annotations to
+    vcf_ann: pysam.VariantFile
+        Vcf containing source annotations
+    vcf_out: pysam.VariantFile
+        Output vcf
+    info_keys: Set[Text]
+        Annotation INFO keys
+    format_keys: Set[Text]
+        Annotation FORMAT keys
+    """
+
+    def _get_shard_files(dir: Text,
+                         header_a: pysam.VariantHeader,
+                         header_b: pysam.VariantHeader,
+                         prefix_a: Text,
+                         prefix_b: Text,
+                         index: int) -> Text:
+        path_a = os.path.join(dir, '{}_{:08d}.vcf.gz'.format(prefix_a, index))
+        path_b = os.path.join(dir, '{}_{:08d}.vcf.gz'.format(prefix_b, index))
+        return pysam.VariantFile(path_a, mode='w', header=header_a), \
+            pysam.VariantFile(path_b, mode='w', header=header_b)
+
+    n_a = 0  # record counts for the current shard
+    n_b = 0
+    shard_index = 0
+    out_a, out_b = _get_shard_files(dir=out_dir, header_a=vcf_a.header, header_b=vcf_b.header,
+                                    prefix_a=prefix_a, prefix_b=prefix_b, index=shard_index)
+    for rec_a, rec_b in pairs(vcf_a, vcf_b, vcf_a.header):
+        if rec_a is not None and not (drop_a and rec_b is None):
+            out_a.write(rec_a)
+            n_a += 1
+        if rec_b is not None and not (drop_b and rec_a is None):
+            out_b.write(rec_b)
+            n_b += 1
+        if max(n_a, n_b) >= shard_size:
+            shard_index += 1
+            n_a = 0
+            n_b = 0
+            out_a.close()
+            out_b.close()
+            out_a, out_b = _get_shard_files(dir=out_dir, header_a=vcf_a.header, header_b=vcf_b.header,
+                                            prefix_a=prefix_a, prefix_b=prefix_b, index=shard_index)
+    out_a.close()
+    out_b.close()
+
+
+def _parse_arg_list(arg: Text) -> List[Text]:
+    if arg is None:
+        return list()
+    else:
+        return arg.split(',')
+
+
+def _parse_arguments(argv: List[Text]) -> argparse.Namespace:
+    # noinspection PyTypeChecker
+    parser = argparse.ArgumentParser(
+        description="Splits records from two vcfs with overlapping variant IDs, "
+                    "ensuring any two records with the same ID end up in the same shard",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("vcf_a", type=str, help="First vcf")
+    parser.add_argument("vcf_b", type=str, help="Second vcf")
+    parser.add_argument("--out-dir", type=str, default="./", help="Output directory")
+    parser.add_argument("--prefix-a", type=str, required=True, help="First vcf's filename prefix")
+    parser.add_argument("--prefix-b", type=str, required=True, help="Second vcf's filename prefix")
+    parser.add_argument("--shard-size", type=int, default=30000, help="Target shard size")
+    parser.add_argument("--drop-a", action='store_true',
+                        help="Drop records from vcf_a without matching IDs in vcf_b")
+    parser.add_argument("--drop-b", action='store_true',
+                        help="Drop records from vcf_b without matching IDs in vcf_a")
+    if len(argv) <= 1:
+        parser.parse_args(["--help"])
+        sys.exit(0)
+    parsed_arguments = parser.parse_args(argv[1:])
+    return parsed_arguments
+
+
+def main(argv: Optional[List[Text]] = None):
+    if argv is None:
+        argv = sys.argv
+    arguments = _parse_arguments(argv)
+    if arguments.shard_size <= 0:
+        raise ValueError('Shard size must be positive')
+    if arguments.prefix_a == arguments.prefix_b:
+        raise ValueError('Prefixes cannot be equal')
+
+    with pysam.VariantFile(arguments.vcf_a) as vcf_a, pysam.VariantFile(arguments.vcf_b) as vcf_b:
+        shard_vcfs(
+            vcf_a=vcf_a,
+            vcf_b=vcf_b,
+            out_dir=arguments.out_dir,
+            prefix_a=arguments.prefix_a,
+            prefix_b=arguments.prefix_b,
+            shard_size=arguments.shard_size,
+            drop_a=arguments.drop_a,
+            drop_b=arguments.drop_b
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sv-pipeline/scripts/transfer_vcf_annotations.py
+++ b/src/sv-pipeline/scripts/transfer_vcf_annotations.py
@@ -1,0 +1,319 @@
+#!/bin/env python
+
+import argparse
+import re
+import pysam
+import sys
+from typing import Optional, List, Text, Set, Dict, Tuple, Iterable
+
+from more_itertools import peekable
+
+
+class PeekIterator:
+
+    def __init__(self, iterable):
+        self.iterator = iter(iterable)
+        self.peeked = deque()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.peeked:
+            return self.peeked.popleft()
+        return next(self.iterator)
+
+    def peek(self, ahead=0):
+        while len(self.peeked) <= ahead:
+            self.peeked.append(next(self.iterator))
+        return self.peeked[ahead]
+
+
+def create_header(header_in: pysam.VariantHeader,
+                  header_ann: pysam.VariantHeader,
+                  info_keys: Set[Text],
+                  format_keys: Set[Text]) -> pysam.VariantHeader:
+    """
+    Adds annotation metadata lines to the input header. Also checks that the fields exist in the annotation vcf.
+
+    Parameters
+    ----------
+    header_in: pysam.VariantHeader
+        input header
+    header_ann: pysam.VariantHeader
+        annotation vcf header
+    info_keys: Set[Text]
+        set of info fields to annotate
+    format_keys: Set[Text]
+        set of format fields to annotate
+
+    Returns
+    -------
+    header: pysam.VariantHeader
+        output header
+    """
+    # Check annotation fields exist
+    for k in info_keys:
+        if k not in header_ann.info:
+            raise ValueError(f"INFO field {k} not found in annotation vcf header")
+    for k in format_keys:
+        if k not in header_ann.formats:
+            raise ValueError(f"FORMAT field {k} not found in annotation vcf header")
+
+    # Add annotation headerlines
+    for line in header_ann.records:
+        if len(line.attrs) > 0 and 'ID' in line.keys() and \
+                (line['ID'] in info_keys or line['ID'] in format_keys):
+            header_in.add_line(str(line))
+    return header_in
+
+
+class ContigComparator(str):
+    """
+    Comparator for contig name sorting, equivalent to 'sort -V'
+    """
+    def __lt__(self, other):
+        num_self = re.sub("[^0-9]", "", self)
+        num_other = re.sub("[^0-9]", "", other)
+        if num_self == "" and num_other == "":
+            return str(self) < str(other)  # e.g. chrX, chrY
+        elif num_self == "":
+            return False
+        elif num_other == "":
+            return True
+        else:
+            return int(num_self) < int(num_other)
+
+
+def pairs(vcf_a: pysam.VariantFile,
+          vcf_b: pysam.VariantFile,
+          header: pysam.VariantHeader) -> Iterable[Tuple]:
+    """
+    Zips records from vcf_a and vcf_b, matching by variant ID. Input vcfs must be sorted
+
+    Parameters
+    ----------
+    vcf_a: pysam.VariantFile
+        first vcf
+    vcf_b: pysam.VariantFile
+        second vcf
+    header: pysam.VariantHeader
+        header defining reference contigs
+
+    Returns
+    -------
+    Iterable[Tuple]
+        paired records (record_a, record_b); one record may be None if no match was found
+    """
+
+    def _cmp_coord(a_chrom: Text,
+                   a_pos: int,
+                   b_chrom: Text,
+                   b_pos: int,
+                   contig_indices: Dict[Text, int]) -> int:
+        """
+        Comparing function for two genomic coordinates
+            a_chrom: Text
+                First contig
+            a_pos: int
+                First position
+            b_chrom: Text
+                Second contig
+            b_pos: int
+                Second position
+            contig_indices: Dict[Text, int]
+                Specifies contig order
+        """
+        x_chrom_i = contig_indices[a_chrom]
+        y_chrom_i = contig_indices[b_chrom]
+        if x_chrom_i < y_chrom_i:
+            return -1
+        elif x_chrom_i > y_chrom_i:
+            return 1
+        elif a_pos < b_pos:
+            return -1
+        elif a_pos > b_pos:
+            return 1
+        else:
+            return 0
+
+    vcf_a = peekable(vcf_a)
+    vcf_b = peekable(vcf_b)
+
+    # Sometimes contigs aren't sorted properly in the header
+    sorted_contig_list = [c for c in header.contigs]
+    sorted_contig_list.sort(key=ContigComparator)
+    contig_indices = {c: sorted_contig_list.index(c) for c in sorted_contig_list}
+
+    chrom = None
+    pos = None
+    a_buff = dict()  # buffer records at the current coordinate (chrom, pos)
+    b_buff = dict()
+    while vcf_a and vcf_b:
+        x = vcf_a.peek()
+        y = vcf_b.peek()
+        if chrom is None:
+            cxy = _cmp_coord(x.chrom, x.pos, y.chrom, y.pos, contig_indices)
+            if cxy <= 0:
+                chrom = x.chrom
+                pos = x.pos
+            else:
+                chrom = y.chrom
+                pos = y.pos
+        else:
+            cxy = _cmp_coord(x.chrom, x.pos, y.chrom, y.pos, contig_indices)
+            cx = _cmp_coord(x.chrom, x.pos, chrom, pos, contig_indices)
+            cy = _cmp_coord(y.chrom, y.pos, chrom, pos, contig_indices)
+            if cx < 0:
+                raise ValueError(f"Position of {x.id} precedes current position {chrom}:{pos}. "
+                                 f"Check that input vcf is sorted.")
+            elif cy < 0:
+                raise ValueError(f"Position of {y.id} precedes current position {chrom}:{pos}. "
+                                 f"Check that annotations vcf is sorted.")
+            if cx == 0:
+                a_buff[x.id] = next(vcf_a)
+            if cy == 0:
+                b_buff[y.id] = next(vcf_b)
+            if cx > 0 and cy > 0:
+                for key, val in a_buff.items():
+                    yield val, b_buff.get(key, None)
+                a_buff = dict()
+                b_buff = dict()
+                if cxy <= 0:
+                    chrom = x.chrom
+                    pos = x.pos
+                else:
+                    chrom = y.chrom
+                    pos = y.pos
+    for key, val in a_buff.items():
+        yield val, b_buff.get(key, None)
+    for x in vcf_a:
+        yield x, None
+    for y in vcf_b:
+        yield None, y
+
+
+def annotate_record(in_record: pysam.VariantRecord,
+                    ann_record: pysam.VariantRecord,
+                    samples: List[Text],
+                    info_keys: Set[Text],
+                    format_keys: Set[Text]) -> pysam.VariantRecord:
+    """
+    Annotates record with INFO and FORMAT fields
+
+    Parameters
+    ----------
+    in_record: pysam.VariantRecord
+        base record
+    ann_record: pysam.VariantRecord
+        annotation source record
+    samples: List[Text]
+        list of samples to transfer annotations of
+    info_keys: List[Text]
+        list of format keys as ordered in format_dict
+    format_keys: List[Text]
+        list of format keys as ordered in format_dict
+
+    Returns
+    -------
+    pysam.VariantRecord
+        annotated record
+    """
+    for key in info_keys:
+        val = ann_record.info.get(key, None)
+        if val is not None and not (isinstance(val, Iterable) and val[0] is None):
+            in_record.info[key] = val
+    for sample_id in samples:
+        ann_format = ann_record.samples[sample_id]
+        new_sample_format = in_record.samples[sample_id]
+        for key in format_keys:
+            val = ann_format.get(key, None)
+            if val is not None and not (isinstance(val, Iterable) and val[0] is None):
+                new_sample_format[key] = val
+    return in_record
+
+
+def annotate_vcf(vcf_in: pysam.VariantFile,
+                 vcf_ann: pysam.VariantFile,
+                 info_keys: Set[Text],
+                 format_keys: Set[Text]) -> None:
+    """
+    Transfers annotations from one vcf to another, matching on variant ID. Result is written to stdout.
+
+    Parameters
+    ----------
+    vcf_in: pysam.VariantFile
+        Base vcf to add annotations to
+    vcf_ann: pysam.VariantFile
+        Vcf containing source annotations
+    info_keys: Set[Text]
+        Annotation INFO keys
+    format_keys: Set[Text]
+        Annotation FORMAT keys
+    """
+    common_samples = list(set(vcf_in.header.samples).intersection(set(vcf_ann.header.samples)))
+    for in_rec, ann_rec in pairs(vcf_in, vcf_ann, vcf_in.header):
+        if in_rec is None:
+            continue
+        if ann_rec is None:
+            sys.stdout.write(str(in_rec))
+        else:
+            if in_rec.id != ann_rec.id:
+                raise ValueError(f"Record ids do not match: {in_rec.id} {ann_rec.id}")
+            if in_rec.chrom != ann_rec.chrom or in_rec.pos != ann_rec.pos:
+                raise ValueError(f"Record positions do not match for {in_rec.id}: "
+                                 f"{in_rec.chrom}:{in_rec.pos} {ann_rec.chrom}:{ann_rec.pos}")
+            sys.stdout.write(str(annotate_record(in_record=in_rec, ann_record=ann_rec, samples=common_samples,
+                                  info_keys=info_keys, format_keys=format_keys)))
+
+
+def _parse_arg_list(arg: Text) -> List[Text]:
+    if arg is None:
+        return list()
+    else:
+        return arg.split(',')
+
+
+def _parse_arguments(argv: List[Text]) -> argparse.Namespace:
+    # noinspection PyTypeChecker
+    parser = argparse.ArgumentParser(
+        description="Annotate the given vcf with fields from another, matching by variant id",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("vcf", type=str,
+                        help="VCF to annotate")
+    parser.add_argument("--ann-vcf", type=str, required=True,
+                        help="Vcf with source annotations")
+    parser.add_argument("--formats", type=str,
+                        help="Comma-delimited list of FORMAT fields to transfer (e.g. SR_GT,SR_GQ)")
+    parser.add_argument("--infos", type=str,
+                        help="Comma-delimited list of INFO fields to transfer (e.g. AC,AN,AF)")
+    if len(argv) <= 1:
+        parser.parse_args(["--help"])
+        sys.exit(0)
+    parsed_arguments = parser.parse_args(argv[1:])
+    return parsed_arguments
+
+
+def main(argv: Optional[List[Text]] = None):
+    if argv is None:
+        argv = sys.argv
+    arguments = _parse_arguments(argv)
+    info_keys = set(_parse_arg_list(arguments.infos))
+    format_keys = set(_parse_arg_list(arguments.formats))
+    if len(info_keys) + len(format_keys) == 0:
+        raise ValueError('No INFO or FORMAT fields were specified')
+
+    with pysam.VariantFile(arguments.vcf) as vcf_in, pysam.VariantFile(arguments.ann_vcf) as vcf_ann:
+        header = create_header(
+            header_in=vcf_in.header,
+            header_ann=vcf_ann.header,
+            info_keys=info_keys,
+            format_keys=format_keys
+        )
+        sys.stdout.write(str(header))
+        annotate_vcf(vcf_in=vcf_in, vcf_ann=vcf_ann, info_keys=info_keys, format_keys=format_keys)
+
+
+if __name__ == "__main__":
+    main()

--- a/wdl/TransferVcfAnnotations.wdl
+++ b/wdl/TransferVcfAnnotations.wdl
@@ -1,0 +1,116 @@
+version 1.0
+
+import "Structs.wdl"
+import "TasksMakeCohortVcf.wdl" as tasks
+import "Utils.wdl" as utils
+
+workflow TransferVcfAnnotations {
+  input {
+    File vcf
+    File vcf_with_annotations
+    Int shard_size
+    String? info_keys_list
+    String? format_keys_list
+    File? transfer_script
+    String prefix
+    String sv_base_mini_docker
+    String sv_pipeline_docker
+    RuntimeAttr? runtime_attr_shard
+    RuntimeAttr? runtime_override_transfer
+    RuntimeAttr? runtime_override_concat
+  }
+
+  call utils.ShardVcfPair {
+    input:
+      vcf_a=vcf,
+      vcf_b=vcf_with_annotations,
+      shard_size=shard_size,
+      prefix_a=basename(vcf, ".vcf.gz"),
+      prefix_b=basename(vcf_with_annotations, ".vcf.gz"),
+      drop_a=false,
+      drop_b=true,
+      sv_pipeline_docker=sv_pipeline_docker,
+      runtime_attr_override=runtime_attr_shard
+  }
+
+  scatter (i in range(length(ShardVcfPair.shards_a))) {
+    call TransferVcfAnnotationsTask {
+      input:
+        vcf_to_annotate=ShardVcfPair.shards_a[i],
+        vcf_with_annotations=ShardVcfPair.shards_b[i],
+        info_keys_list=info_keys_list,
+        format_keys_list=format_keys_list,
+        script=transfer_script,
+        sv_pipeline_docker=sv_pipeline_docker,
+        runtime_attr_override=runtime_override_transfer
+    }
+  }
+
+  call tasks.ConcatVcfs {
+    input:
+      vcfs=TransferVcfAnnotationsTask.annotated_shard,
+      vcfs_idx=TransferVcfAnnotationsTask.annotated_shard_index,
+      naive=true,
+      generate_index=true,
+      outfile_prefix=prefix,
+      sv_base_mini_docker=sv_base_mini_docker,
+      runtime_attr_override=runtime_override_concat
+  }
+
+  output {
+    File annotated_vcf = ConcatVcfs.concat_vcf
+    File annotated_vcf_index = ConcatVcfs.concat_vcf_idx
+  }
+}
+
+
+task TransferVcfAnnotationsTask {
+  input {
+    File vcf_to_annotate
+    File vcf_with_annotations
+    String? info_keys_list  # At least one of info_keys_list or format_keys_list must be provided
+    String? format_keys_list
+    File? script  # For debugging
+    String sv_pipeline_docker
+    RuntimeAttr? runtime_attr_override
+  }
+  String output_file_name = sub(sub(basename(vcf_to_annotate), ".gz$", ""), ".vcf$", "_annotated.vcf.gz")
+
+  # Disk must be scaled proportionally to the size of the VCF
+  # Memory may need to be increased as well, particularly if transferring FORMAT fields on large VCFs
+  RuntimeAttr default_attr = object {
+                               mem_gb: 7.5,
+                               disk_gb: ceil(100.0 + size(vcf_to_annotate, "GB") * 2 + size(vcf_with_annotations, "GB")),
+                               cpu_cores: 1,
+                               preemptible_tries: 3,
+                               max_retries: 1,
+                               boot_disk_gb: 10
+                             }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " SSD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: sv_pipeline_docker
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
+  }
+
+  command <<<
+    set -euo pipefail
+    python ~{default="/opt/sv-pipeline/scripts/transfer_vcf_annotations.py" script} \
+      ~{"--infos " + info_keys_list} \
+      ~{"--formats " + format_keys_list} \
+      --ann-vcf ~{vcf_with_annotations} \
+      ~{vcf_to_annotate} \
+      | bgzip > ~{output_file_name}
+    tabix ~{output_file_name}
+  >>>
+
+  output {
+    File annotated_shard = output_file_name
+    File annotated_shard_index = output_file_name + ".tbi"
+  }
+}


### PR DESCRIPTION
Adds a new workflow for transferring INFO and FORMAT field annotations from one vcf to another. The implementation is efficient in that it traverses the two vcfs together to minimize the number of records that need to be held in memory. It is also robust in that it tolerates some records to be missing from one vcf or the other. 

The workflow is parallelized for efficient execution on large call sets.