### PR TITLE
Fix CTX END2 error in GATK formatting script

### DIFF
--- a/src/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py
+++ b/src/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py
@@ -33,7 +33,7 @@ def _parse_bnd_ends(vcf_path: Text) -> Dict[Text, int]:
             columns = line.split('\t', 8)
             vid = columns[2]
             info = columns[7]
-            if 'SVTYPE=BND' not in info:
+            if 'SVTYPE=BND' not in info and 'SVTYPE=CTX' not in info:
                 continue
             info_tokens = info.split(';')
             end_field_list = [x for x in info_tokens if x.startswith("END=")]


### PR DESCRIPTION
Addresses a bug introduced in #540 that causes the following kind of error in the GATK formatting script:

```
Traceback (most recent call last):
  File "/opt/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py", line 239, in <module>
    main()
  File "/opt/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py", line 235, in main
    _process(vcf_in, vcf_out, arguments)
  File "/opt/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py", line 193, in _process
    out = convert(record=record, bnd_end_dict=bnd_end_dict,
  File "/opt/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py", line 131, in convert
    record.info['END2'] = bnd_end_dict[record.id] if bnd_end_dict is not None \
KeyError: 'ref_panel_1kg.chr2.final_cleanup_CTX_chr2_1'
```

This occurred specifically for CTX records when attempting to update the `END2` field. This update has been tested on an offending VCF.