### PR TITLE
Make the Cromwell root config in the MELT workflow portable

### DIFF
--- a/wdl/MELT.wdl
+++ b/wdl/MELT.wdl
@@ -510,7 +510,24 @@ task RunMELT {
 
     # these locations should be stable
     MELT_DIR="/MELT"
-    CROMWELL_ROOT="$PWD"
+
+    # `cromwell_root` and `cromwell-executions` are the **default**
+    # root directory for cromwell deployments on GCP and Azure respectively.
+    # The last option, i.e., $PWD, is the fall back option if the
+    # default root directory of the cromwell instance was changed,
+    # however, it is not a reliable option as it fails on GCP.
+    # It does not seem Cromwell sets a runtime environment variable
+    # exposing the configured value of the root directory,
+    # which could have provided a portable solution for this.
+    # The following solution works with the Cromwell deployments
+    # we are currently using on GCP and Azure.
+    if [ -d "/cromwell_root" ]; then
+      CROMWELL_ROOT="/cromwell_root"
+    elif [ -d "/cromwell-executions" ]; then
+      CROMWELL_ROOT="/cromwell-executions"
+    else
+      CROMWELL_ROOT="$PWD"
+    fi
 
     # these locations may vary based on MELT version number, so find them:
     MELT_ROOT=$(find "$MELT_DIR" -name "MELT.jar" | xargs -n1 dirname)

--- a/wdl/MELT.wdl
+++ b/wdl/MELT.wdl
@@ -510,7 +510,7 @@ task RunMELT {
 
     # these locations should be stable
     MELT_DIR="/MELT"
-    CROMWELL_ROOT="/cromwell_root"
+    CROMWELL_ROOT="$PWD"
 
     # these locations may vary based on MELT version number, so find them:
     MELT_ROOT=$(find "$MELT_DIR" -name "MELT.jar" | xargs -n1 dirname)


### PR DESCRIPTION
The root directory of the VM started by Cromwell to run a task is a Cromwell instance configuration. The default value is set to `/cromwell_root` and `/cromwell-executions` on GCP and Azure, respectively.  

[MELT script](https://github.com/broadinstitute/gatk-sv/blob/main/dockerfiles/melt/run_MELT_2.0.5.sh) takes the root directory as an input, and MELT's WDL [hardcodes this input to `/cromwell_root`](https://github.com/broadinstitute/gatk-sv/blob/8c9ddab01ab19b86f33afc01f5149645aeee0fa7/wdl/MELT.wdl#L511-L513), which works as expected on GCP. However, the hardcoded value is not portable. 

This PR extends the hardcoded value to the default Cromwell root directories to GCP and Azure, and uses `$PWD` (discussed in https://github.com/broadinstitute/gatk-sv/issues/365#issuecomment-1172809000) as a fallback option if the Cromwell root was set to a different value. 

The changes are successfully tested on GCP and Azure. The GCP workflow id is: `f450a355-031f-44fc-8289-d199d0fd93e8`.