### PR TITLE
Remove CHR2 and END2 for CPX at the end of CleanVcf

### DIFF
--- a/src/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py
+++ b/src/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py
@@ -137,19 +137,11 @@ def convert(record: pysam.VariantRecord,
     is_ddup = svtype == 'CPX' and 'dDUP' in record.info.get('CPX_TYPE', '')
     if svtype == 'BND' or svtype == 'INS' or svtype == 'CTX' or is_ddup:
         record.stop = record.start + 1
-        if is_ddup:
-            # e.g. SOURCE=DUP_chrX:49151588-49151850
-            source = record.info.get('SOURCE', None)
-            if source is not None:
-                tokens = source.split(':')
-                chr2 = tokens[0].split('_')[-1]
-                end2 = int(tokens[-1].split('-')[0])
-                record.info['CHR2'] = chr2
-                record.info['END2'] = end2
-            else:
-                # Sometimes SOURCE is not set (may be from CPX review workflow)
-                record.info['CHR2'] = record.chrom
-                record.info['END2'] = record.stop
+    if svtype == 'CPX':
+        if 'CHR2' in record.info:
+            record.info.pop('CHR2')
+        if 'END2' in record.info:
+            record.info.pop('END2')
     # Delete empty INFO fields (GATK does not like "." for non-String types)
     keys = record.info.keys()
     for k in keys:


### PR DESCRIPTION
### Updates
Remove CHR2 and END2 fields (if they exist) for all CPX records at the end of CleanVcf. These fields are redundant with the information in CPX_INTERVALS and are currently inconsistent and confusing (#377). 

### Testing
* Validated all WDLs and JSONs with womtool & terra validation script
* Rebuilt sv_pipeline_docker (us.gcr.io/broad-dsde-methods/eph/sv-pipeline:eph-cpx-remove-chr2-end2-6feed34) and tested CleanVcf with reference panel data. The workflow ran successfully and the resulting VCF did not have CHR2 or END2 fields for CPX records.

### Note
Downstream workflows should be tested and updated if needed to comply with this change.