### PR TITLE
Remove use of the file command

### DIFF
--- a/src/sv-pipeline/04_variant_resolution/scripts/PESR_RD_merge_wrapper.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/PESR_RD_merge_wrapper.sh
@@ -56,11 +56,6 @@ if ! [ -s ${PESR} ]; then
   usage
   exit 0
 fi
-if [ $( file ${PESR} | fgrep "gzip" | wc -l ) -lt 1 ]; then
-  echo -e "\nERROR: input PESR VCF must be bgzipped\n"
-  usage
-  exit 0
-fi
 if [ -z ${RD} ]; then
   echo -e "\nERROR: input RD VCF not specified\n"
   usage
@@ -68,11 +63,6 @@ if [ -z ${RD} ]; then
 fi
 if ! [ -s ${RD} ]; then
   echo -e "\nERROR: input RD VCF either empty or not found\n"
-  usage
-  exit 0
-fi
-if [ $( file ${RD} | fgrep "gzip" | wc -l ) -lt 1 ]; then
-  echo -e "\nERROR: input RD VCF must be bgzipped\n"
   usage
   exit 0
 fi

--- a/src/sv-pipeline/04_variant_resolution/scripts/gather_cpx_intervals_for_rd_gt.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/gather_cpx_intervals_for_rd_gt.sh
@@ -64,11 +64,6 @@ if ! [ -s ${INVCF} ]; then
   usage
   exit 0
 fi
-if [ $( file ${INVCF} | fgrep "gzip" | wc -l ) -lt 1 ]; then
-  echo -e "\nERROR: input VCF must be bgzipped\n"
-  usage
-  exit 0
-fi
 if [ -z ${OUT} ]; then
   echo -e "\nERROR: path to output BED not specified\n"
   usage

--- a/src/sv-pipeline/04_variant_resolution/scripts/stitch_fragmented_CNVs.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/stitch_fragmented_CNVs.sh
@@ -79,11 +79,6 @@ if ! [ -s ${INVCF} ]; then
   usage
   exit 0
 fi
-if [ $( file ${INVCF} | fgrep "gzip" | wc -l ) -lt 1 ]; then
-  echo -e "\nERROR: input VCF must be bgzipped\n"
-  usage
-  exit 0
-fi
 if [ -z ${OUTVCF} ]; then
   echo -e "\nERROR: path to output VCF not specified\n"
   usage

--- a/src/sv-pipeline/04_variant_resolution/scripts/stitch_fragmented_calls.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/stitch_fragmented_calls.sh
@@ -67,11 +67,6 @@ if ! [ -s ${INVCF} ]; then
   usage
   exit 0
 fi
-if [ $( file ${INVCF} | fgrep "gzip" | wc -l ) -lt 1 ]; then
-  echo -e "\nERROR: input VCF must be bgzipped\n"
-  usage
-  exit 0
-fi
 if [ -z ${OUTVCF} ]; then
   echo -e "\nERROR: path to output VCF not specified\n"
   usage

--- a/src/sv-pipeline/scripts/vcf_qc/collectQC.sh
+++ b/src/sv-pipeline/scripts/vcf_qc/collectQC.sh
@@ -114,12 +114,8 @@ if ! [ -e ${OUTDIR}/data ]; then
 fi
 cd ${QCTMP}
 mkdir ${QCTMP}/perSample
-#Unzip VCF, if gzipped
-if [ $( file ${VCF} | fgrep " gzip " | wc -l ) -gt 0 ]; then
-  zcat ${VCF} > ${QCTMP}/input.vcf
-else
-  cp ${VCF} ${QCTMP}/input.vcf
-fi
+#Unzip VCF
+zcat ${VCF} > ${QCTMP}/input.vcf
 #Gather SV types to process
 cut -f1 ${SVTYPES} | sort | uniq > ${QCTMP}/svtypes.txt
 

--- a/src/sv-pipeline/scripts/vcf_qc/collectQC.vcf_wide.sh
+++ b/src/sv-pipeline/scripts/vcf_qc/collectQC.vcf_wide.sh
@@ -112,12 +112,8 @@ if ! [ -e ${OUTDIR}/data ]; then
   mkdir ${OUTDIR}/data
 fi
 mkdir ${QCTMP}/perSample
-#Unzip VCF, if gzipped
-if [ $( file ${VCF} | fgrep " gzip " | wc -l ) -gt 0 ]; then
-  zcat ${VCF} > ${QCTMP}/input.vcf
-else
-  cp ${VCF} ${QCTMP}/input.vcf
-fi
+#Unzip VCF
+zcat ${VCF} > ${QCTMP}/input.vcf
 #Gather SV types to process
 cut -f1 ${SVTYPES} | sort | uniq > ${QCTMP}/svtypes.txt
 

--- a/src/sv-pipeline/scripts/vcf_qc/compare_callsets.sh
+++ b/src/sv-pipeline/scripts/vcf_qc/compare_callsets.sh
@@ -117,8 +117,7 @@ fi
 ###PREP INPUT FILES
 OVRTMP=`mktemp -d`
 #Unzip SET1, if gzipped, restrict to contigs in $CONTIGS, rewrite non-conventional SVTYPES, and automatically set SVs with size <1 to 1
-if [ $( file ${SET1} | fgrep " gzip " | wc -l ) -gt 0 ] || \
-   [ $( echo ${SET1} | awk -v FS="." '{ if ($NF ~ /gz|bgz/) print "TRUE" }' ) ]; then
+if [ $( echo ${SET1} | awk -v FS="." '{ if ($NF ~ /gz|bgz/) print "TRUE" }' ) ]; then
   zcat ${SET1} | fgrep "#" > ${OVRTMP}/set1.bed
   zcat ${SET1} | fgrep -v "#" | awk -v OFS="\t" '{ if ($3<$2) $3=$2; print }' \
   | grep -f <( awk '{ print "^"$1"\t" }' ${CONTIGS} ) \
@@ -141,8 +140,7 @@ if [ ${CARRIER} == 1 ]; then
   mv ${OVRTMP}/set1.bed2 ${OVRTMP}/set1.bed
 fi
 #Unzip & format SET2, if gzipped
-if [ $( file ${SET2} | fgrep " gzip " | wc -l ) -gt 0 ] || \
-   [ $( echo ${SET2} | awk -v FS="." '{ if ($NF ~ /gz|bgz/) print "TRUE" }' ) ]; then
+if [ $( echo ${SET2} | awk -v FS="." '{ if ($NF ~ /gz|bgz/) print "TRUE" }' ) ]; then
   zcat ${SET2} | fgrep "#" | awk -v OFS="\t" \
   '{ print $1, $2, $3, "VID", $4, $5, $6 }' > ${OVRTMP}/set2.bed
   zcat ${SET2} | fgrep -v "#" \

--- a/src/sv-pipeline/scripts/vcf_qc/external_benchmark.sh
+++ b/src/sv-pipeline/scripts/vcf_qc/external_benchmark.sh
@@ -90,12 +90,8 @@ fi
 cd ${QCTMP}
 mkdir ${QCTMP}/perSample
 mkdir ${QCTMP}/perFamily
-#Unzip VCF, if gzipped
-if [ $( file ${VCF} | fgrep " gzip " | wc -l ) -gt 0 ]; then
-  zcat ${VCF} > ${QCTMP}/input.vcf
-else
-  cp ${VCF} ${QCTMP}/input.vcf
-fi
+#Unzip VCF
+zcat ${VCF} > ${QCTMP}/input.vcf
 #Gather SV types to process
 cut -f1 ${SVTYPES} | sort | uniq > ${QCTMP}/svtypes.txt
 


### PR DESCRIPTION
A user ran into an error in `gather_cpx_intervals_for_rd_gt.sh` [here](https://github.com/broadinstitute/gatk-sv/blob/12e4562578179ca3eaf0ee8557acb258e2853960/src/sv-pipeline/04_variant_resolution/scripts/gather_cpx_intervals_for_rd_gt.sh#L67) where the `file` command returned `DOS/MBR boot sector, COM/EXE Bootloaderd???v` instead of the expected `gzip`. 

The `file` command is generally not reliable and its usage in the code base to check whether files are gzipped is largely unnecessary. I've removed all instances of it I could find by grepping for `file` and `grep` in the same line.