### PR TITLE
Remove hgdp_1kgp_ped test batch input from MainVcfQc template

### DIFF
--- a/inputs/templates/test/MainVcfQc/MainVcfQc.per_sample_benchmark.json.tmpl
+++ b/inputs/templates/test/MainVcfQc/MainVcfQc.per_sample_benchmark.json.tmpl
@@ -16,8 +16,8 @@
   "MainVcfQc.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
   "MainVcfQc.sv_pipeline_qc_docker": {{ dockers.sv_pipeline_qc_docker | tojson }},
 
-  "MainVcfQc.prefix": "HGDP_and_HGSV",
-  "MainVcfQc.ped_file": {{ test_batch.hgdp_1kgp_ped | tojson }},
+  "MainVcfQc.prefix": {{ test_batch.name | tojson }},
+  "MainVcfQc.ped_file": {{ test_batch.ped_file | tojson }},
 
   "MainVcfQc.vcfs": [ {{ test_batch.gq_filtered_vcf | tojson }} ],
   "MainVcfQc.sv_per_shard": 2500,

--- a/inputs/values/hgdp.json
+++ b/inputs/values/hgdp.json
@@ -1,6 +1,6 @@
 {
   "name": "hgdp",
-  "ped_file": "gs://gatk-sv-hgdp/mw-sv-concordance-update/HGDP_1KGP.ped",
+  "ped_file": "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/HGDP_1KGP.ped",
   "ploidy_table": "gs://gatk-sv-hgdp/mw-sv-concordance-update/hgdp.ploidy_table.tsv",
 
   "del_bed": "gs://gatk-sv-hgdp/mw-sv-concordance-update/hgdp.DEL.bed.gz",

--- a/inputs/values/ref_panel_1kg.json
+++ b/inputs/values/ref_panel_1kg.json
@@ -1223,7 +1223,6 @@
     ],
     "gq_filtered_vcf": "gs://gatk-sv-ref-panel-1kg/outputs/qg_filter/hgdp_and_hgsv.cleaned_fixed_annotated_gq_recalibrated.vcf.gz",
     "gq_filtered_vcf_index": "gs://gatk-sv-ref-panel-1kg/outputs/qg_filter/hgdp_and_hgsv.cleaned_fixed_annotated_gq_recalibrated.vcf.gz.tbi",
-    "hgdp_1kgp_ped": "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/HGDP_1KGP.ped",
     "cohort_depth_vcf": "gs://gatk-sv-ref-panel-1kg/outputs/GATKSVPipelineBatch/38c65ca4-2a07-4805-86b6-214696075fef/call-GATKSVPipelinePhase1/GATKSVPipelinePhase1/acce2c71-7458-4205-ae13-624f6efc9956/call-FilterBatch/FilterBatch/184defa3-e61c-4757-9962-f685f6d0d204/call-FilterBatchSamples/FilterBatchSamples/b308c32e-d171-4d8d-aeaf-b561c55b06b4/call-ExcludeOutliers/shard-4/cacheCopy/ref_panel_1kg.depth.outliers_removed.vcf.gz",
     "cohort_pesr_vcf": "gs://gatk-sv-ref-panel-1kg/outputs/GATKSVPipelineBatch/38c65ca4-2a07-4805-86b6-214696075fef/call-GATKSVPipelinePhase1/GATKSVPipelinePhase1/acce2c71-7458-4205-ae13-624f6efc9956/call-FilterBatch/FilterBatch/184defa3-e61c-4757-9962-f685f6d0d204/call-FilterBatchSamples/FilterBatchSamples/b308c32e-d171-4d8d-aeaf-b561c55b06b4/call-MergePesrVcfs/cacheCopy/ref_panel_1kg.filtered_pesr_merged.vcf.gz",
     "combined_vcfs": [


### PR DESCRIPTION
Fixes a minor error in `inputs/templates/test/MainVcfQc/MainVcfQc.per_sample_benchmark.json.tmpl` where HGDP was referenced instead of using the test batch's name/ped file.