### PR TITLE
Update copy_outputs.py

### DIFF
--- a/scripts/cromwell/copy_outputs.py
+++ b/scripts/cromwell/copy_outputs.py
@@ -8,66 +8,18 @@ from google.cloud import storage
 
 # Synopsis:
 #  Copies workflow outputs needed for downstream processing to a destination bucket.
-#
 # Author: Mark Walker (markw@broadinstitute.org)
 
-# Output file definitions: FILENAME_MAP[workflow_name][output_variable] = destination_file_suffix
-FILENAME_MAP = {
-    'GATKSVPipelinePhase1': {
-        'filtered_depth_vcf': 'filtered_depth_vcf.vcf.gz',
-        'filtered_pesr_vcf': 'filtered_pesr_vcf.vcf.gz',
-        'cutoffs': 'rf_cutoffs.tsv',
-        'outlier_samples_excluded_file': 'outliers.list',
-        'batch_samples_postOutlierExclusion_file': 'filtered_samples.list',
-        'ped_file_postOutlierExclusion': 'filtered.ped',
-        'merged_SR': 'SR.txt.gz',
-        'merged_SR_index': 'SR.txt.gz.tbi',
-        'merged_PE': 'PE.txt.gz',
-        'merged_PE_index': 'PE.txt.gz.tbi',
-        'merged_bincov': 'RD.txt.gz',
-        'merged_bincov_index': 'RD.txt.gz.tbi',
-        'median_cov': 'median_cov.bed'
-    },
-    'MergeCohortVcfs': {
-        'cohort_pesr_vcf': 'cohort_pesr.vcf.gz',
-        'cohort_depth_vcf': 'cohort_depth.vcf.gz',
-        'cohort_combined': 'cohort.combined.bed',
-        'lookup': 'master_cluster_dups.bed',
-        'cohort_sort': 'cohort.sort.bed',
-        'cluster_combined': 'cluster.combined.bed'
-    },
-    'Module04': {
-        'sr_bothside_pass': 'sr_bothside_pass.txt',
-        'sr_background_fail': 'sr_background_fail.txt',
-        'trained_PE_metrics': 'trained_PE_metrics.txt',
-        'trained_SR_metrics': 'trained_SR_metrics.txt',
-        'trained_genotype_pesr_pesr_sepcutoff': 'trained_genotype_pesr_pesr_sepcutoff.txt',
-        'trained_genotype_pesr_depth_sepcutoff': 'trained_genotype_pesr_depth_sepcutoff.txt',
-        'trained_genotype_depth_pesr_sepcutoff': 'trained_genotype_depth_pesr_sepcutoff.txt',
-        'trained_genotype_depth_depth_sepcutoff': 'trained_genotype_depth_depth_sepcutoff.txt',
-        'genotyped_depth_vcf': 'genotyped.depth.vcf.gz',
-        'genotyped_depth_vcf_index': 'genotyped.depth.vcf.gz.tbi',
-        'genotyped_pesr_vcf': 'genotyped.pesr.vcf.gz',
-        'genotyped_pesr_vcf_index': 'genotyped.pesr.vcf.gz.tbi',
-        'regeno_depth': 'regeno_depth.bed'
-    }
-}
 
-
-def get_uris(metadata, output_name, dest_prefix):
+def get_uris(metadata, dest_prefix):
     if 'workflowName' not in metadata:
         raise ValueError("Workflow name not found. Check metadata file.")
-    workflow = metadata['workflowName']
-    if workflow not in FILENAME_MAP:
-        raise ValueError(f"Unknown workflow {workflow}")
     outputs = metadata['outputs']
-    for var in FILENAME_MAP[workflow]:
-        key = f"{workflow}.{var}"
-        if outputs[key] is not None:
-            source_uri = outputs[key]
-            dest_filename = f"{output_name}.{FILENAME_MAP[workflow][var]}"
+    for source_uri in outputs.values():
+        if source_uri is not None and source_uri.startswith("gs://"):
+            dest_filename = os.path.basename(source_uri)
             dest_uri = os.path.join(dest_prefix, dest_filename)
-            yield (source_uri, dest_uri)
+            yield source_uri, dest_uri
 
 
 def copy_blob(storage_client, bucket_name, blob_name, destination_bucket_name, destination_blob_name):
@@ -105,14 +57,11 @@ def copy_uri(source_uri, dest_uri, storage_client):
 # Main function
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--name", help="Batch or cohort name", required=True)
-    parser.add_argument(
-        "--metadata", help="Workflow metadata JSON file", required=True)
-    parser.add_argument(
-        "--dest", help="Destination GCS URI (e.g. \"gs://my-bucket/output\")", required=True)
+    parser.add_argument("--metadata", help="Workflow metadata JSON file", required=True)
+    parser.add_argument("--dest", help="Destination GCS URI (e.g. \"gs://my-bucket/output\")", required=True)
     args = parser.parse_args()
     metadata = json.load(open(args.metadata, 'r'))
-    output_uris = get_uris(metadata, args.name, args.dest)
+    output_uris = get_uris(metadata, args.dest)
     client = storage.Client()
     for source_uri, dest_uri in output_uris:
         copy_uri(source_uri, dest_uri, client)


### PR DESCRIPTION
This utility script was very out of date and hard-coded to work with specific workflows. This PR simplifies it to copy down all output files from a Cromwell metadata into a flat GCR location.