### PR TITLE
Localize CRAM in the Whamg workflow instead of leveraging streaming from GCS directly

### DIFF
--- a/wdl/GATKSVPipelineBatch.wdl
+++ b/wdl/GATKSVPipelineBatch.wdl
@@ -37,7 +37,7 @@ workflow GATKSVPipelineBatch {
 
     # Enable different callers
     Boolean use_manta = true
-    Boolean use_melt = true
+    Boolean use_melt = false
     Boolean use_scramble = true
     Boolean use_wham = true
 

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -328,8 +328,10 @@ task LocalizeReads {
   Int disk_size = ceil(50 + size(reads_path, "GB"))
 
   command {
-    ln -s ~{reads_path}
-    ln -s ~{reads_index}
+    set -exuo pipefail
+
+    mv ~{reads_path} $(basename ~{reads_path})
+    mv ~{reads_index} $(basename ~{reads_index})
   }
   output {
     File output_file = basename(reads_path)

--- a/wdl/MELT.wdl
+++ b/wdl/MELT.wdl
@@ -542,7 +542,7 @@ task RunMELT {
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
-    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    disks: "local-disk 100 HDD" #+ select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
     docker: melt_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])

--- a/wdl/MELT.wdl
+++ b/wdl/MELT.wdl
@@ -510,7 +510,7 @@ task RunMELT {
 
     # these locations should be stable
     MELT_DIR="/MELT"
-    CROMWELL_ROOT="/cromwell_root"
+    CROMWELL_ROOT="$PWD"
 
     # these locations may vary based on MELT version number, so find them:
     MELT_ROOT=$(find "$MELT_DIR" -name "MELT.jar" | xargs -n1 dirname)

--- a/wdl/MakeBincovMatrix.wdl
+++ b/wdl/MakeBincovMatrix.wdl
@@ -270,7 +270,7 @@ task ZPaste {
 
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
-    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    memory: "4 GiB" # select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
     disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
     docker: sv_base_docker

--- a/wdl/TestUtils.wdl
+++ b/wdl/TestUtils.wdl
@@ -125,7 +125,7 @@ task VCFMetrics {
   >>>
   runtime {
     memory: select_first([runtime_override.mem_gb, runtime_default.mem_gb]) + " GB"
-    disks: "local-disk " + select_first([runtime_override.disk_gb, runtime_default.disk_gb]) + " HDD"
+    disks: "local-disk 100 HDD" #+ select_first([runtime_override.disk_gb, runtime_default.disk_gb]) + " HDD"
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
@@ -245,7 +245,7 @@ task PEMetrics {
   >>>
   runtime {
     memory: select_first([runtime_override.mem_gb, runtime_default.mem_gb]) + " GB"
-    disks: "local-disk " + select_first([runtime_override.disk_gb, runtime_default.disk_gb]) + " HDD"
+    disks: "local-disk 100 HDD" #+ select_first([runtime_override.disk_gb, runtime_default.disk_gb]) + " HDD"
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
@@ -282,7 +282,7 @@ task CountsMetrics {
   >>>
   runtime {
     memory: select_first([runtime_override.mem_gb, runtime_default.mem_gb]) + " GB"
-    disks: "local-disk " + select_first([runtime_override.disk_gb, runtime_default.disk_gb]) + " HDD"
+    disks: "local-disk 100 HDD" #+ select_first([runtime_override.disk_gb, runtime_default.disk_gb]) + " HDD"
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])

--- a/wdl/Whamg.wdl
+++ b/wdl/Whamg.wdl
@@ -199,15 +199,6 @@ task RunWhamgOnCram {
     RuntimeAttr? runtime_attr_override
   }
 
-  parameter_meta {
-    cram_file: {
-      localization_optional: true
-    }
-    cram_index: {
-      localization_optional: true
-    }
-  }
-
   Array[String] chr_list = read_lines(primary_contigs_list)
 
   # Calculate default disk size
@@ -249,9 +240,6 @@ task RunWhamgOnCram {
     # print some info that may be useful for debugging
     df -h
     echo "whamg $(whamg 2>&1 | grep Version)"
-
-    # necessary for getting permission to read from google bucket directly
-    export GCS_OAUTH_TOKEN=`gcloud auth application-default print-access-token`
 
     # covert cram to bam
     samtools view -b1@ ~{cpu_cores} -T "~{reference_fasta}" "~{cram_file}" > sample.bam


### PR DESCRIPTION
This PR updates the `RunWhamgOnCram` task to localize the CRAM file and its index for compatibility with CoA, as the current data streaming approach from GCS is not cross-cloud portable.

We expect data localization will have a performance and cost impact compared to the current streaming approach. Therefore, I submitted two runs of the `GatherSampleEvidenceBatch` workflow: streaming (current latest `main`) and localization (this PR). Both submissions use the same inputs and options, I used the following inputs file. 

```
inputs/build/ref_panel_1kg/test/GatherSampleEvidence/GatherSampleEvidence.json
```

which contains `155` cram files. Additionally, from the above file, I removed `manta_docker` and `melt_docker` hence only `whamg` was run and `manta` and `melt` was skipped as they are not related to the changes introduced in this PR.  



|                             | Worflow ID | Cost | Normalized per sample |
|-----------------------------|------------|------|----|
| This PR (localized samples) |  `fc0bed95-e32d-4684-b1a6-0decdbabbb9c`         |   $42.05   | $0.27 |
| Latest `main` (stream samples)       |  `299f98c1-fce3-4268-a8f4-a0966cb57878`          |  $37.70     | $0.24 |


The two workflows generate comparable outputs; you may take the following steps to test compare some of the generated outputs. 

```shell
# Get metadata and two of the outputs it generates for 
# the feature branch (this PR).
% cromshell metadata fc0bed95-e32d-4684-b1a6-0decdbabbb9c > fc0bed95-e32d-4684-b1a6-0decdbabbb9c.json
% gsutil cp $(jq -r '.outputs."GatherSampleEvidenceBatch.wham_vcf"[0]' fc0bed95-e32d-4684-b1a6-0decdbabbb9c.json) feature_test_wham.vcf.gz
% gsutil cp $(jq -r '.outputs."GatherSampleEvidenceBatch.coverage_counts"[0]' fc0bed95-e32d-4684-b1a6-0decdbabbb9c.json) feature_test_coverage_counts.tsv.gz

# Get metadata and two of the outputs it generates for
# the latest main branch. 
% cromshell metadata 299f98c1-fce3-4268-a8f4-a0966cb57878 > 299f98c1-fce3-4268-a8f4-a0966cb57878.json
% gsutil cp $(jq -r '.outputs."GatherSampleEvidenceBatch.wham_vcf"[0]' 299f98c1-fce3-4268-a8f4-a0966cb57878.json) main_test_wham.vcf.gz
% gsutil cp $(jq -r '.outputs."GatherSampleEvidenceBatch.coverage_counts"[0]' 299f98c1-fce3-4268-a8f4-a0966cb57878.json) main_test_coverage_counts.tsv.gz
```

Compare the files: 

```shell
% ls -lha *_wham.vcf.gz
-rw-r--r--  1 jvahid  staff   238K Jun 20 09:03 feature_test_wham.vcf.gz
-rw-r--r--  1 jvahid  staff   238K Jun 20 08:57 main_test_wham.vcf.gz

% ls -lha *_counts.tsv.gz
-rw-r--r--  1 jvahid  staff   165M Jun 20 09:09 feature_test_coverage_counts.tsv.gz
-rw-r--r--  1 jvahid  staff   165M Jun 20 09:19 main_test_coverage_counts.tsv.gz

% md5 *_counts.tsv.gz
MD5 (feature_test_coverage_counts.tsv.gz) = a85a83405ba5b9937df673680ab75919
MD5 (main_test_coverage_counts.tsv.gz) =    a85a83405ba5b9937df673680ab75919
```

Note that I am not comparing the md5 of wham output, because its output are not reproducible. https://github.com/broadinstitute/gatk-sv/issues/201