### PR TITLE
Move cloud_sdk_docker to broad-dsde-methods

### DIFF
--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -22,7 +22,7 @@
   "igv_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/igv:mw-xz-fixes-2-b1be6a9",
   "duphold_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/duphold:mw-xz-fixes-2-b1be6a9",
   "vapor_docker": "us.gcr.io/broad-dsde-methods/eph/vapor:header-hash-2fc8f12",
-  "cloud_sdk_docker": "google/cloud-sdk",
+  "cloud_sdk_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/cloud-sdk:354.0.0-alpine",
   "pangenie_docker": "us.gcr.io/broad-dsde-methods/vjalili/pangenie:vj-127571f",
   "sv-base-virtual-env": "us.gcr.io/broad-dsde-methods/vjalili/sv-base-virtual-env:5994670",
   "cnmops-virtual-env": "us.gcr.io/broad-dsde-methods/vjalili/cnmops-virtual-env:5994670",


### PR DESCRIPTION
Prevents quota errors we've been seeing recently with the public image.