### PR TITLE
Improve STR workflow

### DIFF
--- a/src/str/merge_csv_files.py
+++ b/src/str/merge_csv_files.py
@@ -1,10 +1,12 @@
 import argparse
+import os.path
 import pandas as pd
 
 
 def merge_files(input_filename: str, metrics_filename: str, missing_metrics_filename: str):
     with open(input_filename, "r") as fin:
-        files = [line.rstrip() for line in fin]
+        lines = fin.read().splitlines()
+        files = [x for x in lines if os.path.isfile(x)]
 
     dfs = []
     for filename in files:

--- a/src/str/merge_csv_files.py
+++ b/src/str/merge_csv_files.py
@@ -6,7 +6,12 @@ import pandas as pd
 def merge_files(input_filename: str, metrics_filename: str, missing_metrics_filename: str):
     with open(input_filename, "r") as fin:
         lines = fin.read().splitlines()
-        files = [x for x in lines if os.path.isfile(x)]
+        files = []
+        for x in lines:
+            if os.path.isfile(x):
+                files.append(x)
+            else:
+                print(f"Skipping the invalid filename `{x}`.")
 
     dfs = []
     for filename in files:

--- a/src/str/merge_csv_files.py
+++ b/src/str/merge_csv_files.py
@@ -36,21 +36,21 @@ def main():
 
     parser.add_argument(
         "-i", "--input-filename",
+        required=True,
         help="A text file containing the list of CSV files to merge, with one file per line."
     )
 
     parser.add_argument(
-        "-o", "--metrics",
-        help="The output filename containing all the metrics (excluding the NaN values)."
-    )
-
-    parser.add_argument(
-        "-m", "--missing-metrics",
-        help="The output filename containing only the missing metrics."
+        "-p", "--output-prefix",
+        help="Sets a prefix to be used for the output files generated."
     )
 
     args = parser.parse_args()
-    merge_files(args.input_filename, args.metrics, args.missing_metrics)
+    merge_files(
+        args.input_filename,
+        f"{args.output_prefix}_metrics.csv",
+        f"{args.output_prefix}_missing_metrics.csv"
+    )
 
 
 if __name__ == '__main__':

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -25,6 +25,7 @@ workflow ExpansionHunter {
         Boolean? generate_vcf
         Boolean? seeking_analysis_mode
         Boolean? generate_reviewer_images
+        Boolean? include_all_fields
         Int? thread_count
         File? ped_file
         String expansion_hunter_docker
@@ -42,6 +43,7 @@ workflow ExpansionHunter {
     Boolean generate_realigned_bam_ = select_first([generate_realigned_bam, false])
     Boolean generate_vcf_ = select_first([generate_vcf, false])
     Boolean generate_reviewer_images_ = select_first([generate_reviewer_images, false])
+    Boolean include_all_fields_ = select_first([include_all_fields, false])
 
     Boolean is_bam = basename(bam_or_cram, ".bam") + ".bam" == basename(bam_or_cram)
     File bam_or_cram_index_ =
@@ -72,6 +74,7 @@ workflow ExpansionHunter {
                 sample_id = sample_id,
                 generate_realigned_bam = generate_realigned_bam_,
                 generate_vcf = generate_vcf_,
+                include_all_fields = include_all_fields_,
                 analysis_mode = analysis_mode,
                 thread_count = thread_count_,
                 ped_file = ped_file,
@@ -135,6 +138,7 @@ task RunExpansionHunter {
         String sample_id
         Boolean generate_realigned_bam
         Boolean generate_vcf
+        Boolean include_all_fields
         String analysis_mode
         Int thread_count
         File? ped_file
@@ -200,7 +204,9 @@ task RunExpansionHunter {
             touch ~{sample_id}.vcf.gz
         fi
 
-        python /opt/str/combine_expansion_hunter_json_to_tsv.py -o ~{sample_id} ~{sample_id}.json
+        python /opt/str/combine_expansion_hunter_json_to_tsv.py \
+            ~{if (defined(include_all_fields)) then "--include-all-fields " else ""} \
+            -o ~{sample_id} ~{sample_id}.json
         mv ~{sample_id}.*_json_files_alleles.tsv ~{sample_id}_alleles.tsv
         mv ~{sample_id}.*_json_files_variants.tsv ~{sample_id}_variants.tsv
 

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -106,6 +106,7 @@ workflow ExpansionHunter {
             realigned_bams = RunExpansionHunter.realigned_bam,
             realigned_bams_index = RunExpansionHunter.realigned_bam_index,
             generate_realigned_bam = generate_realigned_bam_,
+            generate_reviewer_images = generate_reviewer_images_,
             generate_vcf = generate_vcf_,
             sample_id = sample_id,
             reviewer_images_gzs = RunReviewer.reviewer_images_gz,
@@ -250,6 +251,7 @@ task ConcatEHOutputs {
         Array[File?] sample_metrics
         String sample_id
         Boolean generate_realigned_bam
+        Boolean generate_reviewer_images
         Boolean generate_vcf
         String? output_prefix
         String expansion_hunter_docker
@@ -307,20 +309,26 @@ task ConcatEHOutputs {
         gzip "~{output_prefix}_alleles.tsv"
         gzip "~{output_prefix}_variants.tsv"
 
-        # This will output two files: prefix_metrics.csv & prefix_missing_metrics.csv
-        python /opt/str/merge_csv_files.py \
-            --input-filename ~{write_lines(sample_metrics_)} \
-            --output-prefix ~{output_prefix}
+        if ~{generate_reviewer_images}; then
+            # This will output two files: prefix_metrics.csv & prefix_missing_metrics.csv
+            python /opt/str/merge_csv_files.py \
+                --input-filename ~{write_lines(sample_metrics_)} \
+                --output-prefix ~{output_prefix}
 
-        # Combine multiple archives into one archive,
-        # by first unzipping all to a common directory,
-        # the archiving all the contents of the directory into a single archive.
-        TEMP_DIR_NAME="~{output_prefix}_reviewer_images"
-        mkdir $TEMP_DIR_NAME
-        while read -r archive_filename; do
-            tar -xzf "$archive_filename" -C $TEMP_DIR_NAME
-        done < ~{write_lines(reviewer_images_gz_)}
-        tar -czf ~{output_prefix}_reviewer_images.tar.gz -C $TEMP_DIR_NAME .
+            # Combine multiple archives into one archive,
+            # by first unzipping all to a common directory,
+            # the archiving all the contents of the directory into a single archive.
+            TEMP_DIR_NAME="~{output_prefix}_reviewer_images"
+            mkdir $TEMP_DIR_NAME
+            while read -r archive_filename; do
+                tar -xzf "$archive_filename" -C $TEMP_DIR_NAME
+            done < ~{write_lines(reviewer_images_gz_)}
+            tar -czf ~{output_prefix}_reviewer_images.tar.gz -C $TEMP_DIR_NAME .
+        else
+            touch ~{output_prefix}_metrics.csv
+            touch ~{output_prefix}_missing_metrics.csv
+            touch ~{output_prefix}_reviewer_images.tar.gz
+        fi
     >>>
 
     RuntimeAttr runtime_default = object {

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -307,10 +307,10 @@ task ConcatEHOutputs {
         gzip "~{output_prefix}_alleles.tsv"
         gzip "~{output_prefix}_variants.tsv"
 
+        # This will output two files: prefix_metrics.csv & prefix_missing_metrics.csv
         python /opt/str/merge_csv_files.py \
             --input-filename ~{write_lines(sample_metrics_)} \
-            --metrics ~{output_prefix}_metrics.csv \
-            --missing-metrics ~{output_prefix}_missing_metrics.csv
+            --output-prefix ~{output_prefix}
 
         # Combine multiple archives into one archive,
         # by first unzipping all to a common directory,

--- a/wdl/ExpansionHunter.wdl
+++ b/wdl/ExpansionHunter.wdl
@@ -206,7 +206,7 @@ task RunExpansionHunter {
         fi
 
         python /opt/str/combine_expansion_hunter_json_to_tsv.py \
-            ~{if (defined(include_all_fields)) then "--include-all-fields " else ""} \
+            ~{if include_all_fields then "--include-all-fields " else ""} \
             -o ~{sample_id} ~{sample_id}.json
         mv ~{sample_id}.*_json_files_alleles.tsv ~{sample_id}_alleles.tsv
         mv ~{sample_id}.*_json_files_variants.tsv ~{sample_id}_variants.tsv

--- a/wdl/ExpansionHunterScatter.wdl
+++ b/wdl/ExpansionHunterScatter.wdl
@@ -18,6 +18,7 @@ workflow ExpansionHunterScatter {
         Boolean? generate_vcf
         Boolean? seeking_analysis_mode
         Boolean? generate_reviewer_images
+        Boolean? include_all_fields
         Int? thread_count
         String expansion_hunter_docker
         String python_docker
@@ -70,6 +71,7 @@ workflow ExpansionHunterScatter {
                 generate_vcf = generate_vcf,
                 seeking_analysis_mode = seeking_analysis_mode,
                 generate_reviewer_images = generate_reviewer_images,
+                include_all_fields = include_all_fields,
                 thread_count = thread_count,
                 expansion_hunter_docker = expansion_hunter_docker,
                 python_docker = python_docker,


### PR DESCRIPTION
This PR improves the STR workflow in the following areas: 

- [x] Add a flag to enable including _all_ the ExpansionHunter generated metrics when converting its JSON output to a TSV file using a utility script; defaulted to `false` (i.e., not including);
- [x] Improve on generating metrics from the REViewer images: 
   - Bug fix in the utility script addressing a case where the file containing the list of image files may have invalid file names (e.g., blank space or lines containing only white space). This bug is fixed by considering only lines referencing a valid file.  
   - Simplify the interface so that only a prefix is provided instead of separate output filenames.
   - Run REViewer-related steps only if the `generate_reviewer_images` flag is set; otherwise, generate empty files for the workflow expected outputs.