### PR TITLE
Update melt docker image to current latest build.

### DIFF
--- a/inputs/values/dockers_azure.json
+++ b/inputs/values/dockers_azure.json
@@ -7,7 +7,7 @@
   "genomes_in_the_cloud_docker": "vahid.azurecr.io/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "vahid.azurecr.io/google/ubuntu1804",
   "manta_docker": "vahid.azurecr.io/vjalili/manta:5994670",
-  "melt_docker": "vahid.azurecr.io/melt:vj-4ff9de9f",
+  "melt_docker": "vahid.azurecr.io/melt:3159ce1",
   "scramble_docker": "vahid.azurecr.io/tsharpe/scramble:1.0.2",
   "samtools_cloud_docker": "vahid.azurecr.io/gatk-sv/samtools-cloud:2023-07-28-v0.28.1-beta-e70dfbd7",
   "sv_base_docker": "vahid.azurecr.io/gatk-sv/sv-base:2023-07-28-v0.28.1-beta-e70dfbd7",


### PR DESCRIPTION
Given the license requirements of MELT, this image is not built and pushed to container registries using the GitHub actions. Hence, the latest builds of this image should be manually kept in synch between GCR and ACR. The image currently referenced for ACR is an older build than the image on GCR, and it does not include samtools. This PR updates the Docker image tag of MELT on ACR to the current latest tag on GCR. 