### PR TITLE
Make genome_tracks optional in FilterGenotypes

### DIFF
--- a/inputs/templates/test/FilterGenotypes/FilterGenotypes.fixed_cutoffs.json.tmpl
+++ b/inputs/templates/test/FilterGenotypes/FilterGenotypes.fixed_cutoffs.json.tmpl
@@ -5,8 +5,8 @@
   "FilterGenotypes.gq_recalibrator_model_file": {{ reference_resources.aou_recalibrate_gq_model_file | tojson }},
   "FilterGenotypes.sl_filter_args": "--small-del-threshold 93 --medium-del-threshold 150 --small-dup-threshold -51 --medium-dup-threshold -4 --ins-threshold -13 --inv-threshold -19",
 
-  "FilterGenotypes.RecalibrateGq.genome_tracks": {{ reference_resources.recalibrate_gq_genome_tracks | tojson }},
-  "FilterGenotypes.RecalibrateGq.recalibrate_gq_args": [
+  "FilterGenotypes.genome_tracks": {{ reference_resources.recalibrate_gq_genome_tracks | tojson }},
+  "FilterGenotypes.recalibrate_gq_args": [
     "--keep-homvar false",
     "--keep-homref true",
     "--keep-multiallelic true",
@@ -14,23 +14,23 @@
     "--min-samples-to-estimate-allele-frequency -1"
   ],
 
-  "FilterGenotypes.MainVcfQc.ped_file": {{ test_batch.ped_file | tojson }},
-  "FilterGenotypes.MainVcfQc.primary_contigs_fai": {{ reference_resources.primary_contigs_fai | tojson }},
-  "FilterGenotypes.MainVcfQc.site_level_comparison_datasets": [
+  "FilterGenotypes.ped_file": {{ test_batch.ped_file | tojson }},
+  "FilterGenotypes.primary_contigs_fai": {{ reference_resources.primary_contigs_fai | tojson }},
+  "FilterGenotypes.site_level_comparison_datasets": [
     {{ reference_resources.ccdg_abel_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.gnomad_v2_collins_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.hgsv_byrska_bishop_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.thousand_genomes_site_level_benchmarking_dataset | tojson }}
   ],
-  "FilterGenotypes.MainVcfQc.sample_level_comparison_datasets": [
+  "FilterGenotypes.sample_level_comparison_datasets": [
     {{ reference_resources.hgsv_byrska_bishop_sample_level_benchmarking_dataset | tojson }}
   ],
-  "FilterGenotypes.MainVcfQc.sample_renaming_tsv": {{ reference_resources.hgsv_byrska_bishop_sample_renaming_tsv | tojson }},
-  "FilterGenotypes.MainVcfQc.runtime_override_per_sample_benchmark_plot": {
+  "FilterGenotypes.sample_renaming_tsv": {{ reference_resources.hgsv_byrska_bishop_sample_renaming_tsv | tojson }},
+  "FilterGenotypes.runtime_override_per_sample_benchmark_plot": {
     "mem_gb": 30,
     "disk_gb": 50
   },
-  "FilterGenotypes.MainVcfQc.runtime_override_plot_qc_per_family": {
+  "FilterGenotypes.runtime_override_plot_qc_per_family": {
     "mem_gb": 15,
     "disk_gb": 100
   },

--- a/wdl/FilterGenotypes.wdl
+++ b/wdl/FilterGenotypes.wdl
@@ -24,6 +24,7 @@ workflow FilterGenotypes {
     Int filter_vcf_records_per_shard = 20000
 
     # For MainVcfQc
+    File primary_contigs_fai
     Boolean run_qc = true
     String qc_bcftools_preprocessing_options = "-e 'FILTER~\"UNRESOLVED\" || FILTER~\"HIGH_NCR\"'"
     Int qc_sv_per_shard = 2500
@@ -114,6 +115,7 @@ workflow FilterGenotypes {
         vcfs=[ConcatVcfs.concat_vcf],
         prefix="~{output_prefix_}.filter_genotypes",
         bcftools_preprocessing_options=qc_bcftools_preprocessing_options,
+        primary_contigs_fai=primary_contigs_fai,
         sv_per_shard=qc_sv_per_shard,
         samples_per_shard=qc_samples_per_shard,
         sv_pipeline_qc_docker=sv_pipeline_docker,

--- a/wdl/RecalibrateGq.wdl
+++ b/wdl/RecalibrateGq.wdl
@@ -9,7 +9,7 @@ workflow RecalibrateGq {
         File vcf
         File vcf_index
         Int? recalibrate_records_per_shard
-        Array[File] genome_tracks
+        Array[File] genome_tracks = []
         File gq_recalibrator_model_file
         Array[String] recalibrate_gq_args = []
         String gatk_docker


### PR DESCRIPTION
Current WDLs don't pass genome_tracks through from FilterGenotypes. Calling FilterGenotypes creates a workflow [call to RecalibrateGq](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/FilterGenotypes.wdl#L41). This workflow invocation has neither `genome_tracks` or `recalibrate_gq_args` as attributes.

On the receiving side [only one](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/RecalibrateGq.wdl#L12-L14) of those arguments is marked as optional, the construction of the command to run implies these are both optional.

---

Secondary issue from FilterGenotypes: MainVcfQc requires `primary_contigs_fai` to be passed through, which is not currently possible. 've added this as an argument.

Both of these arguments are present in the [test template](https://github.com/broadinstitute/gatk-sv/blob/main/inputs/templates/test/FilterGenotypes/FilterGenotypes.fixed_cutoffs.json.tmpl#L8-L18), but there's no way to pass them in at runtime.

Apologies if this is all misguided!
