### PR TITLE
Fix a bug committing changes to dockers_*.json after an image is updated

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -209,14 +209,14 @@ jobs:
           python ./scripts/docker/build_docker.py \
             --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \
             --current-git-commit ${{ needs.build_args_job.outputs.head_sha }} \
-            --docker-repo us.gcr.io/${{ secrets.GCP_PROJECT_ID }}/gatk-sv \
+            --docker-repo ${{ secrets.AZ_CR }} us.gcr.io/${{ secrets.GCP_PROJECT_ID }}/gatk-sv \
             --image-tag ${{ needs.build_args_job.outputs.image_tag }} \
             --input-json $DOCKERS_AZURE $DOCKERS_GCP \
             --output-json $DOCKERS_AZURE $DOCKERS_GCP \
             --disable-git-protect
           
           CHANGED=$(git diff --quiet $DOCKERS_GCP || echo True)
-          echo "::set-output name=CHANGED::$CHANGED"
+          echo "CHANGED=$CHANGED" >> $GITHUB_OUTPUT
 
       - name: Commit Changes to dockers_*.json
         if: steps.build_and_publish.outputs.CHANGED

--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -14,7 +14,7 @@
   "sv_base_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:2023-02-01-v0.26.8-beta-9b25c72d",
   "sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/vjalili/sv-base-mini:5994670",
   "sv_pipeline_base_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2023-05-24-v0.27.3-beta-1796b665",
-  "sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2023-05-24-v0.27.3-beta-1796b665",
+  "sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2023-06-27-v0.27.3-beta-0be9cf8a",
   "sv_pipeline_hail_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2023-05-24-v0.27.3-beta-1796b665",
   "sv_pipeline_updates_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2023-05-24-v0.27.3-beta-1796b665",
   "sv_pipeline_qc_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2023-05-24-v0.27.3-beta-1796b665",

--- a/inputs/values/dockers_azure.json
+++ b/inputs/values/dockers_azure.json
@@ -14,7 +14,7 @@
   "sv_base_docker": "vahid.azurecr.io/gatk-sv/sv-base:2023-02-01-v0.26.8-beta-9b25c72d",
   "sv_base_mini_docker": "vahid.azurecr.io/vjalili/sv-base-mini:5994670",
   "sv_pipeline_base_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2023-05-24-v0.27.3-beta-1796b665",
-  "sv_pipeline_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2023-05-24-v0.27.3-beta-1796b665",
+  "sv_pipeline_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2023-06-27-v0.27.3-beta-0be9cf8a",
   "sv_pipeline_hail_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2023-05-24-v0.27.3-beta-1796b665",
   "sv_pipeline_updates_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2023-05-24-v0.27.3-beta-1796b665",
   "sv_pipeline_qc_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2023-05-24-v0.27.3-beta-1796b665",


### PR DESCRIPTION
This PR fixes two bugs: 
- [x] The `Publish` action in the GitHub workflow commits changes to `dockers_*.json` and pushes them to the `main` if a variable that determines whether the file is updated or not is set to `True`. With recent changes to Github actions, the method we previously used to set this variable is deprecated; hence the variable is not correctly set, resulting in not committing the changed `dockers_*.json` files to `main`. This issue is fixed in this PR.
- [x] Azure container registry was not passed as a target repo; this bug is fixed in this PR.
- [x] Due to the above bugs, the `dockers_*.json` was not updated with the latest image builds. The only impact image in the recently merged PRs is `sv-pipeline`; hence this PR adds the build and pushed the image to the `dockers_*.json`. 