### PR TITLE
Bug fix Github actions out of disk error

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -213,7 +213,8 @@ jobs:
             --image-tag ${{ needs.build_args_job.outputs.image_tag }} \
             --input-json $DOCKERS_AZURE $DOCKERS_GCP \
             --output-json $DOCKERS_AZURE $DOCKERS_GCP \
-            --disable-git-protect
+            --disable-git-protect \
+            --prune-after-each-image
           
           CHANGED=$(git diff --quiet $DOCKERS_GCP || echo True)
           echo "CHANGED=$CHANGED" >> $GITHUB_OUTPUT

--- a/dockerfiles/samtools-cloud/Dockerfile
+++ b/dockerfiles/samtools-cloud/Dockerfile
@@ -1,6 +1,6 @@
 # This docker file exists because we need samtools to be able to access GCS buckets
 # so we base off the sv-base-mini image, which has samtools installed, 
-# and only install GCloud SDK here for authentication purpose
+# and only install GCloud SDK here for authentication purposes.
 
 # Start with the barebones image that has samtools (a version that must support NIO) installed
 ARG MINIBASE_IMAGE=sv-base-mini:latest


### PR DESCRIPTION
Github runners currently have ~15 GB disk space, and we run out of disk when building some of the base Docker images, as it will result in rebuilding many derived images. This PR adds the `--prune-after-each-image` to `build_docker` invocation to decrease disk usage. This flag was used in the `Test Images Build` job but missing from the `Publish` job, which is a bug.  

The inconsequential change on the `samtools-cloud/Dockerfile` is to trigger building and publishing `samtools-cloud` docker image and all the derived images since the `Publish` job had failed on #574, and the images were not published.  
