### PR TITLE
Add Terra validation to Github actions

### DIFF
--- a/.github/workflows/testwdls.yaml
+++ b/.github/workflows/testwdls.yaml
@@ -57,4 +57,4 @@ jobs:
 
       - name: Test with WOMtool
         run: |
-          scripts/test/validate.sh -d . -j womtool.jar
+          scripts/test/validate.sh -t -d . -j womtool.jar

--- a/scripts/test/terra_validation.py
+++ b/scripts/test/terra_validation.py
@@ -113,7 +113,7 @@ def main():
     parser.add_argument("-j", "--womtool-jar", help="Path to womtool jar", required=True)
     parser.add_argument("-n", "--num-input-jsons",
                         help="Number of Terra input JSONs expected",
-                        required=False, default=31, type=int)
+                        required=False, default=30, type=int)
     parser.add_argument("--log-level",
                         help="Specify level of logging information, ie. info, warning, error (not case-sensitive)",
                         required=False, default="INFO")


### PR DESCRIPTION
- Enables Terra workflow input validation in the Github WDL validation action
- Fixes Terra validation, as the number of Terra workflows was reduced from 31 to 30 in #562 where a gq-recalibrator workflow was removed.