### PR TITLE
reheader each cram with the standard hg38 sequences

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GatherSampleEvidence.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GatherSampleEvidence.json.tmpl
@@ -2,6 +2,7 @@
   "GatherSampleEvidence.primary_contigs_list": "${workspace.primary_contigs_list}",
   "GatherSampleEvidence.reference_fasta": "${workspace.reference_fasta}",
   "GatherSampleEvidence.reference_index": "${workspace.reference_index}",
+  "GatherSampleEvidence.hg38_header_sq": "${workspace.hg38_header_sq}",
   "GatherSampleEvidence.reference_dict": "${workspace.reference_dict}",
   "GatherSampleEvidence.reference_version": "${workspace.reference_version}",
 

--- a/inputs/templates/terra_workspaces/cohort_mode/workspace.tsv.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workspace.tsv.tmpl
@@ -45,6 +45,7 @@ reference_build	{{ reference_resources.reference_build }}
 reference_dict	{{ reference_resources.reference_dict }}
 reference_fasta	{{ reference_resources.reference_fasta }}
 reference_index	{{ reference_resources.reference_index }}
+hg38_header_sq	{{ reference_resources.hg38_header_sq }}
 reference_version	{{ reference_resources.reference_version }}
 rmsk	{{ reference_resources.rmsk }}
 segdups	{{ reference_resources.segdups }}

--- a/inputs/values/resources_hg38.json
+++ b/inputs/values/resources_hg38.json
@@ -33,6 +33,7 @@
   "reference_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
   "reference_index" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
   "reference_version" : "38",
+  "hg38_header_sq" : "gs://fc-secure-7b4e631c-ed86-4a0d-8023-5123cdac0556/hg38_SQ_header/hg38_header_sq.sam",
   "rmsk" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.randomForest_blacklist.withRepMask.bed.gz",
   "segdups" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/hg38.SD_gaps_Cen_Tel_Heter_Satellite_lumpy.blacklist.sorted.merged.bed.gz",
   "seed_cutoffs" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/seed_cutoff.txt",

--- a/wdl/GatherSampleEvidenceBatch.wdl
+++ b/wdl/GatherSampleEvidenceBatch.wdl
@@ -20,6 +20,7 @@ workflow GatherSampleEvidenceBatch {
     File reference_fasta
     File reference_index    # Index (.fai), must be in same dir as fasta
     File reference_dict     # Dictionary (.dict), must be in same dir as fasta
+    File? hg38_header_sq  # required if the crams for samples are custom reference subset of hg38
     String? reference_version   # Either "38" or "19"
 
     # Coverage collection inputs


### PR DESCRIPTION
**DO NOT MERGE** 

There is a problem with the DRAGEN samples being processed by @kirtanav98. The issue arises from using a customized reference, which only includes a subset of the standard hg38 contigs. This leads to an error when using Manta. As a solution, @kirtanav98 and I are working on a temporary fix within the LocalizeReads task. This fix involves reheadering each cram with the standard hg38 sequences.

**DO NOT MERGE**
