### PR TITLE
Copy or move the files instead of creating symlinks in the LocalizeReads task for compatibility with CoA/TES.

### DIFF
--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -24,8 +24,13 @@ workflow GatherSampleEvidence {
     Boolean collect_coverage = true
     Boolean collect_pesr = true
 
-    # Google Cloud Platform and Azure users can safely enable and get a slight cost improvement.
-    # Users running shared filesystems should NOT enable.
+    # Google Cloud Platform (GCP) and Azure users can safely enable and get a slight cost improvement.
+    # Users running on shared file systems should NOT enable this feature.
+    # Enabling this option when running the workflow on GCP or Azure will result in moving the **localized**
+    # files from one path to another on the VM, without impacting the files in their source persistent location.
+    # It will lead to using a slightly smaller disk size and running faster, thereby providing a slight cost improvement.
+    # However, when run on shared file systems (e.g., HPC), it will, by default, create a copy of the
+    # input files, and all subsequent operations will run on the deep copy of the input file.
     Boolean move_bam_or_cram_files = false
 
     # Convert ambiguous bases (e.g. K, S, Y, etc.) to N

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -343,7 +343,7 @@ task LocalizeReads {
     # When this pipeline is run on an HPC, moving files could lead to
     # moving the files from their original source, compared to moving
     # them from one directory of the VM to another when run on Cloud.
-    # Therefore, to avoid moving files unexpectadely, we provide both
+    # Therefore, to avoid moving files unexpectedly, we provide both
     # options for moving and copying, and set the copy as default.
     # Note that, when copying the files, the task can be slower depending
     # on the file size and IO performance and will need additional disk

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -335,8 +335,10 @@ task LocalizeReads {
   Int disk_size = ceil(50 + size(reads_path, "GB"))
 
   command {
-    ln -s ~{reads_path}
-    ln -s ~{reads_index}
+    set -exuo pipefail
+
+    mv ~{reads_path} $(basename ~{reads_path})
+    mv ~{reads_index} $(basename ~{reads_index})
   }
   output {
     File output_file = basename(reads_path)

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -23,6 +23,9 @@ workflow GatherSampleEvidence {
     # Evidence collection flags
     Boolean collect_coverage = true
     Boolean collect_pesr = true
+
+    # Google Cloud Platform and Azure users can safely enable and get a slight cost improvement.
+    # Users running shared filesystems should NOT enable.
     Boolean move_bam_or_cram_files = false
 
     # Convert ambiguous bases (e.g. K, S, Y, etc.) to N


### PR DESCRIPTION
The task `LocalizeReads` creates symlinks for the localized cram and its corresponding index file in the current working directory to simplify referencing them in the task output. Specifically, the files are localized in the following directory, and symlinks are created in the `/cromwell_root/.` 

```
/cromwell_root/…/analysis/filename.cram
```

Symlinks as this are incompatible with GA4GH TES and [Cromwell on Azure](https://github.com/microsoft/CromwellOnAzure). 

Therefore, this PR updates the script to move or copy the files instead of creating symlinks. Moving files (`mv`) is faster and requires less disk space on the VM than copying the files. However, run on HPC, moving files could lead to moving them from their source directory compared to moving them from the localized directory to the root directory on the VM. Therefore, we provide both options for moving and copying to avoid moving files unexpectedly and set the copy as default.

Cromwell submission ID for a successful test of this PR is `bd10381c-53b3-4c67-a396-291135af0f6f`.


The following can be an alternative to moving the files, though it still needs to be tested.  

```
File output_file = basename(reads_path)  --> File output_file = reads_path
```

