### PR TITLE
Change default behavior of GatherSampleEvidence to skip running module metrics

### DIFF
--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -81,7 +81,7 @@ workflow GatherSampleEvidence {
 
     # Module metrics parameters
     # Run module metrics workflow at the end - on by default
-    Boolean run_module_metrics = true
+    Boolean run_module_metrics = false
     File? primary_contigs_fai # required if run_module_metrics = true
     String? sv_pipeline_base_docker  # required if run_module_metrics = true
     File? baseline_manta_vcf # baseline files are optional for metrics workflow


### PR DESCRIPTION
The `GatherSampleEvidence` workflow is set to run `GatherSampleEvidenceMetrics` by default. However, running that task requires setting values for the optional inputs `primary_contigs_fai` and `sv_pipeline_base_docker`. Therefore, the `GatherSampleEvidence` workflow currently fails if only the required input is provided. 

Since WDL does not support making the optional inputs as required w.r.t to the value of another argument, and Terra UI lacks features to hint to a user about such a chain of requirements, in-line comments in code seem the only option, as it is implemented. However, in-code comments are less user-friendly and should be reserved for developers and power users only.

Skipping to run this task as a default behavior results in the successful execution of the workflow if only the required input is provided seems to be a better design and improved UX. 