### PR TITLE
Update gatk_docker with CPX annotation changes to SVAnnotate

### DIFF
--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -2,7 +2,7 @@
   "name": "dockers",
   "cnmops_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/cnmops:2024-01-24-v0.28.4-beta-9debd6d7",
   "condense_counts_docker": "us.gcr.io/broad-dsde-methods/tsharpe/gatk:4.2.6.1-57-g9e03432",
-  "gatk_docker": "uus.gcr.io/broad-dsde-methods/eph/gatk:2024-02-16-4.5.0.0-8-gcfd4d87ec-NIGHTLY-SNAPSHOT",
+  "gatk_docker": "us.gcr.io/broad-dsde-methods/eph/gatk:2024-02-16-4.5.0.0-8-gcfd4d87ec-NIGHTLY-SNAPSHOT",
   "gatk_docker_pesr_override": "us.gcr.io/broad-dsde-methods/tsharpe/gatk:4.2.6.1-57-g9e03432",
   "genomes_in_the_cloud_docker": "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "marketplace.gcr.io/google/ubuntu1804",

--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -2,7 +2,7 @@
   "name": "dockers",
   "cnmops_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/cnmops:2024-01-24-v0.28.4-beta-9debd6d7",
   "condense_counts_docker": "us.gcr.io/broad-dsde-methods/tsharpe/gatk:4.2.6.1-57-g9e03432",
-  "gatk_docker": "us.gcr.io/broad-dsde-methods/eph/gatk:2024-01-29-4.5.0.0-5-g2d50cf8b3-NIGHTLY-SNAPSHOT",
+  "gatk_docker": "uus.gcr.io/broad-dsde-methods/eph/gatk:2024-02-16-4.5.0.0-8-gcfd4d87ec-NIGHTLY-SNAPSHOT",
   "gatk_docker_pesr_override": "us.gcr.io/broad-dsde-methods/tsharpe/gatk:4.2.6.1-57-g9e03432",
   "genomes_in_the_cloud_docker": "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "marketplace.gcr.io/google/ubuntu1804",

--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -2,7 +2,7 @@
   "name": "dockers",
   "cnmops_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/cnmops:2024-01-24-v0.28.4-beta-9debd6d7",
   "condense_counts_docker": "us.gcr.io/broad-dsde-methods/tsharpe/gatk:4.2.6.1-57-g9e03432",
-  "gatk_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/gatk:2024-01-15-4.5.0.0-3-gb68fadc5f-NIGHTLY-SNAPSHOT",
+  "gatk_docker": "us.gcr.io/broad-dsde-methods/eph/gatk:2024-01-29-4.5.0.0-5-g2d50cf8b3-NIGHTLY-SNAPSHOT",
   "gatk_docker_pesr_override": "us.gcr.io/broad-dsde-methods/tsharpe/gatk:4.2.6.1-57-g9e03432",
   "genomes_in_the_cloud_docker": "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "marketplace.gcr.io/google/ubuntu1804",

--- a/inputs/values/dockers_azure.json
+++ b/inputs/values/dockers_azure.json
@@ -2,7 +2,7 @@
   "name": "dockers",
   "cnmops_docker": "vahid.azurecr.io/gatk-sv/cnmops:2024-01-24-v0.28.4-beta-9debd6d7",
   "condense_counts_docker": "vahid.azurecr.io/tsharpe/gatk:4.2.6.1-57-g9e03432",
-  "gatk_docker": "vahid.azurecr.io/gatk-sv/gatk:2024-01-15-4.5.0.0-3-gb68fadc5f-NIGHTLY-SNAPSHOT",
+  "gatk_docker": "vahid.azurecr.io/gatk-sv/gatk:2024-01-29-4.5.0.0-5-g2d50cf8b3-NIGHTLY-SNAPSHOT",
   "gatk_docker_pesr_override": "vahid.azurecr.io/tsharpe/gatk:4.2.6.1-57-g9e03432",
   "genomes_in_the_cloud_docker": "vahid.azurecr.io/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "vahid.azurecr.io/google/ubuntu1804",

--- a/inputs/values/dockers_azure.json
+++ b/inputs/values/dockers_azure.json
@@ -2,7 +2,7 @@
   "name": "dockers",
   "cnmops_docker": "vahid.azurecr.io/gatk-sv/cnmops:2024-01-24-v0.28.4-beta-9debd6d7",
   "condense_counts_docker": "vahid.azurecr.io/tsharpe/gatk:4.2.6.1-57-g9e03432",
-  "gatk_docker": "vahid.azurecr.io/gatk-sv/gatk:2024-01-29-4.5.0.0-5-g2d50cf8b3-NIGHTLY-SNAPSHOT",
+  "gatk_docker": "vahid.azurecr.io/gatk-sv/gatk:2024-02-16-4.5.0.0-8-gcfd4d87ec-NIGHTLY-SNAPSHOT",
   "gatk_docker_pesr_override": "vahid.azurecr.io/tsharpe/gatk:4.2.6.1-57-g9e03432",
   "genomes_in_the_cloud_docker": "vahid.azurecr.io/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "vahid.azurecr.io/google/ubuntu1804",


### PR DESCRIPTION
Updates:
* SVAnnotate was [recently updated](https://github.com/broadinstitute/gatk/pull/8516) to improve functional consequence annotation for complex SVs
* The GATK docker for GCP and Azure is updated in this PR to a recent nightly GATK snapshot including the latest changes to SVAnnotate

Testing:
* AnnotateVcf WDL & JSON validated with womtool
* Tested AnnotateVcf with updated gatk_docker on GCP cromwell and verified that PREDICTED_PARTIAL_DISPERSED_DUP was present in the header and in INFO for some variants, indicating that the latest changes to SVAnnotate were applied

Update 2/23/24:
* Updated again for [latest changes](https://github.com/broadinstitute/gatk/pull/8693) to SVAnnotate, tested in gnomAD data