### PR TITLE
Update protein-coding GTF to MANE v1.2

### DIFF
--- a/inputs/values/resources_hg38.json
+++ b/inputs/values/resources_hg38.json
@@ -27,7 +27,7 @@
   "primary_contigs_fai" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "primary_contigs_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list",
   "contigs_header": "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/hg38_contigs_header.vcf",
-  "protein_coding_gtf" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/MANE.GRCh38.v0.95.select_ensembl_genomic.gtf",
+  "protein_coding_gtf" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/MANE.GRCh38.v1.1.ensembl_genomic.gtf",
   "reference_build" : "hg38",
   "reference_dict" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
   "reference_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",

--- a/inputs/values/resources_hg38.json
+++ b/inputs/values/resources_hg38.json
@@ -27,7 +27,7 @@
   "primary_contigs_fai" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/contig.fai",
   "primary_contigs_list" : "gs://gcp-public-data--broad-references/hg38/v0/sv-resources/resources/v1/primary_contigs.list",
   "contigs_header": "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/hg38_contigs_header.vcf",
-  "protein_coding_gtf" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/MANE.GRCh38.v1.1.ensembl_genomic.gtf",
+  "protein_coding_gtf" : "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/MANE.GRCh38.v1.2.ensembl_genomic.gtf",
   "reference_build" : "hg38",
   "reference_dict" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
   "reference_fasta" : "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",


### PR DESCRIPTION
### Updates
Update default protein-coding GTF for functional annotation to MANE v1.2 from v0.95. v1.2 is the latest version (from June 21, 2023) and contains more genes than the previous version. The new MANE GTF was retrieved from the [MANE FTP server](https://ftp.ncbi.nlm.nih.gov/refseq/MANE/MANE_human/release_1.2/) and unzipped (to comply with GATK GTF codec) and uploaded to the gatk-sv-resources-public bucket.

### Testing
* Validated all WDLs and JSONs with womtool and Terra validation script
* Successfully ran AnnotateVcf on ref panel with new GTF and checked for presence of ROBO2 annotations, one of the genes added between v0.95 and v1.2