### PR TITLE
Add extra information to dashboard with regards to which workflow versions should be run

### DIFF
--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -176,6 +176,9 @@ class ProjectBuilder:
             docker_dependencies={
                 "sv-base": "SVBASE_IMAGE"}
         ),
+        "scramble": ImageDependencies(
+            git_dependencies=("dockerfiles/scramble/*")
+        ),
         "wham": ImageDependencies(
             git_dependencies="dockerfiles/wham/*",
             docker_dependencies={

--- a/wdl/MELT.wdl
+++ b/wdl/MELT.wdl
@@ -510,7 +510,24 @@ task RunMELT {
 
     # these locations should be stable
     MELT_DIR="/MELT"
-    CROMWELL_ROOT="/cromwell_root"
+
+    # `cromwell_root` and `cromwell-executions` are the **default**
+    # root directory for cromwell deployments on GCP and Azure respectively.
+    # The last option, i.e., $PWD, is the fall back option if the
+    # default root directory of the cromwell instance was changed,
+    # however, it is not a reliable option as it fails on GCP.
+    # It does not seem Cromwell sets a runtime environment variable
+    # exposing the configured value of the root directory,
+    # which could have provided a portable solution for this.
+    # The following solution works with the Cromwell deployments
+    # we are currently using on GCP and Azure.
+    if [ -d "/cromwell_root" ]; then
+      CROMWELL_ROOT="/cromwell_root"
+    elif [ -d "/cromwell-executions" ]; then
+      CROMWELL_ROOT="/cromwell-executions"
+    else
+      CROMWELL_ROOT="$PWD"
+    fi
 
     # these locations may vary based on MELT version number, so find them:
     MELT_ROOT=$(find "$MELT_DIR" -name "MELT.jar" | xargs -n1 dirname)

--- a/website/docs/advanced/docker/images.md
+++ b/website/docs/advanced/docker/images.md
@@ -29,7 +29,7 @@ The figure below illustrates the relationships between the GATK-SV Docker images
 
 ```mermaid
 flowchart TD
-    ubuntu22[Ubuntu 22.04] --> svbasemini[sv-base-mini] & samtoolsenv[samtools-cloud-virtual-env] & svbaseenv[sv-base-virtual-env]
+    ubuntu2204[Ubuntu 22.04] --> svbasemini[sv-base-mini] & samtoolsenv[samtools-cloud-virtual-env] & svbaseenv[sv-base-virtual-env]
     svbasemini & samtoolsenv & svbaseenv --> svpipelineenv[sv-pipeline-virtual-env]
     samtoolsenv --> samtoolscloud[samtools-cloud] & svutilsenv[sv-utils-env]
     svbasemini --> samtoolscloud
@@ -39,9 +39,10 @@ flowchart TD
     svbaseenv --> cnmopsenv[cnmpos-virtual-env]
     svbase & cnmopsenv --> cnmpos[cnmops]
 
-    ubuntu18[Ubuntu 18.04] --> manta[Manta] & melt[MELT] & wham[Wham]
+    ubuntu1804[Ubuntu 18.04] --> melt[MELT] & wham[Wham]
     samtoolscloud --> wham
     ubuntu2210[Ubuntu 22.10] --> str[STR]
+    ubuntu2204 --> scramble[Scramble] & manta[Manta]
 ```
 
 The image depicts the hierarchical relationship among GATK-SV 
@@ -66,6 +67,7 @@ The table below lists the GATK-SV Docker images and their dependencies.
 |------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
 | `manta`                      | <ul><li>`dockerfiles/manta/*`</li></ul>                                                                                                                                                 |                                                                                                     |
 | `melt`                       | <ul><li>`dockerfiles/melt/*`</li></ul>                                                                                                                                                  | <ul><li>`sv-base`</li></ul>                                                                         |
+| `scramble`                   | <ul><li>`dockerfiles/scramble/*`</li></ul>                                                                                                                                              |                                                                                                     |
  | `wham`                       | <ul><li>`dockerfiles/wham/*`</li></ul>                                                                                                                                                  | <ul><li>`samtools-cloud`</li></ul>                                                                  |
  | `str`                        | <ul><li>`dockerfiles/str/*`</li></ul>                                                                                                                                                   |                                                                                                     |
  | `sv-base-mini`               | <ul><li>`dockerfiles/sv-base-mini/*`</li></ul>                                                                                                                                          |                                                                                                     |

--- a/website/package.json
+++ b/website/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.4.1",
-    "@docusaurus/preset-classic": "2.4.1",
-    "@docusaurus/theme-mermaid": "^2.4.1",
+    "@docusaurus/core": "2.4.3",
+    "@docusaurus/preset-classic": "2.4.3",
+    "@docusaurus/theme-mermaid": "^2.4.3",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",


### PR DESCRIPTION
This adds extra information after the dashboard description of module 10. It guides the user to delete the irrelevant workflows based on how many batches are being used. This will prevent any unintended workflows to be run if there is an error or a certain workflow that would need to be run if issues arise further downstream.