### PR TITLE
Disable MakeCohortVcfMetrics by default to avoid pesky resource errors

### DIFF
--- a/wdl/CleanVcf.wdl
+++ b/wdl/CleanVcf.wdl
@@ -33,7 +33,7 @@ workflow CleanVcf {
     String? gcs_project
 
     # Module metrics parameters
-    # Run module metrics workflow at the end - on by default
+    # Run module metrics workflow at the end - off by default to avoid resource errors
     Boolean? run_module_metrics
     String? sv_pipeline_base_docker  # required if run_module_metrics = true
     File? primary_contigs_list  # required if run_module_metrics = true
@@ -207,7 +207,7 @@ workflow CleanVcf {
 
   File cleaned_vcf_ = select_first([ConcatCleanedVcfs.concat_vcf, ConcatVcfsHail.merged_vcf])
 
-  Boolean run_module_metrics_ = if defined(run_module_metrics) then select_first([run_module_metrics]) else true
+  Boolean run_module_metrics_ = if defined(run_module_metrics) then select_first([run_module_metrics]) else false
   if (run_module_metrics_) {
     call metrics.MakeCohortVcfMetrics {
       input:


### PR DESCRIPTION
Multiple users have encountered out-of-memory errors in MakeCohortVcfMetrics with larger cohorts. It can be costly to rerun CleanVcf with updated resources for very large cohorts. This metrics collection is meant for development and is not necessary for users to run every time, so it can be safely disabled. An alternative would be to increase the default memory, but it is enough memory for the test set and unnecessary to run for large cohorts so this seems more efficient.