### PR TITLE
Delete some commented lines in drop_empty_records.py

### DIFF
--- a/src/sv-pipeline/scripts/drop_empty_records.py
+++ b/src/sv-pipeline/scripts/drop_empty_records.py
@@ -17,11 +17,6 @@ def drop_nonref_gts(vcf, fout):
     NULL_GT = [(0, 0), (None, None), (0, ), (None, ), (None, 2)]
     samples = [s for s in vcf.header.samples]
 
-    # for record in vcf.fetch():
-    #     nonref = svu.get_called_samples(record)
-    #     if len(nonref) > 0:
-    #         fout.write(record)
-
     for record in vcf.fetch():
         for s in samples:
             if is_biallelic(record):


### PR DESCRIPTION
Small bit of cleanup, with the ulterior motive to force a rebuild of the sv-pipeline docker.