### PR TITLE
Find CN field for mCNVs in MainVcfQc without hard-coding order of format fields

### DIFF
--- a/inputs/templates/test/MainVcfQc/MainVcfQc.json.tmpl
+++ b/inputs/templates/test/MainVcfQc/MainVcfQc.json.tmpl
@@ -17,10 +17,5 @@
   "MainVcfQc.vcfs": [ {{ test_batch.clean_vcf | tojson }} ],
 
   "MainVcfQc.sv_per_shard": 2500,
-  "MainVcfQc.samples_per_shard": 600,
-
-  "MainVcfQc.runtime_override_plot_qc_per_family": {
-    "mem_gb": 15,
-    "disk_gb": 100
-  }
+  "MainVcfQc.samples_per_shard": 600
 }

--- a/inputs/templates/test/MainVcfQc/MainVcfQc.json.tmpl
+++ b/inputs/templates/test/MainVcfQc/MainVcfQc.json.tmpl
@@ -17,5 +17,10 @@
   "MainVcfQc.vcfs": [ {{ test_batch.clean_vcf | tojson }} ],
 
   "MainVcfQc.sv_per_shard": 2500,
-  "MainVcfQc.samples_per_shard": 600
+  "MainVcfQc.samples_per_shard": 600,
+
+  "MainVcfQc.runtime_override_plot_qc_per_family": {
+    "mem_gb": 15,
+    "disk_gb": 100
+  }
 }

--- a/inputs/templates/test/MainVcfQc/MainVcfQc.per_sample_benchmark.json.tmpl
+++ b/inputs/templates/test/MainVcfQc/MainVcfQc.per_sample_benchmark.json.tmpl
@@ -19,7 +19,7 @@
   "MainVcfQc.prefix": {{ test_batch.name | tojson }},
   "MainVcfQc.ped_file": {{ test_batch.ped_file | tojson }},
 
-  "MainVcfQc.vcfs": [ {{ test_batch.gq_filtered_vcf | tojson }} ],
+  "MainVcfQc.vcfs": [ {{ test_batch.genotype_filtered_vcf | tojson }} ],
   "MainVcfQc.sv_per_shard": 2500,
   "MainVcfQc.samples_per_shard": 600,
   "MainVcfQc.runtime_override_per_sample_benchmark_plot": {

--- a/inputs/templates/test/MainVcfQc/MainVcfQc.per_sample_benchmark.json.tmpl
+++ b/inputs/templates/test/MainVcfQc/MainVcfQc.per_sample_benchmark.json.tmpl
@@ -25,9 +25,5 @@
   "MainVcfQc.runtime_override_per_sample_benchmark_plot": {
     "mem_gb": 30,
     "disk_gb": 50
-  },
-  "MainVcfQc.runtime_override_plot_qc_per_family": {
-    "mem_gb": 15,
-    "disk_gb": 100
   }
 }

--- a/src/sv-pipeline/scripts/vcf_qc/collectQC.vcf_wide.sh
+++ b/src/sv-pipeline/scripts/vcf_qc/collectQC.vcf_wide.sh
@@ -180,13 +180,14 @@ ${QCTMP}/genotype_counts_per_SV.txt
 #Get genotype counts per variant for multi-alleleic CNVs
 grep -v ^# ${QCTMP}/input.vcf | grep "<CNV>" | \
 awk -v FS="\t" -v OFS="\t" -v nsamp=${nsamp} '{
- unknown=0; homref=0; het=0; homalt=0; other=0; for(i=10;i<=NF;i++) {
-  split($i,a,":"); split(a[1],GT,"[/|]");
-    if (a[10]==2) {homref++}
-    else if (a[10]==0) {homalt++}
+ unknown=0; homref=0; het=0; homalt=0; other=0;
+ split($9,format,":"); for (f=1;f<=length(format);f++) { if (format[f] == "CN") CN=f };
+ for(i=10;i<=NF;i++) {
+  split($i,a,":");
+    if (a[CN]==2) {homref++}
+    else if (a[CN]==0) {homalt++}
     else {het++} };
-  if (other > 0 || (nsamp==other+unknown)) {AC="NA"; AN="NA"; AF="NA"}
-  else {AC=(2*homalt)+het; AN=2*(nsamp-(unknown+other)); AF=AC/AN};
+  AC=(2*homalt)+het; AN=2*(nsamp-(unknown+other)); AF=AC/AN;
   print $3, nsamp-unknown, homref, het, homalt, other, unknown, AC, AN, AF }' >> \
 ${QCTMP}/genotype_counts_per_SV.txt
 

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -529,8 +529,8 @@ task PlotQcPerFamily {
   }
   Int random_seed_ = select_first([random_seed, 0])
   RuntimeAttr runtime_default = object {
-    mem_gb: 7.75,
-    disk_gb: 50,
+    mem_gb: 15,
+    disk_gb: 100,
     cpu_cores: 1,
     preemptible_tries: 1,
     max_retries: 1,


### PR DESCRIPTION
### Updates
* The order of the format fields was hard-coded in MainVcfQc, resulting in the CollectQcVcfWide script not using the CN field to evaluate genotypes for mCNVs when the order of the fields was updated after processing with GATK. This resulted in all mCNVs showing up as AF=0.5, creating a weird line in the AF plots. The script was updated to check the order of the format fields and use the CN field regardless of its position
* Memory increased for family QC plots. There are no families in the reference panel and HGDP requires more memory
* Filtered VCF key updated in template JSON

### Testing
* Ran MainVcfQc successfully on HGDP cleaned VCF & filtered (GATK-processed) VCF and verified that the AF varied for mCNVs in intermediate files and the weird line at 0.5 was absent from AF plots. Local testing also confirmed that the calculated AF was equal for the cleaned and filtered VCFs for a handful of example mCNVs.
* Validated all WDLs and JSONs with womtool and Terra validation script