### PR TITLE
Add Scramble docker to the build script & update docs

### DIFF
--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -176,6 +176,9 @@ class ProjectBuilder:
             docker_dependencies={
                 "sv-base": "SVBASE_IMAGE"}
         ),
+        "scramble": ImageDependencies(
+            git_dependencies=("dockerfiles/scramble/*")
+        ),
         "wham": ImageDependencies(
             git_dependencies="dockerfiles/wham/*",
             docker_dependencies={

--- a/website/docs/advanced/docker/images.md
+++ b/website/docs/advanced/docker/images.md
@@ -29,7 +29,7 @@ The figure below illustrates the relationships between the GATK-SV Docker images
 
 ```mermaid
 flowchart TD
-    ubuntu22[Ubuntu 22.04] --> svbasemini[sv-base-mini] & samtoolsenv[samtools-cloud-virtual-env] & svbaseenv[sv-base-virtual-env]
+    ubuntu2204[Ubuntu 22.04] --> svbasemini[sv-base-mini] & samtoolsenv[samtools-cloud-virtual-env] & svbaseenv[sv-base-virtual-env]
     svbasemini & samtoolsenv & svbaseenv --> svpipelineenv[sv-pipeline-virtual-env]
     samtoolsenv --> samtoolscloud[samtools-cloud] & svutilsenv[sv-utils-env]
     svbasemini --> samtoolscloud
@@ -39,9 +39,10 @@ flowchart TD
     svbaseenv --> cnmopsenv[cnmpos-virtual-env]
     svbase & cnmopsenv --> cnmpos[cnmops]
 
-    ubuntu18[Ubuntu 18.04] --> manta[Manta] & melt[MELT] & wham[Wham]
+    ubuntu1804[Ubuntu 18.04] --> manta[Manta] & melt[MELT] & wham[Wham]
     samtoolscloud --> wham
     ubuntu2210[Ubuntu 22.10] --> str[STR]
+    ubuntu2204 --> scramble[Scramble]
 ```
 
 The image depicts the hierarchical relationship among GATK-SV 
@@ -66,6 +67,7 @@ The table below lists the GATK-SV Docker images and their dependencies.
 |------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
 | `manta`                      | <ul><li>`dockerfiles/manta/*`</li></ul>                                                                                                                                                 |                                                                                                     |
 | `melt`                       | <ul><li>`dockerfiles/melt/*`</li></ul>                                                                                                                                                  | <ul><li>`sv-base`</li></ul>                                                                         |
+| `scramble`                   | <ul><li>`dockerfiles/scramble/*`</li></ul>                                                                                                                                              |                                                                                                     |
  | `wham`                       | <ul><li>`dockerfiles/wham/*`</li></ul>                                                                                                                                                  | <ul><li>`samtools-cloud`</li></ul>                                                                  |
  | `str`                        | <ul><li>`dockerfiles/str/*`</li></ul>                                                                                                                                                   |                                                                                                     |
  | `sv-base-mini`               | <ul><li>`dockerfiles/sv-base-mini/*`</li></ul>                                                                                                                                          |                                                                                                     |

--- a/website/docs/advanced/docker/images.md
+++ b/website/docs/advanced/docker/images.md
@@ -39,10 +39,10 @@ flowchart TD
     svbaseenv --> cnmopsenv[cnmpos-virtual-env]
     svbase & cnmopsenv --> cnmpos[cnmops]
 
-    ubuntu1804[Ubuntu 18.04] --> manta[Manta] & melt[MELT] & wham[Wham]
+    ubuntu1804[Ubuntu 18.04] --> melt[MELT] & wham[Wham]
     samtoolscloud --> wham
     ubuntu2210[Ubuntu 22.10] --> str[STR]
-    ubuntu2204 --> scramble[Scramble]
+    ubuntu2204 --> scramble[Scramble] & manta[Manta]
 ```
 
 The image depicts the hierarchical relationship among GATK-SV 

--- a/website/package.json
+++ b/website/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.4.1",
-    "@docusaurus/preset-classic": "2.4.1",
-    "@docusaurus/theme-mermaid": "^2.4.1",
+    "@docusaurus/core": "2.4.3",
+    "@docusaurus/preset-classic": "2.4.3",
+    "@docusaurus/theme-mermaid": "^2.4.3",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",


### PR DESCRIPTION
A follow-up from https://github.com/broadinstitute/gatk-sv/pull/603#issuecomment-1749623550, this PR implements the following:

- [x] Add the Scramble docker to `build_docker.py`, so (a) the image can be built using the script in the same way the other images are built and (b) maintained through the GitHub actions. 
- [x] Add Scramble to the images table and figure in the documentation. 
