### PR TITLE
Remove CHR2 and END2 from INS in CleanVcf

### DIFF
--- a/src/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py
+++ b/src/sv-pipeline/scripts/format_svtk_vcf_for_gatk.py
@@ -137,7 +137,7 @@ def convert(record: pysam.VariantRecord,
     is_ddup = svtype == 'CPX' and 'dDUP' in record.info.get('CPX_TYPE', '')
     if svtype == 'BND' or svtype == 'INS' or svtype == 'CTX' or is_ddup:
         record.stop = record.start + 1
-    if svtype == 'CPX':
+    if svtype == 'CPX' or svtype == 'INS':
         if 'CHR2' in record.info:
             record.info.pop('CHR2')
         if 'END2' in record.info:

--- a/src/svtk/svtk/svfile.py
+++ b/src/svtk/svtk/svfile.py
@@ -107,7 +107,10 @@ class SVRecord(GSNode):
 
         chrA = record.chrom
         posA = record.pos
-        chrB = record.info['CHR2']
+        if 'CHR2' in record.info:
+            chrB = record.info['CHR2']
+        else:
+            chrB = chrA
         posB = record.stop
         name = record.id
 


### PR DESCRIPTION
### Updates
* Remove CHR2 and END2 from INS in CleanVcf. In most cases, these fields duplicate information in CHROM and POS. In other cases, they duplicate information in SOURCE. The inconsistent use is confusing and unnecessary.
* Do not require CHR2 in svtk. If CHR2 is not present, use CHR2=CHROM. This was causing issues when running svtk vcfcluster after removing CHR2 from INS.

### Testing
* Built updated docker image, ran CleanVcf, and verified CHR2 and END2 tags were not present in INS records
* Ran reclustering workflow with updated docker image and it resolved the error message about CHR2<CHROM and the subsequent error message about the missing CHR2 field
* Validated all WDLs and JSONs with womtool and Terra validation script