### PR TITLE
Filter mCNVs under 5kbp

### DIFF
--- a/wdl/CleanVcfChromosome.wdl
+++ b/wdl/CleanVcfChromosome.wdl
@@ -741,7 +741,7 @@ task FinalCleanup {
       --chrom ~{contig} \
       --prefix ~{prefix} \
       ~{vcf} stdout \
-      | bcftools annotate --no-version -x INFO/MEMBERS -Oz -o ~{prefix}.vcf.gz
+      | bcftools annotate --no-version -e 'SVTYPE=="CNV" && SVLEN<5000' -x INFO/MEMBERS -Oz -o ~{prefix}.vcf.gz
     tabix ~{prefix}.vcf.gz
   >>>
 


### PR DESCRIPTION
Adds a filter to the end of `CleanVcf` that removes multiallelic CNVs under 5kbp, as these calls are generally unreliable.

Tested successfully on the reference panel.