### PR TITLE
Bug fix building samtools-cloud docker

### DIFF
--- a/dockerfiles/samtools-cloud/Dockerfile
+++ b/dockerfiles/samtools-cloud/Dockerfile
@@ -24,8 +24,8 @@ ARG CLOUD_SDK_VERSION
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-    tee /usr/share/keyrings/cloud.google.gpg && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
     apt-get update -y && \
     apt-get install google-cloud-sdk=$CLOUD_SDK_VERSION -y && \
     gcloud config set core/disable_usage_reporting true && \


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk-sv/issues/571
This PR updates GCP SDK installation steps to adhere to the latest recommendations [on GCP docs](https://cloud.google.com/sdk/docs/install#deb). Specifically, using `--keyring` to store/register GCP public keys. 