### PR TITLE
Update SR counting and genotyping

### DIFF
--- a/src/sv-pipeline/03_variant_filtering/scripts/rewrite_SR_coords.py
+++ b/src/sv-pipeline/03_variant_filtering/scripts/rewrite_SR_coords.py
@@ -15,10 +15,23 @@ import pandas as pd
 def rewrite_SR_coords(record, metrics, pval_cutoff, bg_cutoff):
     row = metrics.loc[record.id]
     if row.SR_sum_log_pval >= pval_cutoff and row.SR_sum_bg_frac >= bg_cutoff:
-        record.pos = int(row.SR_posA_pos)
-        record.stop = int(row.SR_posB_pos)
-        if record.info['SVTYPE'] == 'INV':
-            record.pos, record.stop = sorted([record.pos, record.stop])
+        posA = int(row.SR_posA_pos)
+        posB = int(row.SR_posB_pos)
+        if record.info['SVTYPE'] == 'INS':
+            # posA is always (+) strand and posB (-) strand; need to set order so pos <= end
+            if posB < posA:
+                record.pos = int(posB)
+                record.stop = int(posA)
+                record.info['STRANDS'] = '-+'
+            else:
+                record.pos = int(posA)
+                record.stop = int(posB)
+                record.info['STRANDS'] = '+-'
+        elif record.info['SVTYPE'] == 'INV':
+            record.pos, record.stop = sorted([posA, posB])
+        else:
+            record.pos = posA
+            record.stop = posB
         if record.info['SVTYPE'] not in 'INS BND'.split():
             record.info['SVLEN'] = record.stop - record.pos
 

--- a/src/sv-pipeline/04_variant_resolution/scripts/SR_genotype.opt_part2.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/SR_genotype.opt_part2.sh
@@ -3,7 +3,7 @@
 # SR_genotype.sh
 #
 
-set -euxo pipefail
+set -euo pipefail
 
 ##Genotype##
 function assign_genotype_quality () {

--- a/src/sv-pipeline/04_variant_resolution/scripts/SR_genotype.opt_part2.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/SR_genotype.opt_part2.sh
@@ -3,14 +3,114 @@
 # SR_genotype.sh
 #
 
+set -euxo pipefail
 
-set -euo pipefail
+##Genotype##
+function assign_genotype_quality () {
+
+  # Arguments
+  INFILE=$1
+  VIDS_LIST=$2
+  MEDIAN_HET=$3
+  STDEV=$4
+  GQ_FILE=$5
+  VARQ_FILE=$6
+
+  ##normalization factor##
+  ##Normalize phred scores to 999 if count is the mean  ##
+  normalization=$(Rscript -e "print(((pnorm(0) )))"  \
+                    | tr '\n' '\t' \
+                    | awk '{print 999/($NF)}')
+  ##null genotype get max quality score##
+  zcat $INFILE \
+    | awk '{if ($NF==0 && $3==0) print $0 "\t" 999}' \
+    | gzip \
+    > null.geno.txt.gz
+
+  ##null genotype but has SR reads determined by poisson test##
+  if [ $(zcat $INFILE|awk '{if ($NF==0 && $3>0) print}'|wc -l) -gt 0 ]
+  then
+    zcat $INFILE|awk '{if ($NF==0 && $3>0) print}' \
+      | Rscript -e 'd<-read.table("stdin")' \
+      -e "z<-cbind(d[1],d[,2],d[,3],d[,4],round(matrix(apply(d[,3,drop=F],1, function (x) (1-ppois(0, lambda=x))* $normalization) ,ncol=1)) )" \
+      -e 'write.table(z,"null.wreads.geno.txt",col.names=FALSE,quote=FALSE,row.names=FALSE,sep = "\t")'
+  else
+    echo "" > null.wreads.geno.txt
+  fi
+
+  ##genotype based on z score for observation with genotypes##
+  if [ $(zcat $INFILE|awk '{if ($NF==1) print}'|wc -l) -gt 0 ]
+  then
+    zcat $INFILE|awk '{if ($NF==1) print}' \
+      | Rscript -e 'd<-read.table("stdin")' \
+      -e "z<-apply(d[,3,drop=F]-$MEDIAN_HET,1, function (x) ((pnorm(x/$STDEV) )))" \
+      -e "zfinal<-round(z* $normalization)" \
+      -e 'write.table(cbind(d[1],d[,2],d[,3],d[,4],zfinal),"wreads.geno.het.txt",col.names=FALSE,quote=FALSE,row.names=FALSE,sep = "\t")'
+  else
+    echo "" > wreads.geno.het.txt
+  fi
+  if [ $(zcat $INFILE|awk '{if ($NF>1) print}'|wc -l) -gt 0 ]
+  then
+    zcat $INFILE|awk '{if ($NF>1) print}' \
+      | Rscript -e 'd<-read.table("stdin")' \
+      -e "z<-apply(d[,3,drop=F]-2*$MEDIAN_HET,1, function (x) ((pnorm(x/$STDEV) )))" \
+      -e "zfinal<-round(z* $normalization)" \
+      -e 'write.table(cbind(d[1],d[,2],d[,3],d[,4],zfinal),"wreads.geno.hom.txt",col.names=FALSE,quote=FALSE,row.names=FALSE,sep = "\t")'
+  else
+    echo "" > wreads.geno.hom.txt
+  fi
+
+  cat wreads.geno.het.txt wreads.geno.hom.txt null.wreads.geno.txt <(zcat null.geno.txt.gz) \
+    | sed '/^$/d' \
+    | awk '{if ($NF<0) print $1,$2,$3,$4,1;else if ($NF>999) print $1,$2,$3,$4,999 ;else print}' \
+    | tr ' ' '\t' \
+    | sort -k1,1 -k2,2 \
+    | gzip \
+    > $GQ_FILE
+
+  ##Per variant quality scores##
+  ##Assign a normalization factor to scale variant up to 999 if based on expected het median ##
+  normalization_var=$(Rscript -e "print(-10*log10(ppois(0, lambda=$MEDIAN_HET)))"  \
+                    | tr '\n' '\t' \
+                    | awk '{print 999/($NF)}')
+
+  if [ $(zcat $INFILE|awk '{if ($NF>0) print}'|wc -l) -gt 0 ]
+  then
+    zcat $INFILE|awk '{if ($NF>0) print}' \
+      | Rscript -e 'd<-read.table("stdin")' \
+      -e 'x<-tapply(d[,3],d[,1],median)' \
+      -e 'z<-cbind(names(x),(-10*log10(ppois(0, lambda=x))))' \
+      -e 'write.table(z,"sr.variant.quality.final.txt",col.names=FALSE,quote=FALSE,row.names=FALSE,sep = "\t")'
+  else
+    echo "" > sr.variant.quality.final.txt
+  fi
+
+  ##add back variants with no SR support##
+  awk '{print $1}' sr.variant.quality.final.txt \
+    | awk -F'\t' -v OFS='\t' 'ARGIND==1{keys[$1]; next} { if (!($1 in keys)) print }' - $VIDS_LIST \
+    | awk '{print $1}' \
+    | sort -u \
+    | awk '{print $1 "\t" 0}' \
+    > sr.variant.quality.final.null.txt
+
+  awk -v var=$normalization_var '{if ($2*var>999) print $1 "\t" 999;else print $1 "\t" $2*var}'  sr.variant.quality.final.txt \
+    | cat - sr.variant.quality.final.null.txt \
+    | awk -F"\t" '{if ($1!="") print}'  \
+    | sort -k1,1 \
+    | gzip \
+    > $VARQ_FILE
+}
 
 #whole cohort files that can be split
 vcf=$1
 SR_counts=$2
 SR_sum=$3
 metric_file=$4
+svtype=$5
+# Recommended 1.6
+hom_cutoff_multiplier=$6
+# Recommended 105
+median_hom_ins=$7
 
 #sr cutoff taken from metric file for genotyping
 sr_count=$(awk '{if($1=="sr_count") print $2}' $metric_file)
@@ -25,6 +125,19 @@ rare_both=$(awk '{if($1=="rare_both") print $2}' $metric_file)
 common_single=$(awk '{if($1=="common_single") print $2}' $metric_file)
 common_both=$(awk '{if($1=="common_both") print $2}' $metric_file)
 
+if [ $svtype == "INS" ]; then
+  # Insertion hom-var counts follow a consistent distribution across cohorts
+  # This is a minimal correction to the genotyping model to minimize hom-var over-calling
+  median_hom=$median_hom_ins
+fi
+
+bothside_median_het=$(echo "print(0.5*$median_hom)" | python)
+bothside_hom_cutoff=$(echo "print($hom_cutoff_multiplier*$bothside_median_het)" | python)
+bothside_sd_het=$sd_het
+
+oneside_median_het=$(echo "print(0.5*$bothside_median_het)" | python)
+oneside_hom_cutoff=$(echo "print($hom_cutoff_multiplier*$oneside_median_het)" | python)
+oneside_sd_het=$(echo "print(0.5*$sd_het)" | python)
 
 zcat ${SR_counts} \
   | awk -v sr_count=$sr_count '{if ($NF>(sr_count/2)) print $1"@"$3}' \
@@ -32,181 +145,155 @@ zcat ${SR_counts} \
   | uniq -c \
   | awk '{if ($1==2) print $2}' \
   > two.sided.pass.txt
+# Output columns:
+# 1) VID@Sample (with sufficient SR count on both sides)
 
-# grep out variants which pass SR in random forest
+# get variants to genotype
 svtk vcf2bed $vcf int.bed -i EVIDENCE
 
 awk '{if ($NF~"SR") print $4}' int.bed> pass.srtest.txt
 
 ##Genotype SR genotype (0-ref, then estimate copy state based on copy state that is 1 sd from sd_het  )##
-if [ $(cat two.sided.pass.txt|wc -l) -gt 0 ]
-then
 zcat ${SR_sum} \
   | awk '{print $0 "\t" $1"@"$2}' \
-  | { fgrep -wf two.sided.pass.txt || [[ $? == 1 ]]; } \
+  | awk -F'\t' -v OFS='\t' 'ARGIND==1{keys[$1]; next} { if ($NF in keys) print }' two.sided.pass.txt - \
   | cut -f1-3 \
-  | awk -v var=$sr_count -v var1=$median_hom -v var2=$sd_het '{if ($3<var) print $1,$2,$3,0;else if ($3<=var1-var2) print $1,$2,$3,1; else print $1,$2,$3,int($3/(var1/2)+0.5)}'  \
-  |tr ' ' '\t' \
-  > sr.geno.final.txt
-fi
-
-zcat ${SR_sum} \
-  | awk '{print $0 "\t" $1"@"$2}' \
-  | { fgrep -wvf two.sided.pass.txt || [[ $? == 1 ]]; } \
-  | cut -f1-3 \
-  | awk '{print $1,$2,$3,0}' \
-  |tr ' ' '\t' \
-  >> sr.geno.final.txt
-
-gzip sr.geno.final.txt
+  | awk -v var=$sr_count -v hom_cutoff=$bothside_hom_cutoff -v median_het=$bothside_median_het '{if ($3<var) print $1,$2,$3,0;else if ($3<=hom_cutoff) print $1,$2,$3,1; else print $1,$2,$3,(int(($3/median_het)+0.5) < 2) ? 2 : int(($3/median_het)+0.5)}'  \
+  | tr ' ' '\t' \
+  | gzip \
+  > sr.geno.final.txt.gz
 
 zcat ${SR_sum} \
   | awk '{print $0 "\t" $1"@"$2}' \
   | cut -f1-3 \
-  | awk -v var=$sr_count -v var1=$median_hom -v var2=$sd_het '{if ($3<var) print $1,$2,$3,0;else if ($3<=var1-var2) print $1,$2,$3,1; else print $1,$2,$3,int($3/(var1/2)+0.5)}' \
-  |tr ' ' '\t' \
+  | awk -v var=$sr_count -v hom_cutoff=$oneside_hom_cutoff -v median_het=$oneside_median_het '{if ($3<var) print $1,$2,$3,0;else if ($3<=hom_cutoff) print $1,$2,$3,1; else print $1,$2,$3,(int(($3/median_het)+0.5) < 2) ? 2 : int(($3/median_het)+0.5)}'  \
+  | tr ' ' '\t' \
   | gzip \
   > sr.geno.final.oneside.txt.gz
+# Output columns:
+# 1) VID
+# 2) Sample ID
+# 3) SR sum
+# 4) Genotype (one-sided)
   
 ##Allow just one side##
 zcat sr.geno.final.oneside.txt.gz \
-  |awk '{if ($3>1) print $1}' \
-  |sort|uniq -c|awk '{print $2 "\t" $1}' \
-  >background.sr.txt
+  | awk '{if ($3>1) print $1}' \
+  | sort \
+  | uniq -c \
+  | awk '{print $2 "\t" $1}' \
+  > background.sr.txt
+# Output columns:
+# 1) VID
+# 2) Number of samples with an SR count over 1
 
 zcat sr.geno.final.oneside.txt.gz \
-  |awk '{if ($NF>0) print $1}' \
-  |sort|uniq -c \
-  |awk '{print $2 "\t" $1}'|sort -k1,1 \
-  |join -j 1 - background.sr.txt \
-  |awk '{ print $0 "\t" $2/$3}' \
-  >recover.txt
+  | awk '{if ($NF>0) print $1}' \
+  | sort \
+  | uniq -c \
+  | awk '{print $2 "\t" $1}'|sort -k1,1 \
+  | join -j 1 - background.sr.txt \
+  | awk '{ print $0 "\t" $2/$3}' \
+  > recover.txt
+# Output columns:
+# 1) VID
+# 2) Number of non-ref genotypes
+# 3) Number of samples with more than 1 SR
+# 4) Fraction of samples with more than 1 SR that have non-ref genotypes, i.e. (2)/(3)
 
 ##Require both##
 zcat $SR_counts|awk '{if ($NF>0) print $1"@"$3}'|sort|uniq -c|awk '{if ($1==2) print $2}'>two.sided.pass.just1read.txt
+# Output columns:
+# 1) VID@Sample (with at least 1 SR on both sides)
 
 join -j 2 <(cut -d"@" -f1 two.sided.pass.txt|sort|uniq -c) \
    <(cut -d"@" -f1 two.sided.pass.just1read.txt|sort|uniq -c) \
-   |awk '{print $0"\t" $2/$3}' \
-   >recover.bothsides.txt
-
+   | awk '{print $0"\t" $2/$3}' \
+   > recover.bothsides.txt
+# Output columns:
+# 1) VID (with at least 1 sample having bothside support)
+# 2) Number of samples with bothside support
+# 3) Number of samples with non-zero counts on both sides
+# 4) Fraction of samples with non-zero SR count that have sufficient counts on both sides, i.e. (2)/(3)
 
 ## Find passing variants based off ROC check##
-
 awk -v var=$rare_max  -v var1=$rare_single '{if ($NF>=var1 && $2<=var) print $1}' recover.txt>single.pass.txt
 awk -v var=$rare_max -v var1=$rare_both '{if ($NF>=var1  && $2<=var) print $1}' recover.bothsides.txt>both.pass.txt
 
 awk -v var=$common_min  -v var1=$common_single '{if ($NF>=var1 && $2>=var) print $1}' recover.txt>>single.pass.txt
+# Output columns:
+# 1) VID (one-sided variants that don't have too many background samples,
+#         i.e. samples with non-zero SR that are genotyped as hom-ref)
 awk -v var=$common_min -v var1=$common_both '{if ($NF>=var1  && $2>=var) print $1}' recover.bothsides.txt>>both.pass.txt
+# Output columns:
+# 1) VID (two-sided variants that don't have too many background samples,
+#         i.e. samples with non-zero SR that have two-sided support)
+
+# Note the VIDs in single.pass.txt and both.pass.txt are not mutually exclusive
 
 ##SR background variant failures##
-if [ $(cat both.pass.txt single.pass.txt \
-  |fgrep -wvf - int.bed \
-  |awk '{print $4}' \
-  |sort -u \
-  |fgrep -wf pass.srtest.txt \
-  |fgrep -wf <(cat recover.txt recover.bothsides.txt|awk '{print $1}'|sort -u)|wc -l) -gt 0 ]
-then
- cat both.pass.txt single.pass.txt \
-  |{ fgrep -wvf - int.bed || [[ $? == 1 ]]; } \
-  |awk '{print $4}' \
-  |sort -u \
-  |{ fgrep -wf pass.srtest.txt || [[ $? == 1 ]]; } \
-  |{ fgrep -wf <(cat recover.txt recover.bothsides.txt|awk '{print $1}'|sort -u) || [[ $? == 1 ]]; } \
-   >background.variant.fail.txt
-else 
- echo "">background.variant.fail.txt 
-fi
+cat both.pass.txt single.pass.txt \
+  | awk -F'\t' -v OFS='\t' 'ARGIND==1{keys[$1]; next} { if ($4 != "name" && !($4 in keys)) print }' - int.bed \
+  | awk '{print $4}' \
+  | sort -u \
+  | awk -F'\t' -v OFS='\t' 'ARGIND==1{keys[$1]; next} { if ($1 in keys) print }' pass.srtest.txt - \
+  | awk -F'\t' -v OFS='\t' 'ARGIND==1{keys[$1]; next} { if ($1 in keys) print }' <(cat recover.txt recover.bothsides.txt|awk '{print $1}'|sort -u) - \
+  > background.variant.fail.txt
 
 ##Pull out variants to genotype##
 join -j 1 -a 1 -a 2  -e "." -o 1.1 2.1 1.2 1.3 1.4 1.5 2.2 2.3 2.4 2.5 \
   <(zcat sr.geno.final.txt.gz \
-  |fgrep -wf both.pass.txt \
   |awk '{print $1"@"$2"\t"$0}' |sort -k1,1) \
   <(zcat sr.geno.final.oneside.txt.gz \
-  |fgrep -wf single.pass.txt|awk '{print $1"@"$2"\t"$0}'|sort -k1,1) \
-  |awk '{if ($1!=".") print $1,$3,$4,$5,$6,$9,$10; else print $2,$7,$8,$5,$6,$9,$10}' \
+  |awk '{print $1"@"$2"\t"$0}'|sort -k1,1) \
+  |awk '{if ($1!="." && $5) print $1,$3,$4,$5,$6,$9,$10; else print $2,$7,$8,$5,$6,$9,$10}' \
+  |awk '{if ($4>0) print $1,$2,$3,$4,$5; else print $1,$2,$3,$6,$7}' \
   |gzip>combine.int.txt.gz
+# Output columns:
+# 1) VID@Sample (passing variants only)
+# 2) VID
+# 3) Sample
+# 4) SR count (prioritizing two-sided if its two-sided genotype is non-ref)
+# 5) Genotype (prioritizing two-sided if its two-sided genotype is non-ref)
 
-join -j 1 -a 1 -a 2 -e "." -o 1.1 2.1 1.2 1.3 1.4 1.5 1.6 1.7 2.2 2.3 2.4 2.5 \
-  <(zcat combine.int.txt.gz) <(zcat sr.geno.final.oneside.txt.gz \
-  |awk '{print $1"@"$2"\t"$0}' \
-  |sort -k1,1)|awk '{ if ($1!=".") print $1,$3,$4,$5,$6,$7,$8,$11,$12; else print $2,$9,$10,$5,$6,$7,$8,$11,$12}' \
-  |awk '{if ($5>0) print $2,$3,$4,$5; else if ($7>0) print $2,$3,6,$7;else print $2,$3,$8,$9}' \
-  |tr ' ' '\t'|gzip>sr.geno.withfinal.fitler.txt.gz
+# Reformat
+zcat combine.int.txt.gz | awk '{print $2,$3,$4,$5}' |tr ' ' '\t'|gzip>sr.geno.withfinal.filter.txt.gz
+# Output columns:
+# 1) VID (passing variants only)
+# 2) Sample
+# 3) SR count
+# 4) Genotype (prioritizing two-sided if it is passing)
 
-##Genotype##
-##normalization factor##
-##Phred score for z score of 0 (p=0.5) normalized (3.0103) to 999 after subtracting nearest alternative genotype like GATK  ##
-normalization=$(Rscript -e "print(-10*log10((1-pnorm(($median_hom/2)/$sd_het) )))"  \
-                  | tr '\n' '\t' \
-                  | awk '{print 999/($NF-3.0103)}')
-##null genotype get max quality score##
-zcat sr.geno.withfinal.fitler.txt.gz|awk '{if ($NF==0 && $3==0) print $0 "\t" 999}'|gzip>null.geno.txt.gz
+# Genotype bothsided and onesided variants separately
+echo "Genotyping bothside..."
+zcat sr.geno.withfinal.filter.txt.gz \
+  | awk -F'\t' -v OFS='\t' '{ print $1"@"$2,$0 }' \
+  | awk -F'\t' -v OFS='\t' 'ARGIND==1{keys[$1]; next} { if ($1 in keys) print }' two.sided.pass.txt - \
+  | awk -F'\t' -v OFS='\t' '{ print $2,$3,$4,$5 }' \
+  | gzip \
+  > sr.geno.withfinal.filter.bothside.txt.gz
+bcftools query -f '%ID\n' $vcf > vids.list
+assign_genotype_quality "sr.geno.withfinal.filter.bothside.txt.gz" "vids.list" $bothside_median_het $bothside_sd_het "sr.geno.withquality.bothside.txt.gz" "sr.variant.quality.bothside.txt.gz"
 
-##null genotype but has SR reads determined by poisson test##
-if [ $(zcat sr.geno.withfinal.fitler.txt.gz|awk '{if ($NF==0 && $3>0) print}'|wc -l) -gt 0 ]
-then
-zcat sr.geno.withfinal.fitler.txt.gz|awk '{if ($NF==0 && $3>0) print}' \
-  | Rscript -e 'd<-read.table("stdin")' \
-  -e "z<-cbind(d[1],d[,2],d[,3],d[,4],round(matrix(apply(d[,3,drop=F],1, function (x) -10*log10(1-ppois(0, lambda=x))* $normalization) ,ncol=1)) )" \
-  -e 'write.table(z,"null.wreads.geno.txt",col.names=FALSE,quote=FALSE,row.names=FALSE,sep = "\t")'
-else 
-echo "">null.wreads.geno.txt
-fi
+echo "Genotyping oneside..."
+zcat sr.geno.withfinal.filter.txt.gz \
+  | awk -F'\t' -v OFS='\t' '{ print $1"@"$2,$0 }' \
+  | awk -F'\t' -v OFS='\t' 'ARGIND==1{keys[$1]; next} { if (!($1 in keys)) print }' two.sided.pass.txt - \
+  | awk -F'\t' -v OFS='\t' '{ print $2,$3,$4,$5 }' \
+  | gzip \
+  > sr.geno.withfinal.filter.oneside.txt.gz
+assign_genotype_quality "sr.geno.withfinal.filter.oneside.txt.gz" "vids.list" $oneside_median_het $oneside_sd_het "sr.geno.withquality.oneside.txt.gz" "sr.variant.quality.oneside.txt.gz"
 
-##genotype based on z score for observation with genotypes##
-if [ $(zcat sr.geno.withfinal.fitler.txt.gz|awk '{if ($NF>0) print}'|wc -l) -gt 0 ]
-then
-zcat sr.geno.withfinal.fitler.txt.gz|awk '{if ($NF>0) print}' \
-  | Rscript -e 'd<-read.table("stdin")' \
-  -e "z<-apply(d[,3,drop=F]-(d[,4,drop=F]*$median_hom/2),1, function (x) -10*log10((1-pnorm(abs(x)/$sd_het) )))" \
-  -e "z1<-apply(d[,3,drop=F]-((d[,4,drop=F]*$median_hom/2)-($median_hom/2)),1, function (x) -10*log10((1-pnorm(abs(x)/$sd_het) )))" \
-  -e "z2<-apply(d[,3,drop=F]-((d[,4,drop=F]*$median_hom/2)+($median_hom/2)),1, function (x) -10*log10((1-pnorm(abs(x)/$sd_het) )))" \
-  -e "zfinal<-round((pmin(z1,z2)-z)* $normalization)" \
-  -e 'write.table(cbind(d[1],d[,2],d[,3],d[,4],zfinal),"wreads.geno.txt",col.names=FALSE,quote=FALSE,row.names=FALSE,sep = "\t")'
-else 
-echo "">wreads.geno.txt
-fi
+echo "Concatenating results..."
+zcat sr.geno.withquality.bothside.txt.gz sr.geno.withquality.oneside.txt.gz \
+  | sort -k1,1 \
+  | gzip \
+  > sr.geno.withquality.txt.gz
 
-cat wreads.geno.txt null.wreads.geno.txt <(zcat null.geno.txt.gz)|sed '/^$/d'|awk '{if ($NF<0) print $1,$2,$3,$4,1;else if ($NF>999) print $1,$2,$3,$4,999 ;else print}' |tr ' ' '\t'|sort -k1,1 -k2,2|gzip>sr.geno.withquality.txt.gz
-
-##Per variant quality scores##
-##Assign a normalization factor to scale variant up to 999 if based on expected het median ##
-normalization_var=$(Rscript -e "print(-10*log10(ppois(0, lambda=$median_hom/2)))"  \
-                  | tr '\n' '\t' \
-                  | awk '{print 999/($NF)}')
-
-if [ $(zcat sr.geno.withfinal.fitler.txt.gz|awk '{if ($NF>0) print}'|wc -l) -gt 0 ]
-then
-zcat sr.geno.withfinal.fitler.txt.gz|awk '{if ($NF>0) print}' \
-  | Rscript -e 'd<-read.table("stdin")' \
-  -e 'x<-tapply(d[,3],d[,1],median)' \
-  -e 'z<-cbind(names(x),(-10*log10(ppois(0, lambda=x))))' \
-  -e 'write.table(z,"sr.variant.quality.final.txt",col.names=FALSE,quote=FALSE,row.names=FALSE,sep = "\t")'
-else 
-echo "">sr.variant.quality.final.txt
-fi
-
-
-##add back variants with no SR support##
-if [ $(awk '{print $1}' sr.variant.quality.final.txt |fgrep -wvf - <(zcat $vcf|egrep -v "^#" |awk '{print $3}') |wc -l) -gt 0 ]
-then
-
-awk '{print $1}' sr.variant.quality.final.txt \
-  |{ fgrep -wvf - <(zcat $vcf|egrep -v "^#" |awk '{print $3}') || [[ $? == 1 ]]; } \
-  |awk '{print $1}' \
-  |sort -u \
-  |awk '{print $1 "\t" 0}' \
-  >sr.variant.quality.final.null.txt
-
-else
-echo "">sr.variant.quality.final.null.txt
-fi
-
-awk -v var=$normalization_var '{if ($2*var>999) print $1 "\t" 999;else print $1 "\t" $2*var}'  sr.variant.quality.final.txt \
-  |cat - sr.variant.quality.final.null.txt \
-  |awk -F"\t" '{if ($1!="") print}'  \
-  |sort -k1,1|gzip \
-  >sr.variant.quality.final.txt.gz
-
+# Computes weighted average of one-sided and two-sided variant qualities, weighted by fraction of two-sided samples
+join -j 1 -a 1 -a 2 -e "." -o 1.1 1.2 2.1 2.2 <(zcat sr.variant.quality.bothside.txt.gz) <(zcat sr.variant.quality.oneside.txt.gz) \
+  | awk '{ if ($1==".") {print $3,$2,$4} else {print $1,$2,$4} }' \
+  | join -j 1 -e "." -a 1 -o 1.1 1.2 1.3 2.4 - recover.bothsides.txt \
+  | awk '{ if ($2==".") {print $1,$3} else if ($3==".") {print $1,$2} else {print $1,($2*$4)+($3*(1-$4))} }' \
+  | gzip \
+  > sr.variant.quality.final.txt.gz

--- a/src/svtk/svtk/cli/pesr_test.py
+++ b/src/svtk/svtk/cli/pesr_test.py
@@ -29,6 +29,9 @@ def sr_test(argv):
     parser.add_argument('-w', '--window', type=int, default=100,
                         help='Window around variant start/end to consider for '
                         'split read support. [100]')
+    parser.add_argument('--insertion-window', type=int, default=50,
+                        help='Maximum distance between left and right breakpoint for INS. Allows for crossing in '
+                             'cases of microhomology. [50]')
     parser.add_argument('--common', default=False,
                         action='store_true', help='Ignore background for common AF')
     parser.add_argument('-b', '--background', type=int, default=160,
@@ -84,8 +87,9 @@ def sr_test(argv):
     else:
         medians = None
 
-    runner = SRTestRunner(vcf, countfile, fout, args.background, args.common,
-                          args.window, whitelist, medians=medians, log=args.log)
+    runner = SRTestRunner(vcf, countfile, fout, args.background, common=args.common,
+                          window=args.window, ins_window=args.insertion_window,
+                          whitelist=whitelist, medians=medians, log=args.log)
     runner.run()
 
 

--- a/src/svtk/svtk/pesr/pesr_test.py
+++ b/src/svtk/svtk/pesr/pesr_test.py
@@ -65,7 +65,7 @@ class PESRTest:
         if self.common != "False":
             if len(samples) > len(background):
                 result.background = 0.0
-        pval = ss.poisson.cdf(result.background, result.called)
+        pval = max(ss.poisson.cdf(result.background, result.called), sys.float_info.min)
         result['log_pval'] = np.abs(np.log10(pval))
 
         return result

--- a/src/svtk/svtk/pesr/sr_test.py
+++ b/src/svtk/svtk/pesr/sr_test.py
@@ -9,59 +9,61 @@
 import numpy as np
 import scipy.stats as ss
 import pandas as pd
+import sys
 from .pesr_test import PESRTest, PESRTestRunner
 
 
 class SRTest(PESRTest):
-    def __init__(self, countfile, common=False, window=50, medians=None):
+    def __init__(self, countfile, common=False, window=50, ins_window=50, medians=None):
         self.countfile = countfile
         self.window = window
+        self.ins_window = ins_window
         self.common = common
 
         super().__init__(medians, common)
 
-    def test_record_rec(self, record, called, background):
-        # Test SR support at all coordinates within window of start/end
-        results = []
-        for coord in 'posA posB'.split():
-            result = self._test_coord(record, coord, called, background)
-            result['coord'] = coord
-            results.append(result)
-        results = pd.concat(results, ignore_index=True)
-
-        # Add test for sum of posA and posB
-        total = self._test_total(results)
-        results = pd.concat([results, total], ignore_index=True)
-
-        # Clean up columns
-        results['name'] = record.id
-        results['bg_frac'] = results.called / \
-            (results.background + results.called)
-        results['bg_frac'] = results.bg_frac.fillna(0)
-        cols = 'name coord pos log_pval called background bg_frac'.split()
-        return results[cols]
-
     def test_record(self, record, called, background):
         # Test SR support at all coordinates within window of start/end
         resultA = self._test_coord(
-            record, 'posA', record.chrom, called, background)
-        resultA['coord'] = 'posA'
+            record.pos, record.info['STRANDS'][0], record.chrom,
+            called, background, record.pos - self.window, record.pos + self.window)
 
         resultB = self._test_coord(
-            record, 'posB', record.info['CHR2'], called, background)
+            record.stop, record.info['STRANDS'][1], record.info['CHR2'],
+            called, background, record.stop - self.window, record.stop + self.window)
+
+        posA = int(resultA.pos)
+        posB = int(resultB.pos)
+        log_pval_A = float(resultA.log_pval)
+        log_pval_B = float(resultB.log_pval)
+        if record.info['SVTYPE'] == 'INS':
+            if posA > posB + self.ins_window or posA < posB - self.ins_window:
+                # Invalid coordinates, need to re-optimize around the better coordinate within the insertion window size
+                if log_pval_A >= log_pval_B:
+                    # posA is better, so use posA as anchor and check for best posB in valid window
+                    resultB = self._test_coord(
+                        posA, record.info['STRANDS'][1], record.info['CHR2'],
+                        called, background, posA - self.ins_window, posA + self.ins_window)
+                else:
+                    # vice versa
+                    resultA = self._test_coord(
+                        posB, record.info['STRANDS'][0], record.chrom,
+                        called, background, posB - self.ins_window, posB + self.ins_window)
+        elif record.chrom == record.info['CHR2'] and posA >= posB:
+            # Invalid coordinates, need to re-optimize around the better coordinate
+            if log_pval_A >= log_pval_B:
+                # posA is better, so use posA as anchor and check for best posB in valid window
+                resultB = self._test_coord(
+                    record.stop, record.info['STRANDS'][1], record.info['CHR2'],
+                    called, background, posA, posA + self.window)
+            else:
+                # vice versa
+                resultA = self._test_coord(
+                    record.pos, record.info['STRANDS'][0], record.chrom,
+                    called, background, posB - self.window, posB)
+
+        resultA['coord'] = 'posA'
         resultB['coord'] = 'posB'
-
-        if (record.chrom == record.info['CHR2']) and (int(resultA.pos) >= int(resultB.pos)):
-            rec = 1
-            while True:
-                result = self._test_coord_V2(
-                    record, 'posB', record.chrom, called, background, rec)
-                if int(result.pos) > int(resultA.pos.iloc[0]):
-                    result['coord'] = 'posB'
-                    resultB = result
-                    break
-                rec = rec + 1
-
         results = pd.concat([resultA, resultB], ignore_index=True)
         # Add test for sum of posA and posB
         total = self._test_total(results)
@@ -75,35 +77,6 @@ class SRTest(PESRTest):
         cols = 'name coord pos log_pval called background bg_frac'.split()
 
         return results[cols]
-
-    def _test_coord_V2(self, record, coord, chrom, samples, background, optimal=0):
-        """Test enrichment at all positions within window"""
-        if coord == 'posA':
-            coord, strand = record.pos, record.info['STRANDS'][0]
-        else:
-            coord, strand = record.stop, record.info['STRANDS'][1]
-
-        # Run SR test at each position
-        results = []
-        for pos in range(coord - self.window, coord + self.window + 1):
-            result = self.test(chrom, pos, strand, samples, background)
-            result = result.to_frame().transpose()
-            result['pos'] = pos
-            result['dist'] = np.abs(pos - coord)
-            results.append(result)
-
-        results = pd.concat(results, ignore_index=True)
-
-        # Choose most significant position, using distance to predicted
-        # breakpoint as tiebreaker
-        results = results.sort_values(['log_pval', 'dist'], ascending=False)
-        if optimal < len(results):
-            best = results.iloc[optimal].to_frame().transpose()
-        else:
-            best = results.iloc[-1].to_frame().transpose()
-            best['log_pval'] = 0
-            best['pos'] = record.stop + self.window + 1
-        return best
 
     def test(self, chrom, pos, strand, called, background):
         """
@@ -162,7 +135,7 @@ class SRTest(PESRTest):
     def _test_total(self, results):
         """Test enrichment of posA+posB"""
         total = results['called background'.split()].sum()
-        pval = ss.poisson.cdf(total.background, total.called)
+        pval = max(ss.poisson.cdf(total.background, total.called), sys.float_info.min)
         total['log_pval'] = np.abs(np.log10(pval))
 
         # format and add dummy metadata
@@ -172,20 +145,17 @@ class SRTest(PESRTest):
 
         return total
 
-    def _test_coord(self, record, coord, chrom, samples, background):
+    def _test_coord(self, coord, strand, chrom, samples, background, left_boundary, right_boundary):
         """Test enrichment at all positions within window"""
-        if coord == 'posA':
-            coord, strand = record.pos, record.info['STRANDS'][0]
-        else:
-            coord, strand = record.stop, record.info['STRANDS'][1]
 
         # Run SR test at each position
         results = []
-        for pos in range(coord - self.window, coord + self.window + 1):
+        for pos in range(left_boundary, right_boundary + 1):
             result = self.test(chrom, pos, strand, samples, background)
             result = result.to_frame().transpose()
             result['pos'] = pos
-            result['dist'] = np.abs(pos - coord)
+            # make negative so it sorts correctly
+            result['dist'] = -np.abs(pos - coord)
             results.append(result)
 
         results = pd.concat(results, ignore_index=True)
@@ -199,7 +169,7 @@ class SRTest(PESRTest):
 
 
 class SRTestRunner(PESRTestRunner):
-    def __init__(self, vcf, countfile, fout, n_background=160, common=False, window=100,
+    def __init__(self, vcf, countfile, fout, n_background=160, common=False, window=100, ins_window=50,
                  whitelist=None, blacklist=None, medians=None, log=False):
         """
         vcf : pysam.VariantFile
@@ -207,10 +177,11 @@ class SRTestRunner(PESRTestRunner):
         fout : writable file
         n_background : int
         window : int
+        ins_window : int
         whitelist : list of str
         blacklist : list of str
         """
-        self.srtest = SRTest(countfile, common, window, medians=medians)
+        self.srtest = SRTest(countfile, common=common, window=window, ins_window=ins_window, medians=medians)
         self.fout = fout
 
         super().__init__(vcf, common, n_background, whitelist, blacklist, log)

--- a/wdl/GenotypeBatch.wdl
+++ b/wdl/GenotypeBatch.wdl
@@ -47,6 +47,10 @@ workflow GenotypeBatch {
     File? baseline_genotyped_depth_vcf  # baseline files are optional for metrics workflow
     File? baseline_genotyped_pesr_vcf
 
+    # SR genotyping parameters
+    Int? sr_median_hom_ins
+    Float? sr_hom_cutoff_multiplier
+
     String sv_base_mini_docker
     String sv_pipeline_docker
     String sv_pipeline_rdtest_docker
@@ -187,6 +191,8 @@ workflow GenotypeBatch {
       splitfile = splitfile,
       splitfile_index = splitfile_index,
       ref_dict = ref_dict,
+      sr_hom_cutoff_multiplier = sr_hom_cutoff_multiplier,
+      sr_median_hom_ins = sr_median_hom_ins,
       sv_base_mini_docker = sv_base_mini_docker,
       sv_pipeline_docker = sv_pipeline_docker,
       sv_pipeline_rdtest_docker = sv_pipeline_rdtest_docker,

--- a/wdl/GenotypePESRPart2.wdl
+++ b/wdl/GenotypePESRPart2.wdl
@@ -2,6 +2,7 @@ version 1.0
 
 import "Structs.wdl"
 import "TasksGenotypeBatch.wdl" as tasksgenotypebatch
+import "TasksMakeCohortVcf.wdl" as tasksmakecohortvcf
 
 workflow GenotypePESRPart2 {
   input {
@@ -25,6 +26,10 @@ workflow GenotypePESRPart2 {
     File? discfile_index
     File splitfile
     File? splitfile_index
+
+    # SR genotyping parameters
+    Int? sr_median_hom_ins
+    Float? sr_hom_cutoff_multiplier
 
     String sv_pipeline_docker
     String sv_base_mini_docker
@@ -102,7 +107,9 @@ workflow GenotypePESRPart2 {
         SR_counts = CountSRUnder5kb.sr_counts,
         SR_sum = CountSRUnder5kb.sr_sum,
         SR_metrics = SR_metrics,
-        sv_pipeline_rdtest_docker = sv_pipeline_rdtest_docker,
+        svtype = "CNV_LT_5KBP",
+        hom_cutoff_multiplier = sr_hom_cutoff_multiplier,
+        sv_pipeline_rdtest_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_genotype_sr
     }
 
@@ -195,7 +202,9 @@ workflow GenotypePESRPart2 {
         SR_counts = CountSROver5kb.sr_counts,
         SR_sum = CountSROver5kb.sr_sum,
         SR_metrics = SR_metrics,
-        sv_pipeline_rdtest_docker = sv_pipeline_rdtest_docker,
+        svtype = "CNV_GT_5KBP",
+        hom_cutoff_multiplier = sr_hom_cutoff_multiplier,
+        sv_pipeline_rdtest_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_genotype_sr
     }
 
@@ -288,7 +297,9 @@ workflow GenotypePESRPart2 {
         SR_counts = CountSRBca.sr_counts,
         SR_sum = CountSRBca.sr_sum,
         SR_metrics = SR_metrics,
-        sv_pipeline_rdtest_docker = sv_pipeline_rdtest_docker,
+        svtype = "BCA",
+        hom_cutoff_multiplier = sr_hom_cutoff_multiplier,
+        sv_pipeline_rdtest_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_genotype_sr
     }
 
@@ -314,42 +325,113 @@ workflow GenotypePESRPart2 {
     }
   }
 
-  call TripleStreamCat as TripleStreamCatFail {
+  scatter (ins_bed in SplitVariants.ins_beds) {
+    call tasksgenotypebatch.MakeSubsetVcf as MakeSubsetVcfIns {
+      input:
+        vcf = cohort_vcf,
+        bed = ins_bed,
+        sv_base_mini_docker = sv_base_mini_docker,
+        runtime_attr_override = runtime_attr_make_subset_vcf
+    }
+
+    call tasksgenotypebatch.CountPE as CountPEIns {
+      input:
+        vcf = MakeSubsetVcfIns.subset_vcf,
+        discfile = discfile,
+        discfile_index = discfile_index,
+        medianfile = medianfile,
+        samples = samples,
+        ref_dict = ref_dict,
+        sv_pipeline_docker = sv_pipeline_docker,
+        runtime_attr_override = runtime_attr_count_pe
+    }
+
+    call GenotypePEPart2 as GenotypePEPart2Ins {
+      input:
+        PE_counts = CountPEIns.pe_counts,
+        PE_metrics = PE_metrics,
+        sv_pipeline_rdtest_docker = sv_pipeline_rdtest_docker,
+        runtime_attr_override = runtime_attr_genotype_pe
+    }
+
+    call tasksgenotypebatch.CountSR as CountSRIns {
+      input:
+        vcf = MakeSubsetVcfIns.subset_vcf,
+        splitfile = splitfile,
+        splitfile_index = splitfile_index,
+        medianfile = medianfile,
+        samples = samples,
+        ref_dict = ref_dict,
+        sv_pipeline_docker = sv_pipeline_docker,
+        runtime_attr_override = runtime_attr_count_sr
+    }
+
+    call GenotypeSRPart2 as GenotypeSRPart2Ins {
+      input:
+        vcf = MakeSubsetVcfIns.subset_vcf,
+        SR_counts = CountSRIns.sr_counts,
+        SR_sum = CountSRIns.sr_sum,
+        SR_metrics = SR_metrics,
+        svtype = "INS",
+        hom_cutoff_multiplier = sr_hom_cutoff_multiplier,
+        median_hom_ins = sr_median_hom_ins,
+        sv_pipeline_rdtest_docker = sv_pipeline_docker,
+        runtime_attr_override = runtime_attr_genotype_sr
+    }
+
+    call IntegratePesrGQ as IntegratePesrGQIns {
+      input:
+        vcf = MakeSubsetVcfIns.subset_vcf,
+        PE_genotypes = GenotypePEPart2Ins.genotypes,
+        PE_vargq = GenotypePEPart2Ins.varGQ,
+        SR_genotypes = GenotypeSRPart2Ins.genotypes,
+        SR_vargq = GenotypeSRPart2Ins.varGQ,
+        sv_pipeline_docker = sv_pipeline_docker,
+        runtime_attr_override = runtime_attr_integrate_pesr_gq
+    }
+
+    call tasksgenotypebatch.AddGenotypes as AddGenotypesIns {
+      input:
+        vcf = MakeSubsetVcfIns.subset_vcf,
+        genotypes = IntegratePesrGQIns.genotypes,
+        varGQ = IntegratePesrGQIns.varGQ,
+        prefix = basename(ins_bed, ".bed"),
+        sv_pipeline_docker = sv_pipeline_docker,
+        runtime_attr_override = runtime_attr_add_genotypes
+    }
+  }
+
+  call CatFiles as CatFilesFail {
     input:
-      files_a = GenotypeSRPart2Under5kb.background_fail,
-      files_b = GenotypeSRPart2Over5kb.background_fail,
-      files_c = GenotypeSRPart2Bca.background_fail,
-      outfile = "${batch}.genotype_SR_part2_background_fail.txt",
+      files = flatten([GenotypeSRPart2Under5kb.background_fail, GenotypeSRPart2Over5kb.background_fail, GenotypeSRPart2Bca.background_fail, GenotypeSRPart2Ins.background_fail]),
+      outfile = "~{batch}.genotype_SR_part2_background_fail.txt",
       linux_docker = linux_docker,
       runtime_attr_override = runtime_attr_triple_stream_cat
   }
 
-  call TripleStreamCat as TripleStreamCatPass {
+  call CatFiles as CatFilesPass {
     input:
-      files_a = GenotypeSRPart2Under5kb.bothside_pass,
-      files_b = GenotypeSRPart2Over5kb.bothside_pass,
-      files_c = GenotypeSRPart2Bca.bothside_pass,
-      outfile = "${batch}.genotype_SR_part2_bothside_pass.txt",
+      files = flatten([GenotypeSRPart2Under5kb.bothside_pass, GenotypeSRPart2Over5kb.bothside_pass, GenotypeSRPart2Bca.bothside_pass, GenotypeSRPart2Ins.bothside_pass]),
+      outfile = "~{batch}.genotype_SR_part2_bothside_pass.txt",
       linux_docker = linux_docker,
       runtime_attr_override = runtime_attr_triple_stream_cat
   }
 
-  call tasksgenotypebatch.ConcatGenotypedVcfs as ConcatGenotypedVcfs {
+  call tasksmakecohortvcf.ConcatVcfs {
     input:
-      lt5kb_vcfs = AddGenotypesUnder5kb.genotyped_vcf,
-      gt5kb_vcfs = AddGenotypesOver5kb.genotyped_vcf,
-      bca_vcfs = AddGenotypesBca.genotyped_vcf,
-      batch = batch,
-      evidence_type = "pesr",
-      sv_base_mini_docker = sv_base_mini_docker,
-      runtime_attr_override = runtime_attr_concat_vcfs
+      vcfs=flatten([AddGenotypesUnder5kb.genotyped_vcf, AddGenotypesOver5kb.genotyped_vcf, AddGenotypesBca.genotyped_vcf, AddGenotypesIns.genotyped_vcf]),
+      vcfs_idx=flatten([AddGenotypesUnder5kb.genotyped_vcf_index, AddGenotypesOver5kb.genotyped_vcf_index, AddGenotypesBca.genotyped_vcf_index, AddGenotypesIns.genotyped_vcf_index]),
+      allow_overlaps=true,
+      outfile_prefix="~{batch}.genotyped_pesr",
+      sv_base_mini_docker=sv_base_mini_docker,
+      runtime_attr_override=runtime_attr_concat_vcfs
   }
 
   output {
-    File bothside_pass = TripleStreamCatPass.merged_file
-    File background_fail = TripleStreamCatFail.merged_file
-    File genotyped_vcf = ConcatGenotypedVcfs.genotyped_vcf
-    File genotyped_vcf_index = ConcatGenotypedVcfs.genotyped_vcf_index
+    File bothside_pass = CatFilesPass.merged_file
+    File background_fail = CatFilesFail.merged_file
+    File genotyped_vcf = ConcatVcfs.concat_vcf
+    File genotyped_vcf_index = ConcatVcfs.concat_vcf_idx
   }
 }
 
@@ -449,11 +531,9 @@ task IntegratePesrGQ {
   }
 }
 
-task TripleStreamCat {
+task CatFiles {
   input {
-    Array[File] files_a
-    Array[File] files_b
-    Array[File] files_c
+    Array[File] files
     String outfile
     String linux_docker
     RuntimeAttr? runtime_attr_override
@@ -475,7 +555,7 @@ task TripleStreamCat {
   command <<<
 
     set -euo pipefail
-    cat ~{sep=" " files_a} ~{sep=" " files_b} ~{sep=" " files_c} \
+    cat ~{sep=" " files} \
       | sort -Vk1,1 \
       | uniq > ~{outfile}
   
@@ -537,6 +617,10 @@ task GenotypeSRPart2 {
     File SR_counts
     File SR_sum
     File SR_metrics
+    File? script
+    Float hom_cutoff_multiplier = 1.6
+    Int median_hom_ins = 105
+    String svtype
     String sv_pipeline_rdtest_docker
     RuntimeAttr? runtime_attr_override
   }
@@ -559,11 +643,14 @@ task GenotypeSRPart2 {
   }
   command <<<
 
-    /opt/sv-pipeline/04_variant_resolution/scripts/SR_genotype.opt_part2.sh \
+    bash ~{default="/opt/sv-pipeline/04_variant_resolution/scripts/SR_genotype.opt_part2.sh" script} \
       ~{vcf} \
       ~{SR_counts} \
       ~{SR_sum} \
-      ~{SR_metrics}
+      ~{SR_metrics} \
+      ~{svtype} \
+      ~{hom_cutoff_multiplier} \
+      ~{median_hom_ins}
   
   >>>
   runtime {

--- a/wdl/TasksGenotypeBatch.wdl
+++ b/wdl/TasksGenotypeBatch.wdl
@@ -25,6 +25,7 @@ task SplitVariants {
     Array[File] lt5kb_beds = glob("lt5kb.*")
     Array[File] gt5kb_beds = glob("gt5kb.*")
     Array[File] bca_beds = glob("bca.*")
+    Array[File] ins_beds = glob("ins.*")
   }
   command <<<
 
@@ -37,8 +38,11 @@ task SplitVariants {
       | split --additional-suffix ".bed" -l ~{n_per_split} -a 6 - lt5kb.
     if [ ~{generate_bca} == "true" ]; then
       svtk vcf2bed ~{vcf} stdout \
-        | awk -v OFS="\t" '($5!="DEL" && $5!="DUP") {print $1, $2, $3, $4, $6, $5}' \
+        | awk -v OFS="\t" '($5!="DEL" && $5!="DUP" && $5!="INS") {print $1, $2, $3, $4, $6, $5}' \
         | split --additional-suffix ".bed" -l ~{n_per_split} -a 6 - bca.
+      svtk vcf2bed ~{vcf} stdout \
+        | awk -v OFS="\t" '($5=="INS") {print $1, $2, $3, $4, $6, $5}' \
+        | split --additional-suffix ".bed" -l ~{n_per_split} -a 6 - ins.
     fi
 
   >>>
@@ -123,7 +127,8 @@ task AddGenotypes {
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 
   output {
-    File genotyped_vcf = "${prefix}.genotyped.vcf.gz"
+    File genotyped_vcf = "~{prefix}.genotyped.vcf.gz"
+    File genotyped_vcf_index = "~{prefix}.genotyped.vcf.gz.tbi"
   }
   command <<<
 
@@ -139,8 +144,11 @@ task AddGenotypes {
       clean.vcf.gz \
       clean.genotypes.txt.gz \
       clean.vargq.txt.gz \
-      ~{prefix}.genotyped.vcf;
-    vcf-sort -c ~{prefix}.genotyped.vcf | bgzip > ~{prefix}.genotyped.vcf.gz
+      ~{prefix}.genotyped.vcf
+
+    mkdir tmp
+    bcftools sort -T tmp/ ~{prefix}.genotyped.vcf -Oz -o ~{prefix}.genotyped.vcf.gz
+    tabix ~{prefix}.genotyped.vcf.gz
 
   >>>
   runtime {
@@ -201,6 +209,7 @@ task ConcatGenotypedVcfs {
     Array[File] lt5kb_vcfs
     Array[File] gt5kb_vcfs
     Array[File] bca_vcfs
+    Array[File] ins_vcfs
     String batch
     String evidence_type    # depth or pesr
     String sv_base_mini_docker


### PR DESCRIPTION
- Fixes svtk sr-test and count-sr code to allow for `-+` in addition to `+-` strandedness on INS variants. The sr-test strategy also was updated so that it is more likely to find a significant SR signature on each side, and now defaults to the nearest significant position rather than one 50bp away. These changes result in substantially more two-sided support for INS variants, as well as more accurate breakpoint refinement for small variants, particularly insertions.
- Updates SR genotyping model. First, INS are now genotyped separately from other balanced variants, as they exhibit a distinctive SR count distribution. Second, separate model parameters are now used for one-sided and two-sided variants. The two models are also applied based on whether the particular sample exhibits one- or two-sided support, rather than the variant as a whole. Third, the SR GQ model has been simplified to compute a p-value of the left-hand tail based on the count z-score. It therefore scores the confidence that the genotype is not over-called rather than that the genotype is correct (i.e. using a two-sided test).

The combination of these updates substantially improves INS genotyping and alleviates some of the het bias of the previous model in all SR-supported variants.

This branch has been tested on the 1kgp reference panel as well as batch_23 from AoU-PhaseI.