### PR TITLE
Reduce SVConcordance memory usage

### DIFF
--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -2,7 +2,7 @@
   "name": "dockers",
   "cnmops_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/cnmops:2023-07-28-v0.28.1-beta-e70dfbd7",
   "condense_counts_docker": "us.gcr.io/broad-dsde-methods/tsharpe/gatk:4.2.6.1-57-g9e03432",
-  "gatk_docker": "us.gcr.io/broad-dsde-methods/markw/gatk:mw-sv-concordance-opt-1097258",
+  "gatk_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/gatk:2024-01-15-4.5.0.0-3-gb68fadc5f-NIGHTLY-SNAPSHOT",
   "gatk_docker_pesr_override": "us.gcr.io/broad-dsde-methods/tsharpe/gatk:4.2.6.1-57-g9e03432",
   "genomes_in_the_cloud_docker": "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "marketplace.gcr.io/google/ubuntu1804",

--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -2,7 +2,7 @@
   "name": "dockers",
   "cnmops_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/cnmops:2023-07-28-v0.28.1-beta-e70dfbd7",
   "condense_counts_docker": "us.gcr.io/broad-dsde-methods/tsharpe/gatk:4.2.6.1-57-g9e03432",
-  "gatk_docker": "us.gcr.io/broad-dsde-methods/markw/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT",
+  "gatk_docker": "us.gcr.io/broad-dsde-methods/markw/gatk:mw-sv-concordance-opt-1097258",
   "gatk_docker_pesr_override": "us.gcr.io/broad-dsde-methods/tsharpe/gatk:4.2.6.1-57-g9e03432",
   "genomes_in_the_cloud_docker": "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "marketplace.gcr.io/google/ubuntu1804",

--- a/inputs/values/dockers_azure.json
+++ b/inputs/values/dockers_azure.json
@@ -2,7 +2,7 @@
   "name": "dockers",
   "cnmops_docker": "vahid.azurecr.io/gatk-sv/cnmops:2023-07-28-v0.28.1-beta-e70dfbd7",
   "condense_counts_docker": "vahid.azurecr.io/tsharpe/gatk:4.2.6.1-57-g9e03432",
-  "gatk_docker": "vahid.azurecr.io/markw/gatk:2024-01-15-4.5.0.0-3-gb68fadc5f-NIGHTLY-SNAPSHOT",
+  "gatk_docker": "vahid.azurecr.io/gatk-sv/gatk:2024-01-15-4.5.0.0-3-gb68fadc5f-NIGHTLY-SNAPSHOT",
   "gatk_docker_pesr_override": "vahid.azurecr.io/tsharpe/gatk:4.2.6.1-57-g9e03432",
   "genomes_in_the_cloud_docker": "vahid.azurecr.io/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "vahid.azurecr.io/google/ubuntu1804",

--- a/inputs/values/dockers_azure.json
+++ b/inputs/values/dockers_azure.json
@@ -2,7 +2,7 @@
   "name": "dockers",
   "cnmops_docker": "vahid.azurecr.io/gatk-sv/cnmops:2023-07-28-v0.28.1-beta-e70dfbd7",
   "condense_counts_docker": "vahid.azurecr.io/tsharpe/gatk:4.2.6.1-57-g9e03432",
-  "gatk_docker": "vahid.azurecr.io/markw/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT",
+  "gatk_docker": "vahid.azurecr.io/markw/gatk:2024-01-15-4.5.0.0-3-gb68fadc5f-NIGHTLY-SNAPSHOT",
   "gatk_docker_pesr_override": "vahid.azurecr.io/tsharpe/gatk:4.2.6.1-57-g9e03432",
   "genomes_in_the_cloud_docker": "vahid.azurecr.io/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "vahid.azurecr.io/google/ubuntu1804",

--- a/wdl/SVConcordance.wdl
+++ b/wdl/SVConcordance.wdl
@@ -18,10 +18,8 @@ workflow SVConcordance {
 
     Float? java_mem_fraction
 
-    RuntimeAttr? runtime_attr_format_eval
-    RuntimeAttr? runtime_attr_format_truth
     RuntimeAttr? runtime_attr_sv_concordance
-    RuntimeAttr? runtime_attr_postprocess
+    RuntimeAttr? runtime_attr_sort_vcf
     RuntimeAttr? runtime_override_concat_shards
   }
 
@@ -30,19 +28,27 @@ workflow SVConcordance {
       input:
         eval_vcf=eval_vcf,
         truth_vcf=truth_vcf,
-        output_prefix="~{output_prefix}.concordance.~{contig}",
+        output_prefix="~{output_prefix}.concordance.~{contig}.unsorted",
         contig=contig,
         reference_dict=reference_dict,
         java_mem_fraction=java_mem_fraction,
         gatk_docker=gatk_docker,
         runtime_attr_override=runtime_attr_sv_concordance
     }
+
+    call tasks_cohort.SortVcf {
+      input:
+        vcf=SVConcordanceTask.out_unsorted,
+        outfile_prefix="~{output_prefix}.concordance.~{contig}.sorted",
+        sv_base_mini_docker=sv_base_mini_docker,
+        runtime_attr_override=runtime_attr_sort_vcf
+    }
   }
 
   call tasks_cohort.ConcatVcfs {
     input:
-      vcfs=SVConcordanceTask.out,
-      vcfs_idx=SVConcordanceTask.out_index,
+      vcfs=SortVcf.out,
+      vcfs_idx=SortVcf.out_index,
       naive=true,
       outfile_prefix="~{output_prefix}.concordance",
       sv_base_mini_docker=sv_base_mini_docker,
@@ -89,8 +95,7 @@ task SVConcordanceTask {
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 
   output {
-    File out = "~{output_prefix}.vcf.gz"
-    File out_index = "~{output_prefix}.vcf.gz.tbi"
+    File out_unsorted = "~{output_prefix}.vcf.gz"
   }
   command <<<
     set -euo pipefail
@@ -108,18 +113,15 @@ task SVConcordanceTask {
     JVM_MAX_MEM=$(getJavaMem MemTotal)
     echo "JVM memory: $JVM_MAX_MEM"
 
+    # As of 12/15/2023, the gatk docker contains an outdated version of bcftools so we sort in a subsequent task
     gatk --java-options "-Xmx${JVM_MAX_MEM}" SVConcordance \
       ~{"-L " + contig} \
       --sequence-dictionary ~{reference_dict} \
       --eval ~{eval_vcf} \
       --truth ~{truth_vcf} \
-      -O unsorted.vcf.gz \
+      -O ~{output_prefix}.vcf.gz \
       --do-not-sort \
       ~{additional_args}
-
-    mkdir tmp
-    bcftools sort --max-mem ${JVM_MAX_MEM}M -T tmp -Oz -o ~{output_prefix}.vcf.gz unsorted.vcf.gz
-    tabix ~{output_prefix}.vcf.gz
   >>>
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])

--- a/wdl/SVConcordance.wdl
+++ b/wdl/SVConcordance.wdl
@@ -81,7 +81,7 @@ task SVConcordanceTask {
   RuntimeAttr default_attr = object {
                                cpu_cores: 1,
                                mem_gb: 16,
-                               disk_gb: ceil(10 + size(eval_vcf, "GB") * 2 + size(truth_vcf, "GB")),
+                               disk_gb: ceil(10 + size(eval_vcf, "GB") * 4 + size(truth_vcf, "GB")),
                                boot_disk_gb: 10,
                                preemptible_tries: 3,
                                max_retries: 1
@@ -113,8 +113,13 @@ task SVConcordanceTask {
       --sequence-dictionary ~{reference_dict} \
       --eval ~{eval_vcf} \
       --truth ~{truth_vcf} \
-      -O ~{output_prefix}.vcf.gz \
+      -O unsorted.vcf.gz \
+      --do-not-sort \
       ~{additional_args}
+
+    mkdir tmp
+    bcftools sort --max-mem ${JVM_MAX_MEM}M -T tmp -Oz -o ~{output_prefix}.vcf.gz unsorted.vcf.gz
+    tabix ~{output_prefix}.vcf.gz
   >>>
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])


### PR DESCRIPTION
Updates WDL and GATK docker for SVConcordance following the GATK update [here](https://github.com/broadinstitute/gatk/pull/8623). 

Briefly, SVConcordance memory usage is reduced by sorting the VCF with `bcftools` rather than performing a sort within the tool itself (GATK does have some neat classes for spilling sorted collections to disk, but they would almost certainly be slower than bcftools for a full vcf sort).

Tested successfully on the `hgdp` cohort.