### PR TITLE
Toggle Collect PESR/Counts in GatherSampleEvidence with booleans

### DIFF
--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -140,7 +140,7 @@ workflow GatherSampleEvidence {
   File reads_file_ = select_first([CramToBamReviseBase.bam_file, LocalizeReads.output_file])
   File reads_index_ = select_first([CramToBamReviseBase.bam_index, LocalizeReads.output_index])
 
-  if (collect_coverage || run_melt || run_module_metrics) {
+  if (collect_coverage || run_melt) {
     call cov.CollectCounts {
       input:
         intervals = preprocessed_intervals,
@@ -174,7 +174,7 @@ workflow GatherSampleEvidence {
     }
   }
 
-  if (collect_pesr || run_module_metrics) {
+  if (collect_pesr) {
     call coev.CollectSVEvidence {
       input:
         bam_or_cram_file = reads_file_,


### PR DESCRIPTION
### Updates
Setting `collect_coverage` or `collect_pesr` to `false` in GatherSampleEvidence should disable CollectCounts and CollectSVEvidence (except if MELT is enabled, which requires CollectCounts), but this setting was ignored if `run_module_metrics` was set to `true`. This is unnecessary because every task in the metrics workflow is optional, and the metrics workflow should only collect metrics on the desired outputs. This PR removes the requirement to run CollectSVEvidence and CollectCounts just for module metrics.

### Testing
* Validated all WDLs and JSONs with womtool and terra validation script
* Ran GatherSampleEvidence on one sample with `collect_pesr = false` and `collect_coverage = false` and only the `wham_docker` provided and verified that only LocalizeReads, Wham, and Wham metrics tasks ran