### PR TITLE
Update JoinRawCalls formatter arg in template

### DIFF
--- a/inputs/templates/test/JoinRawCalls/JoinRawCalls.json.tmpl
+++ b/inputs/templates/test/JoinRawCalls/JoinRawCalls.json.tmpl
@@ -15,6 +15,8 @@
   "JoinRawCalls.clustered_melt_vcfs" : [{{ test_batch.merged_melt_vcf | tojson }}],
   "JoinRawCalls.clustered_melt_vcf_indexes" : [{{ test_batch.merged_melt_vcf_index | tojson }}],
 
+  "JoinRawCalls.FormatVcfForGatk.formatter_args": "--fix-end",
+
   "JoinRawCalls.ped_file": {{ test_batch.ped_file | tojson }},
 
   "JoinRawCalls.contig_list": {{ reference_resources.primary_contigs_list | tojson }},

--- a/wdl/JoinRawCalls.wdl
+++ b/wdl/JoinRawCalls.wdl
@@ -26,8 +26,6 @@ workflow JoinRawCalls {
 
     File ped_file
 
-    String? preprocess_args
-
     File contig_list
     File reference_fasta
     File reference_fasta_fai


### PR DESCRIPTION
JoinRawCalls has been failing due to improper assignment of `END2` during GATK-style formatting. This PR includes 2 small updates:
- Adds a needed "--fix-end" argument to the GATK formatter
- Removes unused parameter `preprocess_args`