### PR TITLE
Remove ped file from workspace data TSV for cohort mode terra workspace

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/workspace.tsv.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workspace.tsv.tmpl
@@ -22,7 +22,6 @@ allosome_file	{{ reference_resources.allosome_file }}
 autosome_file	{{ reference_resources.autosome_file }}
 bin_exclude	{{ reference_resources.bin_exclude }}
 cnmops_exclude_list	{{ reference_resources.cnmops_exclude_list }}
-cohort_ped_file	gs://broad-dsde-methods-eph/ped_1kgp_all.ped
 contig_ploidy_priors	{{ reference_resources.contig_ploidy_priors }}
 copy_number_autosomal_contigs	{{ reference_resources.copy_number_autosomal_contigs }}
 cytobands	{{ reference_resources.cytobands }}


### PR DESCRIPTION
### Updates
Removed `cohort_ped_file` attribute from workspace data TSV template for cohort-mode Terra workspace. 

### Motivation
When users need to update the workspace data (most often docker images) in an existing GATK-SV Terra workspace, the easiest way is to upload the new workspace data TSV. But if the reference panel PED file is included, this will overwrite the user's own PED file in workspace data. This is not obvious and can lead to errors that are hard to diagnose. Removing the reference panel PED file is the simplest way to prevent this issue.

### Testing
Successfully built the workspace TSV from its template and uploaded it to a test workspace.