### PR TITLE
Make LocalizeReads Optional in GatherSampleEvidence

### DIFF
--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -134,14 +134,11 @@ workflow GatherSampleEvidence {
   }
 
 
-  File reads_file_ = select_first([CramToBamReviseBase.bam_file, LocalizeReads.output_file])
-  File reads_index_ = select_first([CramToBamReviseBase.bam_index, LocalizeReads.output_index])
-
   if (revise_base) {
     call rb.CramToBamReviseBase {
       input:
-        cram_file = reads_file_,
-        cram_index = reads_index_,
+        cram_file = select_first([LocalizeReads.output_file, bam_or_cram_file]),
+        cram_index = select_first([LocalizeReads.output_index, bam_or_cram_index]),
         reference_fasta = reference_fasta,
         reference_index = reference_index,
         contiglist = select_first([primary_contigs_fai]),
@@ -152,6 +149,8 @@ workflow GatherSampleEvidence {
     }
   }
 
+  File reads_file_ = select_first([CramToBamReviseBase.bam_file, LocalizeReads.output_file])
+  File reads_index_ = select_first([CramToBamReviseBase.bam_index, LocalizeReads.output_index])
 
   if (collect_coverage || run_melt) {
     call cov.CollectCounts {

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -76,6 +76,11 @@ workflow GatherSampleEvidence {
     File? baseline_melt_vcf
     File? baseline_scramble_vcf
 
+
+    # Localize reads parameters
+    # set to true on default, skips localize_reads if set to false
+    Boolean run_localize_reads = true
+
     # Docker
     String sv_pipeline_docker
     String sv_base_mini_docker
@@ -303,7 +308,17 @@ workflow GatherSampleEvidence {
 
     Array[File]? sample_metrics_files = GatherSampleEvidenceMetrics.sample_metrics_files
   }
+
+  if (run_localize_reads){
+    call LocalizeReads{
+      input:
+        reads_path = bam_or_cram_file,
+        reads_index = bam_or_cram_index,
+        runtime_attr_override = runtime_attr_localize_reads
+    }
+  }
 }
+
 
 task LocalizeReads {
   input {

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -124,12 +124,15 @@ workflow GatherSampleEvidence {
   File bam_or_cram_index_ = select_first([bam_or_cram_index, bam_or_cram_file + index_ext_])
 
   # move the reads nearby -- handles requester_pays and makes cross-region transfers just once
-  call LocalizeReads {
+  if (run_localize_reads) {
+    call LocalizeReads {
     input:
       reads_path = bam_or_cram_file,
       reads_index = bam_or_cram_index_,
       runtime_attr_override = runtime_attr_localize_reads
+    }
   }
+
 
   if (revise_base) {
     call rb.CramToBamReviseBase {
@@ -307,15 +310,6 @@ workflow GatherSampleEvidence {
     File? wham_index = Whamg.index
 
     Array[File]? sample_metrics_files = GatherSampleEvidenceMetrics.sample_metrics_files
-  }
-
-  if (run_localize_reads){
-    call LocalizeReads{
-      input:
-        reads_path = bam_or_cram_file,
-        reads_index = bam_or_cram_index,
-        runtime_attr_override = runtime_attr_localize_reads
-    }
   }
 }
 

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -134,11 +134,14 @@ workflow GatherSampleEvidence {
   }
 
 
+  File reads_file_ = select_first([CramToBamReviseBase.bam_file, LocalizeReads.output_file])
+  File reads_index_ = select_first([CramToBamReviseBase.bam_index, LocalizeReads.output_index])
+
   if (revise_base) {
     call rb.CramToBamReviseBase {
       input:
-        cram_file = LocalizeReads.output_file,
-        cram_index = LocalizeReads.output_index,
+        cram_file = reads_file_,
+        cram_index = reads_index_,
         reference_fasta = reference_fasta,
         reference_index = reference_index,
         contiglist = select_first([primary_contigs_fai]),
@@ -149,8 +152,6 @@ workflow GatherSampleEvidence {
     }
   }
 
-  File reads_file_ = select_first([CramToBamReviseBase.bam_file, LocalizeReads.output_file])
-  File reads_index_ = select_first([CramToBamReviseBase.bam_index, LocalizeReads.output_index])
 
   if (collect_coverage || run_melt) {
     call cov.CollectCounts {

--- a/wdl/GatherSampleEvidenceBatch.wdl
+++ b/wdl/GatherSampleEvidenceBatch.wdl
@@ -64,6 +64,12 @@ workflow GatherSampleEvidenceBatch {
     File? baseline_melt_vcf
     File? baseline_scramble_vcf
 
+
+    # Localize reads parameters
+    # set to true on default, skips localize_reads if set to false
+    Boolean run_localize_reads = true
+
+
     # Docker
     String sv_pipeline_docker
     String sv_base_mini_docker
@@ -136,6 +142,7 @@ workflow GatherSampleEvidenceBatch {
         baseline_melt_vcf = baseline_melt_vcf,
         baseline_scramble_vcf = baseline_scramble_vcf,
         baseline_wham_vcf = baseline_wham_vcf,
+        run_localize_reads = run_localize_reads,
         sv_pipeline_docker = sv_pipeline_docker,
         sv_base_mini_docker = sv_base_mini_docker,
         samtools_cloud_docker = samtools_cloud_docker,


### PR DESCRIPTION
This pull request addresses issue [#585](https://github.com/broadinstitute/gatk-sv/issues/585). The LocalizeReads task was introduced to GatherSampleEvidence to simplify cases for CRAMs sourced from requester-pays and multi-regional buckets to simplify the code, but could be skipped in some cases for some cost and time savings. An optional boolean variable set to a default value of true to run LocalizeReads was added. When set to false, the LocalizeReads task is skipped. 
This passed validation with both womtool and cromshell against the reference panel.