### PR TITLE
Add PlotSVCountsPerSample subworkflow to the end of ClusterBatch and FilterBatchSites

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ A structural variation discovery pipeline for Illumina short-read whole-genome s
   * [Cromwell](https://github.com/broadinstitute/cromwell) (v36 or higher). A dedicated server is highly recommended.
   * or [Terra](https://terra.bio/) (note preconfigured GATK-SV workflows are not yet available for this platform)
 * Recommended: [MELT](https://melt.igs.umaryland.edu/). Due to licensing restrictions, we cannot provide a public docker image or reference panel VCFs for this algorithm.
+* Recommended: [Manta](https://github.com/Illumina/manta). Calls SVs and indels from mapped PE reads based on split read and discordant read pair evidence.
+* Recommended: [Wham](https://github.com/zeeev/wham). Used to predict SV breakpoints after integrating all evidence.
+* Recommended: [cn.MOPS](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3351174/). Used to detect CNVs from variations in read depth using a mixture of Poisson models.
+* Recommended: [gatk-gCNV](https://gatk.broadinstitute.org/hc/en-us/articles/360035531152). Detects germline CNVs from variations in read depth.
 * Recommended: [cromshell](https://github.com/broadinstitute/cromshell) for interacting with a dedicated Cromwell server.
 * Recommended: [WOMtool](https://cromwell.readthedocs.io/en/stable/WOMtool/) for validating WDL/json files.
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ A structural variation discovery pipeline for Illumina short-read whole-genome s
   * [Cromwell](https://github.com/broadinstitute/cromwell) (v36 or higher). A dedicated server is highly recommended.
   * or [Terra](https://terra.bio/) (note preconfigured GATK-SV workflows are not yet available for this platform)
 * Recommended: [MELT](https://melt.igs.umaryland.edu/). Due to licensing restrictions, we cannot provide a public docker image or reference panel VCFs for this algorithm.
-* Recommended: [Manta](https://github.com/Illumina/manta). Calls SVs and indels from mapped PE reads based on split read and discordant read pair evidence.
-* Recommended: [Wham](https://github.com/zeeev/wham). Used to predict SV breakpoints after integrating all evidence.
-* Recommended: [cn.MOPS](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3351174/). Used to detect CNVs from variations in read depth using a mixture of Poisson models.
-* Recommended: [gatk-gCNV](https://gatk.broadinstitute.org/hc/en-us/articles/360035531152). Detects germline CNVs from variations in read depth.
 * Recommended: [cromshell](https://github.com/broadinstitute/cromshell) for interacting with a dedicated Cromwell server.
 * Recommended: [WOMtool](https://cromwell.readthedocs.io/en/stable/WOMtool/) for validating WDL/json files.
 

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ClusterBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ClusterBatch.json.tmpl
@@ -28,5 +28,6 @@
   "ClusterBatch.manta_vcf_tar": "${this.std_manta_vcf_tar}",
   "ClusterBatch.melt_vcf_tar": "${this.std_melt_vcf_tar}",
   "ClusterBatch.scramble_vcf_tar": "${this.std_scramble_vcf_tar}",
-  "ClusterBatch.ped_file": "${workspace.cohort_ped_file}"
+  "ClusterBatch.ped_file": "${workspace.cohort_ped_file}",
+  "ClusterBatch.N_IQR_cutoff_plotting": "6"
 }

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/FilterBatchSites.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/FilterBatchSites.json.tmpl
@@ -8,5 +8,6 @@
   "FilterBatchSites.melt_vcf" : "${this.clustered_melt_vcf}",
   "FilterBatchSites.scramble_vcf" : "${this.clustered_scramble_vcf}",
   "FilterBatchSites.evidence_metrics": "${this.metrics}",
-  "FilterBatchSites.evidence_metrics_common": "${this.metrics_common}"
+  "FilterBatchSites.evidence_metrics_common": "${this.metrics_common}",
+  "FilterBatchSites.N_IQR_cutoff_plotting": "6"
 }

--- a/inputs/templates/test/ClusterBatch/ClusterBatch.json.tmpl
+++ b/inputs/templates/test/ClusterBatch/ClusterBatch.json.tmpl
@@ -29,5 +29,6 @@
   "ClusterBatch.wham_vcf_tar": {{ test_batch.std_wham_vcf_tar | tojson }},
   "ClusterBatch.manta_vcf_tar": {{ test_batch.std_manta_vcf_tar | tojson }},
   "ClusterBatch.melt_vcf_tar": {{ test_batch.std_melt_vcf_tar | tojson }},
-  "ClusterBatch.ped_file": {{ test_batch.ped_file | tojson }}
+  "ClusterBatch.ped_file": {{ test_batch.ped_file | tojson }},
+  "ClusterBatch.N_IQR_cutoff_plotting": "6"
 }

--- a/inputs/templates/test/FilterBatch/FilterBatchSites.json.tmpl
+++ b/inputs/templates/test/FilterBatch/FilterBatchSites.json.tmpl
@@ -7,5 +7,6 @@
   "FilterBatchSites.wham_vcf" : {{ test_batch.merged_wham_vcf | tojson }},
   "FilterBatchSites.melt_vcf" : {{ test_batch.merged_melt_vcf | tojson }},
   "FilterBatchSites.evidence_metrics": {{ test_batch.evidence_metrics | tojson }},
-  "FilterBatchSites.evidence_metrics_common": {{ test_batch.evidence_metrics_common | tojson }}
+  "FilterBatchSites.evidence_metrics_common": {{ test_batch.evidence_metrics_common | tojson }},
+  "FilterBatchSites.N_IQR_cutoff_plotting": "6"
 }

--- a/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
@@ -104,7 +104,7 @@
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.segdups": {{ reference_resources.segdups | tojson }},
 
   "GATKSVPipelineBatch.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
-  "GATKSVPipelineBatch.outlier_cutoff_nIQR": "999999",
+  "GATKSVPipelineBatch.GATKSVPipelinePhase1.outlier_cutoff_nIQR": "999999",
   "GATKSVPipelineBatch.GenotypeBatch.n_RD_genotype_bins": "100000",
   "GATKSVPipelineBatch.GenotypeBatch.n_per_split": "5000",
   "GATKSVPipelineBatch.GenotypeBatch.pesr_exclude_list": {{ reference_resources.pesr_exclude_list | tojson }},

--- a/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
@@ -94,7 +94,7 @@
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.depth_exclude_overlap_fraction": "0.5",
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.depth_interval_overlap": "0.8",
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.depth_clustering_algorithm": "SINGLE_LINKAGE",
-  "GATKSVPipelineBatch.GATKSVPipelinePhase1.N_IQR_cutoff_plotting": "6",
+  "GATKSVPipelineBatch.N_IQR_cutoff_plotting": "6",
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.BAF_split_size": "10000",
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.RD_split_size": "10000",
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.PE_split_size": "10000",
@@ -104,7 +104,7 @@
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.segdups": {{ reference_resources.segdups | tojson }},
 
   "GATKSVPipelineBatch.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
-  "GATKSVPipelineBatch.outlier_cutoff_nIQR": "999999",
+  "GATKSVPipelineBatch.GATKSVPipelinePhase1.outlier_cutoff_nIQR": "999999",
   "GATKSVPipelineBatch.GenotypeBatch.n_RD_genotype_bins": "100000",
   "GATKSVPipelineBatch.GenotypeBatch.n_per_split": "5000",
   "GATKSVPipelineBatch.GenotypeBatch.pesr_exclude_list": {{ reference_resources.pesr_exclude_list | tojson }},

--- a/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
@@ -104,7 +104,7 @@
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.segdups": {{ reference_resources.segdups | tojson }},
 
   "GATKSVPipelineBatch.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
-  "GATKSVPipelineBatch.GATKSVPipelinePhase1.outlier_cutoff_nIQR": "999999",
+  "GATKSVPipelineBatch.outlier_cutoff_nIQR": "999999",
   "GATKSVPipelineBatch.GenotypeBatch.n_RD_genotype_bins": "100000",
   "GATKSVPipelineBatch.GenotypeBatch.n_per_split": "5000",
   "GATKSVPipelineBatch.GenotypeBatch.pesr_exclude_list": {{ reference_resources.pesr_exclude_list | tojson }},

--- a/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
@@ -94,7 +94,7 @@
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.depth_exclude_overlap_fraction": "0.5",
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.depth_interval_overlap": "0.8",
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.depth_clustering_algorithm": "SINGLE_LINKAGE",
-
+  "GATKSVPipelineBatch.GATKSVPipelinePhase1.N_IQR_cutoff_plotting": "6",
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.BAF_split_size": "10000",
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.RD_split_size": "10000",
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.PE_split_size": "10000",
@@ -105,7 +105,7 @@
 
   "GATKSVPipelineBatch.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.outlier_cutoff_nIQR": "999999",
-
+  "GATKSVPipelineBatch.GATKSVPipelinePhase1.N_IQR_cutoff_plotting": "6",
   "GATKSVPipelineBatch.GenotypeBatch.n_RD_genotype_bins": "100000",
   "GATKSVPipelineBatch.GenotypeBatch.n_per_split": "5000",
   "GATKSVPipelineBatch.GenotypeBatch.pesr_exclude_list": {{ reference_resources.pesr_exclude_list | tojson }},

--- a/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
@@ -105,7 +105,6 @@
 
   "GATKSVPipelineBatch.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
   "GATKSVPipelineBatch.GATKSVPipelinePhase1.outlier_cutoff_nIQR": "999999",
-  "GATKSVPipelineBatch.GATKSVPipelinePhase1.N_IQR_cutoff_plotting": "6",
   "GATKSVPipelineBatch.GenotypeBatch.n_RD_genotype_bins": "100000",
   "GATKSVPipelineBatch.GenotypeBatch.n_per_split": "5000",
   "GATKSVPipelineBatch.GenotypeBatch.pesr_exclude_list": {{ reference_resources.pesr_exclude_list | tojson }},

--- a/inputs/templates/test/GATKSVPipelinePhase1/GATKSVPipelinePhase1.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelinePhase1/GATKSVPipelinePhase1.json.tmpl
@@ -45,6 +45,7 @@
 
   "GATKSVPipelinePhase1.outlier_cutoff_table" : {{ test_batch.outlier_cutoff_table | tojson }},
   "GATKSVPipelinePhase1.outlier_cutoff_nIQR": "6",
+  "GATKSVPipelinePhase1.N_IQR_cutoff_plotting": "6",
 
   "GATKSVPipelinePhase1.ploidy_sample_psi_scale": "0.001",
   "GATKSVPipelinePhase1.contig_ploidy_model_tar" : {{ test_batch.contig_ploidy_model_tar | tojson }},

--- a/wdl/ClusterBatch.wdl
+++ b/wdl/ClusterBatch.wdl
@@ -294,7 +294,7 @@ workflow ClusterBatch {
     input:
       prefix = batch,
       vcfs = [ClusterDepth.clustered_vcf, ClusterPESR_manta.clustered_vcf, ClusterPESR_wham.clustered_vcf, ClusterPESR_melt.clustered_vcf, ClusterPESR_scramble.clustered_vcf],
-      N_IQR_cutoff = N_IQR_cutoff_plotting,
+      N_IQR_cutoff = select_first([N_IQR_cutoff_plotting]),
       sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_count_svs = runtime_attr_count_svs,
       runtime_attr_plot_svcounts = runtime_attr_plot_svcounts,
@@ -313,8 +313,8 @@ workflow ClusterBatch {
     File? clustered_melt_vcf_index = ClusterPESR_melt.clustered_vcf_index
     File? clustered_scramble_vcf = ClusterPESR_scramble.clustered_vcf
     File? clustered_scramble_vcf_index = ClusterPESR_scramble.clustered_vcf_index
-    Array[File?] clustered_sv_counts = PlotSVCountsPerSample.sv_counts
-    Array[File?] clustered_sv_count_plots = PlotSVCountsPerSample.sv_count_plots
+    Array[File]? clustered_sv_counts = PlotSVCountsPerSample.sv_counts
+    Array[File]? clustered_sv_count_plots = PlotSVCountsPerSample.sv_count_plots
     File? clustered_outlier_samples_preview = PlotSVCountsPerSample.outlier_samples_preview
     File? clustered_outlier_samples_with_reason = PlotSVCountsPerSample.outlier_samples_with_reason
     Int? clustered_num_outlier_samples = PlotSVCountsPerSample.num_outlier_samples

--- a/wdl/FilterBatchSites.wdl
+++ b/wdl/FilterBatchSites.wdl
@@ -90,9 +90,6 @@ workflow FilterBatchSites {
     File sites_filtered_outlier_samples_preview = PlotSVCountsPerSample.outlier_samples_preview
     File sites_filtered_outlier_samples_with_reason = PlotSVCountsPerSample.outlier_samples_with_reason
     Int sites_filtered_num_outlier_samples = PlotSVCountsPerSample.num_outlier_samples
-    RuntimeAttr? runtime_attr_count_svs = PlotSVCountsPerSample.runtime_attr_count_svs
-    RuntimeAttr? runtime_attr_plot_svcounts = PlotSVCountsPerSample.runtime_attr_plot_svcounts
-    RuntimeAttr? runtime_attr_cat_outliers_preview = PlotSVCountsPerSample.runtime_attr_cat_outliers_preview
   }
 
 }

--- a/wdl/FilterBatchSites.wdl
+++ b/wdl/FilterBatchSites.wdl
@@ -207,7 +207,7 @@ task FilterAnnotateVcf {
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 
   output {
-    File annotated_vcf = "${prefix}.with_evidence.vcf.gz",
+    File annotated_vcf = "${prefix}.with_evidence.vcf.gz"
   }
   command <<<
 

--- a/wdl/GATKSVPipelineBatch.wdl
+++ b/wdl/GATKSVPipelineBatch.wdl
@@ -109,6 +109,9 @@ workflow GATKSVPipelineBatch {
     RuntimeAttr? runtime_attr_cat_metrics
     RuntimeAttr? runtime_attr_plot_metrics
 
+    # PlotSVCountsPerSample metrics from ClusterBatch in GATKSVPipelinePhase1
+    Int? N_IQR_cutoff_plotting
+
     # Do not use
     Array[File]? NONE_ARRAY_
     String? NONE_STRING_
@@ -204,6 +207,7 @@ workflow GATKSVPipelineBatch {
       counts=counts_files_,
       bincov_matrix=EvidenceQC.bincov_matrix,
       bincov_matrix_index=EvidenceQC.bincov_matrix_index,
+      N_IQR_cutoff_plotting = N_IQR_cutoff_plotting,
       PE_files=pe_files_,
       SR_files=sr_files_,
       SD_files=sd_files_,
@@ -211,6 +215,7 @@ workflow GATKSVPipelineBatch {
       melt_vcfs=melt_vcfs_,
       scramble_vcfs=scramble_vcfs_,
       wham_vcfs=wham_vcfs_,
+
       cnmops_chrom_file=autosome_file,
       cnmops_allo_file=allosome_file,
       allosome_contigs=allosome_file,
@@ -420,6 +425,11 @@ workflow GATKSVPipelineBatch {
     File? merged_melt_vcf_index = GATKSVPipelinePhase1.melt_vcf_index
     File? merged_wham_vcf = GATKSVPipelinePhase1.wham_vcf
     File? merged_wham_vcf_index = GATKSVPipelinePhase1.wham_vcf_index
+    Array[File?] clustered_sv_counts = GATKSVPipelinePhase1.clustered_sv_counts
+    Array[File?] clustered_sv_count_plots = GATKSVPipelinePhase1.clustered_sv_count_plots
+    File? clustered_outlier_samples_preview = GATKSVPipelinePhase1.clustered_outlier_samples_preview
+    File? clustered_outlier_samples_with_reason = GATKSVPipelinePhase1.clustered_outlier_samples_with_reason
+    Int? clustered_num_outlier_samples = GATKSVPipelinePhase1.clustered_num_outlier_samples
 
     File evidence_metrics = GATKSVPipelinePhase1.evidence_metrics
     File evidence_metrics_common = GATKSVPipelinePhase1.evidence_metrics_common
@@ -432,7 +442,11 @@ workflow GATKSVPipelineBatch {
     File? sites_filtered_wham_vcf = GATKSVPipelinePhase1.sites_filtered_wham_vcf
     File? sites_filtered_melt_vcf = GATKSVPipelinePhase1.sites_filtered_melt_vcf
     File? sites_filtered_depth_vcf = GATKSVPipelinePhase1.sites_filtered_depth_vcf
-
+    Array[File?] clustered_sv_counts = GATKSVPipelinePhase1.clustered_sv_counts
+    Array[File?] clustered_sv_count_plots = GATKSVPipelinePhase1.clustered_sv_count_plots
+    File? clustered_outlier_samples_preview = GATKSVPipelinePhase1.clustered_outlier_samples_preview
+    File? clustered_outlier_samples_with_reason = GATKSVPipelinePhase1.clustered_outlier_samples_with_reason
+    Int? clustered_num_outlier_samples = GATKSVPipelinePhase1.clustered_num_outlier_samples
     File cutoffs = GATKSVPipelinePhase1.cutoffs
     File genotyped_pesr_vcf = GenotypeBatch.genotyped_pesr_vcf
     File genotyped_depth_vcf = GenotypeBatch.genotyped_depth_vcf

--- a/wdl/GATKSVPipelineBatch.wdl
+++ b/wdl/GATKSVPipelineBatch.wdl
@@ -442,11 +442,6 @@ workflow GATKSVPipelineBatch {
     File? sites_filtered_wham_vcf = GATKSVPipelinePhase1.sites_filtered_wham_vcf
     File? sites_filtered_melt_vcf = GATKSVPipelinePhase1.sites_filtered_melt_vcf
     File? sites_filtered_depth_vcf = GATKSVPipelinePhase1.sites_filtered_depth_vcf
-    Array[File?] clustered_sv_counts = GATKSVPipelinePhase1.clustered_sv_counts
-    Array[File?] clustered_sv_count_plots = GATKSVPipelinePhase1.clustered_sv_count_plots
-    File? clustered_outlier_samples_preview = GATKSVPipelinePhase1.clustered_outlier_samples_preview
-    File? clustered_outlier_samples_with_reason = GATKSVPipelinePhase1.clustered_outlier_samples_with_reason
-    Int? clustered_num_outlier_samples = GATKSVPipelinePhase1.clustered_num_outlier_samples
     File cutoffs = GATKSVPipelinePhase1.cutoffs
     File genotyped_pesr_vcf = GenotypeBatch.genotyped_pesr_vcf
     File genotyped_depth_vcf = GenotypeBatch.genotyped_depth_vcf

--- a/wdl/GATKSVPipelineBatch.wdl
+++ b/wdl/GATKSVPipelineBatch.wdl
@@ -425,8 +425,8 @@ workflow GATKSVPipelineBatch {
     File? merged_melt_vcf_index = GATKSVPipelinePhase1.melt_vcf_index
     File? merged_wham_vcf = GATKSVPipelinePhase1.wham_vcf
     File? merged_wham_vcf_index = GATKSVPipelinePhase1.wham_vcf_index
-    Array[File?] clustered_sv_counts = GATKSVPipelinePhase1.clustered_sv_counts
-    Array[File?] clustered_sv_count_plots = GATKSVPipelinePhase1.clustered_sv_count_plots
+    Array[File] ?clustered_sv_counts = GATKSVPipelinePhase1.clustered_sv_counts
+    Array[File]? clustered_sv_count_plots = GATKSVPipelinePhase1.clustered_sv_count_plots
     File? clustered_outlier_samples_preview = GATKSVPipelinePhase1.clustered_outlier_samples_preview
     File? clustered_outlier_samples_with_reason = GATKSVPipelinePhase1.clustered_outlier_samples_with_reason
     Int? clustered_num_outlier_samples = GATKSVPipelinePhase1.clustered_num_outlier_samples

--- a/wdl/GATKSVPipelineBatch.wdl
+++ b/wdl/GATKSVPipelineBatch.wdl
@@ -63,6 +63,9 @@ workflow GATKSVPipelineBatch {
     File contig_ploidy_model_tar
     Array[File] gcnv_model_tars
 
+    # PlotSVCountsPerSample metrics from ClusterBatch in GATKSVPipelinePhase1
+    Int? N_IQR_cutoff_plotting
+    
     File? outlier_cutoff_table
     File qc_definitions
 
@@ -108,9 +111,6 @@ workflow GATKSVPipelineBatch {
     # Batch metrics
     RuntimeAttr? runtime_attr_cat_metrics
     RuntimeAttr? runtime_attr_plot_metrics
-
-    # PlotSVCountsPerSample metrics from ClusterBatch in GATKSVPipelinePhase1
-    Int? N_IQR_cutoff_plotting
 
     # Do not use
     Array[File]? NONE_ARRAY_

--- a/wdl/GATKSVPipelinePhase1.wdl
+++ b/wdl/GATKSVPipelinePhase1.wdl
@@ -504,8 +504,8 @@ workflow GATKSVPipelinePhase1 {
     File? melt_vcf_index = ClusterBatch.clustered_melt_vcf_index
     File? scramble_vcf = ClusterBatch.clustered_scramble_vcf
     File? scramble_vcf_index = ClusterBatch.clustered_scramble_vcf_index
-    Array[File?] clustered_sv_counts = ClusterBatch.clustered_sv_counts
-    Array[File?] clustered_sv_count_plots = ClusterBatch.clustered_sv_count_plots
+    Array[File]? clustered_sv_counts = ClusterBatch.clustered_sv_counts
+    Array[File]? clustered_sv_count_plots = ClusterBatch.clustered_sv_count_plots
     File? clustered_outlier_samples_preview = ClusterBatch.clustered_outlier_samples_preview
     File? clustered_outlier_samples_with_reason = ClusterBatch.clustered_outlier_samples_with_reason
     Int? clustered_num_outlier_samples = ClusterBatch.clustered_num_outlier_samples

--- a/wdl/GATKSVPipelinePhase1.wdl
+++ b/wdl/GATKSVPipelinePhase1.wdl
@@ -101,9 +101,6 @@ workflow GATKSVPipelinePhase1 {
     Array[File]? wham_vcfs         # Wham VCF
     Int min_svsize                 # Minimum SV length to include
 
-    # PlotSVCountsPerSample metrics
-    Int? N_IQR_cutoff_plotting
-
     # QC options
     Boolean run_matrix_qc
 
@@ -163,6 +160,8 @@ workflow GATKSVPipelinePhase1 {
     Int pesr_breakend_window
     String? pesr_clustering_algorithm
 
+    Int? N_IQR_cutoff_plotting
+
     File? baseline_depth_vcf_cluster_batch
     File? baseline_manta_vcf_cluster_batch
     File? baseline_wham_vcf_cluster_batch
@@ -186,6 +185,9 @@ workflow GATKSVPipelinePhase1 {
     RuntimeAttr? runtime_attr_gatk_to_svtk_vcf_depth_cluster_batch
     RuntimeAttr? runtime_override_concat_vcfs_depth_cluster_batch
     RuntimeAttr? runtime_attr_exclude_intervals_pesr_cluster_batch
+    RuntimeAttr? runtime_attr_count_svs
+    RuntimeAttr? runtime_attr_plot_svcounts
+    RuntimeAttr? runtime_attr_cat_outliers_preview
 
     ############################################################
     ## GenerateBatchMetrics
@@ -388,7 +390,10 @@ workflow GATKSVPipelinePhase1 {
       runtime_attr_svcluster_depth=runtime_attr_svcluster_depth_cluster_batch,
       runtime_attr_gatk_to_svtk_vcf_depth=runtime_attr_gatk_to_svtk_vcf_depth_cluster_batch,
       runtime_override_concat_vcfs_depth=runtime_override_concat_vcfs_depth_cluster_batch,
-      runtime_attr_exclude_intervals_pesr=runtime_attr_exclude_intervals_pesr_cluster_batch
+      runtime_attr_exclude_intervals_pesr=runtime_attr_exclude_intervals_pesr_cluster_batch,
+      runtime_attr_count_svs = runtime_attr_count_svs,
+      runtime_attr_plot_svcounts = runtime_attr_plot_svcounts,
+      runtime_attr_cat_outliers_preview = runtime_attr_cat_outliers_preview
   }
 
   call batchmetrics.GenerateBatchMetrics as GenerateBatchMetrics {

--- a/wdl/GATKSVPipelinePhase1.wdl
+++ b/wdl/GATKSVPipelinePhase1.wdl
@@ -101,6 +101,9 @@ workflow GATKSVPipelinePhase1 {
     Array[File]? wham_vcfs         # Wham VCF
     Int min_svsize                 # Minimum SV length to include
 
+    # PlotSVCountsPerSample metrics
+    Int? N_IQR_cutoff_plotting
+
     # QC options
     Boolean run_matrix_qc
 
@@ -358,6 +361,7 @@ workflow GATKSVPipelinePhase1 {
       pesr_interval_overlap=pesr_interval_overlap,
       pesr_breakend_window=pesr_breakend_window,
       pesr_clustering_algorithm=pesr_clustering_algorithm,
+      N_IQR_cutoff_plotting = N_IQR_cutoff_plotting,
       run_module_metrics=run_clusterbatch_metrics,
       linux_docker=linux_docker,
       sv_pipeline_base_docker=sv_pipeline_base_docker,
@@ -500,6 +504,11 @@ workflow GATKSVPipelinePhase1 {
     File? melt_vcf_index = ClusterBatch.clustered_melt_vcf_index
     File? scramble_vcf = ClusterBatch.clustered_scramble_vcf
     File? scramble_vcf_index = ClusterBatch.clustered_scramble_vcf_index
+    Array[File?] clustered_sv_counts = ClusterBatch.clustered_sv_counts
+    Array[File?] clustered_sv_count_plots = ClusterBatch.clustered_sv_count_plots
+    File? clustered_outlier_samples_preview = ClusterBatch.clustered_outlier_samples_preview
+    File? clustered_outlier_samples_with_reason = ClusterBatch.clustered_outlier_samples_with_reason
+    Int? clustered_num_outlier_samples = ClusterBatch.clustered_num_outlier_samples
 
     File? metrics_file_clusterbatch = ClusterBatch.metrics_file_clusterbatch
 


### PR DESCRIPTION
Addressing issue [544](https://github.com/broadinstitute/gatk-sv/issues/544) here. 
PlotSVCountsPerSample.wdl was imported into ClusterBatch.wdl and FilterBatchSites.wdl. Then the N_IQR_cutoff input to the workflow with a default value of 6 was added to both wdls. PlotSVCountsPerSample is called as a subworkflow at the end of each workflow, passing the final VCF's as the input and the batch as the prefix. The outputs of PlotSVCountsPerSample were added to each workflow's outputs with unique names. Tthe JSON templates for ClusterBatch and FilterBatchSites in test and terra were updated to include the N_IQR_cuttoff input with a value of 6. Then the ClusterBatch and FilterBatchSites wofkflows were validated with womtool and the Terra validation script, and ran on the ref_panel_1kg test data. There was successful completion and decent outputs.