### PR TITLE
Setup automatic updates to WDLs on Dockstore

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -1,0 +1,73 @@
+version: 1.2
+workflows:
+  - subclass: WDL
+    name: 01-GatherSampleEvidence
+    primaryDescriptorPath: /wdl/GatherSampleEvidence.wdl
+
+  - subclass: WDL
+    name: 02-EvidenceQC
+    primaryDescriptorPath: /wdl/EvidenceQC.wdl
+
+  - subclass: WDL
+    name: 03-TrainGCNV
+    primaryDescriptorPath: /wdl/TrainGCNV.wdl
+
+  - subclass: WDL
+    name: 04-GatherBatchEvidence
+    primaryDescriptorPath: /wdl/GatherBatchEvidence.wdl
+
+  - subclass: WDL
+    name: 05-ClusterBatch
+    primaryDescriptorPath: /wdl/ClusterBatch.wdl
+
+  - subclass: WDL
+    name: 06-GenerateBatchMetrics
+    primaryDescriptorPath: /wdl/GenerateBatchMetrics.wdl
+
+  - subclass: WDL
+    name: 07-FilterBatchSites
+    primaryDescriptorPath: /wdl/FilterBatchSites.wdl
+
+  - subclass: WDL
+    name: 08-PlotSVCountsPerSample
+    primaryDescriptorPath: /wdl/PlotSVCountsPerSample.wdl
+
+  - subclass: WDL
+    name: 09-FilterBatchSamples
+    primaryDescriptorPath: /wdl/FilterBatchSamples.wdl
+
+  - subclass: WDL
+    name: 10-MergeBatchSites
+    primaryDescriptorPath: /wdl/MergeBatchSites.wdl
+
+  - subclass: WDL
+    name: 11-GenotypeBatch
+    primaryDescriptorPath: /wdl/GenotypeBatch.wdl
+
+  - subclass: WDL
+    name: 12-RegenotypeCNVs
+    primaryDescriptorPath: /wdl/RegenotypeCNVs.wdl
+
+  - subclass: WDL
+    name: 13-CombineBatches
+    primaryDescriptorPath: /wdl/CombineBatches.wdl
+
+  - subclass: WDL
+    name: 14-ResolveComplexVariants
+    primaryDescriptorPath: /wdl/ResolveComplexVariants.wdl
+
+  - subclass: WDL
+    name: 15-GenotypeComplexVariants
+    primaryDescriptorPath: /wdl/GenotypeComplexVariants.wdl
+
+  - subclass: WDL
+    name: 16-CleanVcf
+    primaryDescriptorPath: /wdl/CleanVcf.wdl
+
+  - subclass: WDL
+    name: 17-MainVcfQc
+    primaryDescriptorPath: /wdl/MainVcfQc.wdl
+
+  - subclass: WDL
+    name: 18-AnnotateVcf
+    primaryDescriptorPath: /wdl/AnnotateVcf.wdl

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -1,73 +1,163 @@
 version: 1.2
 workflows:
   - subclass: WDL
-    name: 01-GatherSampleEvidence
+    name: GatherSampleEvidence
     primaryDescriptorPath: /wdl/GatherSampleEvidence.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 02-EvidenceQC
+    name: EvidenceQC
     primaryDescriptorPath: /wdl/EvidenceQC.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 03-TrainGCNV
+    name: TrainGCNV
     primaryDescriptorPath: /wdl/TrainGCNV.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 04-GatherBatchEvidence
+    name: GatherBatchEvidence
     primaryDescriptorPath: /wdl/GatherBatchEvidence.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 05-ClusterBatch
+    name: ClusterBatch
     primaryDescriptorPath: /wdl/ClusterBatch.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 06-GenerateBatchMetrics
+    name: GenerateBatchMetrics
     primaryDescriptorPath: /wdl/GenerateBatchMetrics.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 07-FilterBatchSites
+    name: FilterBatchSites
     primaryDescriptorPath: /wdl/FilterBatchSites.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 08-PlotSVCountsPerSample
+    name: PlotSVCountsPerSample
     primaryDescriptorPath: /wdl/PlotSVCountsPerSample.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 09-FilterBatchSamples
+    name: FilterBatchSamples
     primaryDescriptorPath: /wdl/FilterBatchSamples.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 10-MergeBatchSites
+    name: MergeBatchSites
     primaryDescriptorPath: /wdl/MergeBatchSites.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 11-GenotypeBatch
+    name: GenotypeBatch
     primaryDescriptorPath: /wdl/GenotypeBatch.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 12-RegenotypeCNVs
+    name: RegenotypeCNVs
     primaryDescriptorPath: /wdl/RegenotypeCNVs.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 13-CombineBatches
+    name: CombineBatches
     primaryDescriptorPath: /wdl/CombineBatches.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 14-ResolveComplexVariants
+    name: ResolveComplexVariants
     primaryDescriptorPath: /wdl/ResolveComplexVariants.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 15-GenotypeComplexVariants
+    name: GenotypeComplexVariants
     primaryDescriptorPath: /wdl/GenotypeComplexVariants.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 16-CleanVcf
+    name: CleanVcf
     primaryDescriptorPath: /wdl/CleanVcf.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 17-MainVcfQc
+    name: MainVcfQc
     primaryDescriptorPath: /wdl/MainVcfQc.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/
 
   - subclass: WDL
-    name: 18-AnnotateVcf
+    name: AnnotateVcf
     primaryDescriptorPath: /wdl/AnnotateVcf.wdl
+    filters:
+      branches: 
+        - main
+      tags:
+        - /.*/


### PR DESCRIPTION
This PR adds configurations necessary to enable automatic updates of the WDLs on Dockstore. 
Accordingly, this PR adds `.dockstore.yml`, which registers the workflows defined on GATK-SV Terra workspace (i.e., `[gnomad-v3-sv/gatk-sv-pipeline-1kgp](https://app.terra.bio/#workspaces/gnomad-v3-sv/gatk-sv-pipeline-1kgp-test-noaddress)`) for an automatic sync with Dockstore. 

Only the root workflows need to be registered for automatic sync, and Dockstore will fetch all the dependencies automatically without a need for explicit registration. Additionally, the dockstore app does not support registering workflows using wildcards; hence, each workflow must be registered separately. 

After this PR is merged, dockstore app will automatically sync the registered workflows with dockstore with every commit pushed to any branch on broadinstitute/gatk-sv that has `.github/.dockstore.yml` file in it. 