### PR TITLE
Replace `sv_pipeline_base_docker` with `sv_pipeline_docker`

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CleanVcf.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CleanVcf.SingleBatch.json.tmpl
@@ -11,7 +11,6 @@
   "CleanVcf.clean_vcf5_records_per_shard": 5000,
 
   "CleanVcf.primary_contigs_list": "${workspace.primary_contigs_list}",
-  "CleanVcf.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
 
   "CleanVcf.linux_docker": "${workspace.linux_docker}",
   "CleanVcf.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CleanVcf.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CleanVcf.json.tmpl
@@ -11,7 +11,6 @@
   "CleanVcf.clean_vcf5_records_per_shard": 5000,
 
   "CleanVcf.primary_contigs_list": "${workspace.primary_contigs_list}",
-  "CleanVcf.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
 
   "CleanVcf.linux_docker": "${workspace.linux_docker}",
   "CleanVcf.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ClusterBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ClusterBatch.json.tmpl
@@ -18,7 +18,6 @@
   "ClusterBatch.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
   "ClusterBatch.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
   "ClusterBatch.gatk_docker": "${workspace.gatk_docker}",
-  "ClusterBatch.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
   "ClusterBatch.linux_docker": "${workspace.linux_docker}",
 
   "ClusterBatch.batch": "${this.sample_set_id}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GatherSampleEvidence.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GatherSampleEvidence.json.tmpl
@@ -27,7 +27,6 @@
   "GatherSampleEvidence.cloud_sdk_docker": "${workspace.cloud_sdk_docker}",
 
   "GatherSampleEvidence.primary_contigs_fai": "${workspace.primary_contigs_fai}",
-  "GatherSampleEvidence.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
 
   "GatherSampleEvidence.bam_or_cram_file": "${this.bam_or_cram_file}",
   "GatherSampleEvidence.sample_id": "${this.sample_id}"

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenerateBatchMetrics.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenerateBatchMetrics.json.tmpl
@@ -3,7 +3,6 @@
   "GenerateBatchMetrics.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",
   "GenerateBatchMetrics.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
   "GenerateBatchMetrics.sv_base_docker": "${workspace.sv_base_docker}",
-  "GenerateBatchMetrics.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
   "GenerateBatchMetrics.linux_docker" : "${workspace.linux_docker}",
 
   "GenerateBatchMetrics.BAF_split_size": "10000",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenotypeBatch.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenotypeBatch.SingleBatch.json.tmpl
@@ -12,7 +12,6 @@
   "GenotypeBatch.ref_dict": "${workspace.reference_dict}",
 
   "GenotypeBatch.primary_contigs_list": "${workspace.primary_contigs_list}",
-  "GenotypeBatch.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
 
   "GenotypeBatch.batch": "${this.sample_set_id}",
   "GenotypeBatch.rf_cutoffs": "${this.cutoffs}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenotypeBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenotypeBatch.json.tmpl
@@ -12,7 +12,6 @@
   "GenotypeBatch.ref_dict": "${workspace.reference_dict}",
 
   "GenotypeBatch.primary_contigs_list": "${workspace.primary_contigs_list}",
-  "GenotypeBatch.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
 
   "GenotypeBatch.batch": "${this.sample_set_id}",
   "GenotypeBatch.rf_cutoffs": "${this.cutoffs}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MakeCohortVcf.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MakeCohortVcf.SingleBatch.json.tmpl
@@ -34,7 +34,6 @@
   "MakeCohortVcf.sv_pipeline_qc_docker": "${workspace.sv_pipeline_qc_docker}",
 
   "MakeCohortVcf.primary_contigs_list": "${workspace.primary_contigs_list}",
-  "MakeCohortVcf.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
 
   "MakeCohortVcf.chr_x": "${workspace.chr_x}",
   "MakeCohortVcf.chr_y": "${workspace.chr_y}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MakeCohortVcf.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MakeCohortVcf.json.tmpl
@@ -34,7 +34,6 @@
   "MakeCohortVcf.sv_pipeline_qc_docker": "${workspace.sv_pipeline_qc_docker}",
 
   "MakeCohortVcf.primary_contigs_list": "${workspace.primary_contigs_list}",
-  "MakeCohortVcf.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
 
   "MakeCohortVcf.chr_x": "${workspace.chr_x}",
   "MakeCohortVcf.chr_y": "${workspace.chr_y}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/RegenotypeCNVs.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/RegenotypeCNVs.SingleBatch.json.tmpl
@@ -1,6 +1,5 @@
 {
   "RegenotypeCNVs.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",
-  "RegenotypeCNVs.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
   "RegenotypeCNVs.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
   "RegenotypeCNVs.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
   "RegenotypeCNVs.n_RdTest_bins": "100000",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/RegenotypeCNVs.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/RegenotypeCNVs.json.tmpl
@@ -1,6 +1,5 @@
 {
   "RegenotypeCNVs.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",
-  "RegenotypeCNVs.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
   "RegenotypeCNVs.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
   "RegenotypeCNVs.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
   "RegenotypeCNVs.n_RdTest_bins": "100000",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/TrainGCNV.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/TrainGCNV.json.tmpl
@@ -62,5 +62,5 @@
   "TrainGCNV.samples": "${this.samples.sample_id}",
 
   "TrainGCNV.n_samples_subsample": 100,
-  "TrainGCNV.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}"
+  "TrainGCNV.sv_pipeline_docker": "${workspace.sv_pipeline_docker}"
 }

--- a/inputs/templates/terra_workspaces/cohort_mode/workspace.tsv.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workspace.tsv.tmpl
@@ -10,7 +10,6 @@ manta_docker	{{ dockers.manta_docker }}
 samtools_cloud_docker	{{ dockers.samtools_cloud_docker }}
 sv_base_docker	{{ dockers.sv_base_docker }}
 sv_base_mini_docker	{{ dockers.sv_base_mini_docker }}
-sv_pipeline_base_docker	{{ dockers.sv_pipeline_base_docker }}
 sv_pipeline_docker	{{ dockers.sv_pipeline_docker }}
 sv_pipeline_hail_docker	{{ dockers.sv_pipeline_hail_docker }}
 sv_pipeline_updates_docker	{{ dockers.sv_pipeline_updates_docker }}

--- a/inputs/templates/terra_workspaces/single_sample/GATKSVPipelineSingleSample.no_melt.json.tmpl
+++ b/inputs/templates/terra_workspaces/single_sample/GATKSVPipelineSingleSample.no_melt.json.tmpl
@@ -33,7 +33,6 @@
   "GATKSVPipelineSingleSample.linux_docker" : "${workspace.linux_docker}",
   "GATKSVPipelineSingleSample.manta_docker": "${workspace.manta_docker}",
   "GATKSVPipelineSingleSample.sv_base_docker": "${workspace.sv_base_docker}",
-  "GATKSVPipelineSingleSample.sv_pipeline_base_docker": "${workspace.sv_pipeline_base_docker}",
   "GATKSVPipelineSingleSample.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
   "GATKSVPipelineSingleSample.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
   "GATKSVPipelineSingleSample.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",

--- a/inputs/templates/terra_workspaces/single_sample/workspace.tsv.tmpl
+++ b/inputs/templates/terra_workspaces/single_sample/workspace.tsv.tmpl
@@ -9,7 +9,6 @@ manta_docker	{{ dockers.manta_docker }}
 samtools_cloud_docker	{{ dockers.samtools_cloud_docker }}
 sv_base_docker	{{ dockers.sv_base_docker }}
 sv_base_mini_docker	{{ dockers.sv_base_mini_docker }}
-sv_pipeline_base_docker	{{ dockers.sv_pipeline_base_docker }}
 sv_pipeline_docker	{{ dockers.sv_pipeline_docker }}
 sv_pipeline_hail_docker	{{ dockers.sv_pipeline_hail_docker }}
 sv_pipeline_updates_docker	{{ dockers.sv_pipeline_updates_docker }}

--- a/inputs/templates/test/ClusterBatch/ClusterBatch.json.tmpl
+++ b/inputs/templates/test/ClusterBatch/ClusterBatch.json.tmpl
@@ -20,7 +20,6 @@
   "ClusterBatch.depth_clustering_algorithm": "SINGLE_LINKAGE",
 
   "ClusterBatch.gatk_docker": {{ dockers.gatk_docker | tojson }},
-  "ClusterBatch.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
   "ClusterBatch.linux_docker": {{ dockers.linux_docker | tojson }},
 
   "ClusterBatch.batch": {{ test_batch.name | tojson }},

--- a/inputs/templates/test/FilterBatch/FilterBatch.json.tmpl
+++ b/inputs/templates/test/FilterBatch/FilterBatch.json.tmpl
@@ -6,7 +6,6 @@
   "FilterBatch.outlier_cutoff_nIQR": "10000",
 
   "FilterBatch.primary_contigs_list": {{ reference_resources.primary_contigs_list | tojson }},
-  "FilterBatch.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
   "FilterBatch.ped_file": {{ test_batch.ped_file | tojson }},
 
   "FilterBatch.batch": {{ test_batch.name | tojson }},

--- a/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.FromSampleEvidence.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.FromSampleEvidence.json.tmpl
@@ -29,7 +29,6 @@
   "GATKSVPipelineBatch.condense_counts_docker" : {{ dockers.condense_counts_docker | tojson }},
   "GATKSVPipelineBatch.genomes_in_the_cloud_docker" : {{ dockers.genomes_in_the_cloud_docker | tojson }},
   "GATKSVPipelineBatch.sv_base_docker": {{ dockers.sv_base_docker | tojson }},
-  "GATKSVPipelineBatch.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
   "GATKSVPipelineBatch.sv_base_mini_docker": {{ dockers.sv_base_mini_docker | tojson }},
   "GATKSVPipelineBatch.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
   "GATKSVPipelineBatch.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},

--- a/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
@@ -23,7 +23,6 @@
   "GATKSVPipelineBatch.genomes_in_the_cloud_docker" : {{ dockers.genomes_in_the_cloud_docker | tojson }},
   "GATKSVPipelineBatch.scramble_docker" : {{ dockers.scramble_docker | tojson }},
   "GATKSVPipelineBatch.sv_base_docker": {{ dockers.sv_base_docker | tojson }},
-  "GATKSVPipelineBatch.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
   "GATKSVPipelineBatch.sv_base_mini_docker": {{ dockers.sv_base_mini_docker | tojson }},
   "GATKSVPipelineBatch.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
   "GATKSVPipelineBatch.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},

--- a/inputs/templates/test/GATKSVPipelinePhase1/GATKSVPipelinePhase1.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelinePhase1/GATKSVPipelinePhase1.json.tmpl
@@ -1,7 +1,6 @@
 {
   "GATKSVPipelinePhase1.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
   "GATKSVPipelinePhase1.sv_base_docker": {{ dockers.sv_base_docker | tojson }},
-  "GATKSVPipelinePhase1.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
   "GATKSVPipelinePhase1.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
   "GATKSVPipelinePhase1.sv_pipeline_rdtest_docker": {{ dockers.sv_pipeline_rdtest_docker | tojson }},
   "GATKSVPipelinePhase1.sv_pipeline_qc_docker": {{ dockers.sv_pipeline_qc_docker | tojson }},

--- a/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.json.tmpl
@@ -31,7 +31,6 @@
   "GATKSVPipelineSingleSample.melt_docker" : {{ dockers.melt_docker | tojson }},
   "GATKSVPipelineSingleSample.scramble_docker" : {{ dockers.scramble_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_base_docker": {{ dockers.sv_base_docker | tojson }},
-  "GATKSVPipelineSingleSample.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_base_mini_docker": {{ dockers.sv_base_mini_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},

--- a/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.no_melt.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.no_melt.json.tmpl
@@ -34,7 +34,6 @@
   "GATKSVPipelineSingleSample.melt_docker": {{ dockers.melt_docker | tojson }},
   "GATKSVPipelineSingleSample.scramble_docker": {{ dockers.scramble_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_base_docker": {{ dockers.sv_base_docker | tojson }},
-  "GATKSVPipelineSingleSample.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_base_mini_docker": {{ dockers.sv_base_mini_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},

--- a/inputs/templates/test/GatherSampleEvidence/GatherSampleEvidence.json.tmpl
+++ b/inputs/templates/test/GatherSampleEvidence/GatherSampleEvidence.json.tmpl
@@ -21,7 +21,6 @@
   "GatherSampleEvidence.samtools_cloud_docker": {{ dockers.samtools_cloud_docker | tojson }},
   "GatherSampleEvidence.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
   "GatherSampleEvidence.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
-  "GatherSampleEvidence.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
   "GatherSampleEvidence.manta_docker": {{ dockers.manta_docker | tojson }},
   "GatherSampleEvidence.melt_docker" : {{ dockers.melt_docker | tojson }},
   "GatherSampleEvidence.scramble_docker" : {{ dockers.scramble_docker | tojson }},

--- a/inputs/templates/test/GatherSampleEvidenceBatch/GatherSampleEvidenceBatch.json.tmpl
+++ b/inputs/templates/test/GatherSampleEvidenceBatch/GatherSampleEvidenceBatch.json.tmpl
@@ -29,7 +29,6 @@
 
   "GatherSampleEvidenceBatch.batch": {{ test_batch.name | tojson }},
   "GatherSampleEvidenceBatch.primary_contigs_fai": {{ reference_resources.primary_contigs_fai | tojson }},
-  "GatherSampleEvidenceBatch.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
   "GatherSampleEvidenceBatch.linux_docker": {{ dockers.linux_docker | tojson }},
 
   "GatherSampleEvidenceBatch.bam_or_cram_files": {{ test_batch.bam_or_cram_files | tojson }},

--- a/inputs/templates/test/GenerateBatchMetrics/GenerateBatchMetrics.json.tmpl
+++ b/inputs/templates/test/GenerateBatchMetrics/GenerateBatchMetrics.json.tmpl
@@ -3,7 +3,6 @@
   "GenerateBatchMetrics.sv_pipeline_rdtest_docker": {{ dockers.sv_pipeline_rdtest_docker | tojson }},
   "GenerateBatchMetrics.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
   "GenerateBatchMetrics.sv_base_docker": {{ dockers.sv_base_docker | tojson }},
-  "GenerateBatchMetrics.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
   "GenerateBatchMetrics.linux_docker" : {{ dockers.linux_docker | tojson }},
 
   "GenerateBatchMetrics.BAF_split_size": "10000",

--- a/inputs/templates/test/GenotypeBatch/GenotypeBatch.json.tmpl
+++ b/inputs/templates/test/GenotypeBatch/GenotypeBatch.json.tmpl
@@ -12,7 +12,6 @@
   "GenotypeBatch.ref_dict": {{ reference_resources.reference_dict | tojson }},
 
   "GenotypeBatch.primary_contigs_list": {{ reference_resources.primary_contigs_list | tojson }},
-  "GenotypeBatch.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
 
   "GenotypeBatch.batch": {{ test_batch.name | tojson }},
   "GenotypeBatch.rf_cutoffs": {{ test_batch.cutoffs | tojson }},

--- a/inputs/templates/test/MakeCohortVcf/CleanVcf.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/CleanVcf.json.tmpl
@@ -11,7 +11,6 @@
   "CleanVcf.clean_vcf5_records_per_shard": 5000,
 
   "CleanVcf.primary_contigs_list": {{ reference_resources.primary_contigs_list | tojson }},
-  "CleanVcf.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
 
   "CleanVcf.linux_docker": {{ dockers.linux_docker | tojson }},
   "CleanVcf.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},

--- a/inputs/templates/test/MakeCohortVcf/MakeCohortVcf.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/MakeCohortVcf.json.tmpl
@@ -29,7 +29,6 @@
   "MakeCohortVcf.random_seed": 0,
 
   "MakeCohortVcf.primary_contigs_list": {{ reference_resources.primary_contigs_list | tojson }},
-  "MakeCohortVcf.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
 
   "MakeCohortVcf.linux_docker": {{ dockers.linux_docker | tojson }},
   "MakeCohortVcf.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},

--- a/inputs/templates/test/RegenotypeCNVs/RegenotypeCNVs.json.tmpl
+++ b/inputs/templates/test/RegenotypeCNVs/RegenotypeCNVs.json.tmpl
@@ -1,6 +1,5 @@
 {
   "RegenotypeCNVs.sv_pipeline_rdtest_docker": {{ dockers.sv_pipeline_rdtest_docker | tojson }},
-  "RegenotypeCNVs.sv_pipeline_base_docker": {{ dockers.sv_pipeline_base_docker | tojson }},
   "RegenotypeCNVs.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
   "RegenotypeCNVs.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
   "RegenotypeCNVs.n_RdTest_bins": "100000",

--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -12,7 +12,6 @@
   "samtools_cloud_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/samtools-cloud:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_base_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:2024-01-24-v0.28.4-beta-9debd6d7",
-  "sv_pipeline_base_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_hail_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_updates_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",

--- a/inputs/values/dockers_azure.json
+++ b/inputs/values/dockers_azure.json
@@ -12,7 +12,6 @@
   "samtools_cloud_docker": "vahid.azurecr.io/gatk-sv/samtools-cloud:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_base_docker": "vahid.azurecr.io/gatk-sv/sv-base:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_base_mini_docker": "vahid.azurecr.io/gatk-sv/sv-base-mini:2024-01-24-v0.28.4-beta-9debd6d7",
-  "sv_pipeline_base_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_hail_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_updates_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",

--- a/wdl/CleanVcf.wdl
+++ b/wdl/CleanVcf.wdl
@@ -35,7 +35,6 @@ workflow CleanVcf {
     # Module metrics parameters
     # Run module metrics workflow at the end - on by default
     Boolean? run_module_metrics
-    String? sv_pipeline_base_docker  # required if run_module_metrics = true
     File? primary_contigs_list  # required if run_module_metrics = true
     File? baseline_cluster_vcf  # baseline files are optional for metrics workflow
     File? baseline_complex_resolve_vcf
@@ -222,7 +221,7 @@ workflow CleanVcf {
         baseline_cleaned_vcf = baseline_cleaned_vcf,
         contig_list = select_first([primary_contigs_list]),
         linux_docker = linux_docker,
-        sv_pipeline_base_docker = select_first([sv_pipeline_base_docker]),
+        sv_pipeline_docker = sv_pipeline_docker,
         sv_base_mini_docker = sv_base_mini_docker
     }
   }

--- a/wdl/ClusterBatch.wdl
+++ b/wdl/ClusterBatch.wdl
@@ -56,7 +56,6 @@ workflow ClusterBatch {
     # Run module metrics workflow at the end - on by default
     Boolean? run_module_metrics
     String? linux_docker  # required if run_module_metrics = true
-    String? sv_pipeline_base_docker  # required if run_module_metrics = true
     File? baseline_depth_vcf  # baseline files are optional for metrics workflow
     File? baseline_manta_vcf
     File? baseline_wham_vcf
@@ -284,7 +283,7 @@ workflow ClusterBatch {
         baseline_melt_vcf = baseline_melt_vcf,
         contig_list = select_first([contig_list]),
         sv_base_mini_docker = sv_base_mini_docker,
-        sv_pipeline_base_docker = select_first([sv_pipeline_base_docker]),
+        sv_pipeline_docker = sv_pipeline_docker,
         linux_docker = select_first([linux_docker])
     }
   }

--- a/wdl/ClusterBatchMetrics.wdl
+++ b/wdl/ClusterBatchMetrics.wdl
@@ -22,7 +22,7 @@ workflow ClusterBatchMetrics {
 
     File contig_list
     String? sv_base_mini_docker  # required if not providing samples array
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     String linux_docker
 
     RuntimeAttr? runtime_attr_sample_ids_from_vcf
@@ -51,7 +51,7 @@ workflow ClusterBatchMetrics {
       prefix = "depth_clustered",
       types = "DEL,DUP",
       contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_depth_metrics
   }
   if (defined(manta_vcf)) {
@@ -63,7 +63,7 @@ workflow ClusterBatchMetrics {
         prefix = "manta_clustered",
         types = "DEL,DUP,INS,INV,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_manta_metrics
     }
   }
@@ -76,7 +76,7 @@ workflow ClusterBatchMetrics {
         prefix = "melt_clustered",
         types = "INS",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_melt_metrics
     }
   }
@@ -89,7 +89,7 @@ workflow ClusterBatchMetrics {
         prefix = "scramble_clustered",
         types = "INS",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_scramble_metrics
     }
   }
@@ -102,7 +102,7 @@ workflow ClusterBatchMetrics {
         prefix = "wham_clustered",
         types = "DEL,DUP",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_wham_metrics
     }
   }

--- a/wdl/CombineReassess.wdl
+++ b/wdl/CombineReassess.wdl
@@ -10,7 +10,6 @@ workflow CombineReassess {
     Array[File] vcfs 
     Int min_var_per_sample_outlier_threshold
     Float regeno_sample_overlap
-    String sv_pipeline_base_docker
     String sv_pipeline_docker
     RuntimeAttr? runtime_attr_vcf2bed
     RuntimeAttr? runtime_attr_merge_list_creassess
@@ -33,7 +32,7 @@ workflow CombineReassess {
       min_var_per_sample_outlier_threshold = min_var_per_sample_outlier_threshold,
       regeno_sample_overlap = regeno_sample_overlap,
       runtime_attr_override = runtime_attr_merge_list_creassess,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_docker = sv_pipeline_docker
   }
   output {
     File regeno_variants = MergeList.regeno_var
@@ -88,7 +87,7 @@ task MergeList {
     File regeno_sample_ids_lookup
     Int min_var_per_sample_outlier_threshold
     Float regeno_sample_overlap
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
   RuntimeAttr default_attr = object {
@@ -175,7 +174,7 @@ task MergeList {
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
     disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }

--- a/wdl/FilterBatch.wdl
+++ b/wdl/FilterBatch.wdl
@@ -23,7 +23,6 @@ workflow FilterBatch {
     # Module metrics parameters
     # Run module metrics workflow at the end - on by default
     Boolean? run_module_metrics
-    String? sv_pipeline_base_docker  # required if run_module_metrics = true
     File? primary_contigs_list  # required if run_module_metrics = true
     File? ped_file  # required if run_module_metrics = true
     File? baseline_filtered_depth_vcf  # baseline files are optional for metrics workflow
@@ -120,7 +119,7 @@ workflow FilterBatch {
         baseline_filtered_depth_vcf = baseline_filtered_depth_vcf,
         contig_list = select_first([primary_contigs_list]),
         linux_docker = linux_docker,
-        sv_pipeline_base_docker = select_first([sv_pipeline_base_docker]),
+        sv_pipeline_docker = sv_pipeline_docker,
         sv_base_mini_docker = sv_base_mini_docker
     }
   }

--- a/wdl/FilterBatchMetrics.wdl
+++ b/wdl/FilterBatchMetrics.wdl
@@ -21,7 +21,7 @@ workflow FilterBatchMetrics {
 
     File contig_list
     String linux_docker
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     String sv_base_mini_docker
 
     RuntimeAttr? runtime_attr_subset_ped
@@ -41,7 +41,7 @@ workflow FilterBatchMetrics {
       prefix = "filtered_pesr",
       types = "DEL,DUP,INS,INV,BND",
       contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_pesr_vcf_metrics
   }
 
@@ -53,7 +53,7 @@ workflow FilterBatchMetrics {
       prefix = "filtered_depth",
       types = "DEL,DUP",
       contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_depth_vcf_metrics
   }
 
@@ -72,7 +72,7 @@ workflow FilterBatchMetrics {
       outlier_list = outlier_list,
       filtered_ped_file = SubsetPedFile.ped_subset_file,
       samples = samples,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_cutoff_outlier_metrics
   }
 

--- a/wdl/GATKSVPipelineBatch.wdl
+++ b/wdl/GATKSVPipelineBatch.wdl
@@ -92,7 +92,6 @@ workflow GATKSVPipelineBatch {
     String sv_pipeline_hail_docker
     String sv_pipeline_updates_docker
     String sv_pipeline_rdtest_docker
-    String sv_pipeline_base_docker
     String sv_pipeline_qc_docker
     String linux_docker
     String cnmops_docker
@@ -142,7 +141,6 @@ workflow GATKSVPipelineBatch {
         run_module_metrics = run_sampleevidence_metrics,
         primary_contigs_fai = primary_contigs_fai,
         batch = name,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
         linux_docker = linux_docker,
         sv_pipeline_docker=sv_pipeline_docker,
         sv_base_mini_docker=sv_base_mini_docker,
@@ -227,7 +225,6 @@ workflow GATKSVPipelineBatch {
       primary_contigs_list = primary_contigs_list,
       sv_base_mini_docker=sv_base_mini_docker,
       sv_base_docker=sv_base_docker,
-      sv_pipeline_base_docker=sv_pipeline_base_docker,
       sv_pipeline_docker=sv_pipeline_docker,
       sv_pipeline_rdtest_docker=sv_pipeline_rdtest_docker,
       sv_pipeline_qc_docker=sv_pipeline_qc_docker,
@@ -256,7 +253,6 @@ workflow GATKSVPipelineBatch {
       ref_dict=reference_dict,
       run_module_metrics = run_genotypebatch_metrics,
       primary_contigs_list = primary_contigs_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
       sv_base_mini_docker=sv_base_mini_docker,
       sv_pipeline_docker=sv_pipeline_docker,
       sv_pipeline_rdtest_docker=sv_pipeline_rdtest_docker,
@@ -278,8 +274,7 @@ workflow GATKSVPipelineBatch {
       regeno_coverage_medians=[GenotypeBatch.regeno_coverage_medians],
       sv_base_mini_docker=sv_base_mini_docker,
       sv_pipeline_docker=sv_pipeline_docker,
-      sv_pipeline_rdtest_docker=sv_pipeline_rdtest_docker,
-      sv_pipeline_base_docker=sv_pipeline_base_docker
+      sv_pipeline_rdtest_docker=sv_pipeline_rdtest_docker
   }
   
 
@@ -307,7 +302,6 @@ workflow GATKSVPipelineBatch {
       median_coverage_files=[GATKSVPipelinePhase1.median_cov],
       run_module_metrics = run_makecohortvcf_metrics,
       primary_contigs_list = primary_contigs_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
       linux_docker=linux_docker,
       sv_pipeline_docker=sv_pipeline_docker,
       sv_pipeline_hail_docker=sv_pipeline_hail_docker,
@@ -340,7 +334,7 @@ workflow GATKSVPipelineBatch {
         samples = samples,
         test_metrics = CatBatchMetrics.out,
         base_metrics = CatBaselineMetrics.out,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_plot_metrics
     }
   }
@@ -350,7 +344,7 @@ workflow GATKSVPipelineBatch {
       name = name,
       metrics = CatBatchMetrics.out,
       qc_definitions = qc_definitions,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_docker = sv_pipeline_docker
   }
 
   scatter (i in range(length(samples))) {

--- a/wdl/GATKSVPipelinePhase1.wdl
+++ b/wdl/GATKSVPipelinePhase1.wdl
@@ -26,7 +26,6 @@ workflow GATKSVPipelinePhase1 {
 
     String sv_base_mini_docker
     String sv_base_docker
-    String sv_pipeline_base_docker
     String sv_pipeline_docker
     String sv_pipeline_rdtest_docker
     String sv_pipeline_qc_docker
@@ -333,8 +332,7 @@ workflow GATKSVPipelinePhase1 {
       runtime_attr_postprocess = runtime_attr_postprocess,
       runtime_attr_explode = runtime_attr_explode,
       run_module_metrics = run_batchevidence_metrics,
-      primary_contigs_list = primary_contigs_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      primary_contigs_list = primary_contigs_list
   }
 
   call clusterbatch.ClusterBatch as ClusterBatch {
@@ -366,7 +364,6 @@ workflow GATKSVPipelinePhase1 {
       N_IQR_cutoff_plotting = N_IQR_cutoff_plotting,
       run_module_metrics=run_clusterbatch_metrics,
       linux_docker=linux_docker,
-      sv_pipeline_base_docker=sv_pipeline_base_docker,
       baseline_depth_vcf=baseline_depth_vcf_cluster_batch,
       baseline_manta_vcf=baseline_manta_vcf_cluster_batch,
       baseline_wham_vcf=baseline_wham_vcf_cluster_batch,
@@ -422,7 +419,6 @@ workflow GATKSVPipelinePhase1 {
       allosome_contigs=allosome_contigs,
       sv_base_mini_docker=sv_base_mini_docker,
       sv_base_docker=sv_base_docker,
-      sv_pipeline_base_docker=sv_pipeline_base_docker,
       sv_pipeline_docker=sv_pipeline_docker,
       sv_pipeline_rdtest_docker=sv_pipeline_rdtest_docker,
       linux_docker=linux_docker,
@@ -465,7 +461,6 @@ workflow GATKSVPipelinePhase1 {
       runtime_attr_filter_samples=runtime_attr_filter_samples,
       run_module_metrics = run_filterbatch_metrics,
       primary_contigs_list = primary_contigs_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
       ped_file = ped_file
   }
 

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -69,7 +69,6 @@ workflow GATKSVPipelineSingleSample {
     String sv_pipeline_hail_docker
     String sv_pipeline_updates_docker
     String sv_pipeline_rdtest_docker
-    String sv_pipeline_base_docker
     String sv_pipeline_qc_docker
     String linux_docker
     String cnmops_docker
@@ -891,7 +890,6 @@ workflow GATKSVPipelineSingleSample {
       pesr_clustering_algorithm=pesr_clustering_algorithm,
       run_module_metrics=run_clusterbatch_metrics,
       linux_docker=linux_docker,
-      sv_pipeline_base_docker=sv_pipeline_base_docker,
       baseline_depth_vcf=baseline_depth_vcf_cluster_batch,
       baseline_manta_vcf=baseline_manta_vcf_cluster_batch,
       baseline_wham_vcf=baseline_wham_vcf_cluster_batch,
@@ -1158,7 +1156,6 @@ workflow GATKSVPipelineSingleSample {
       run_module_metrics = run_makecohortvcf_metrics,
 
       primary_contigs_list=primary_contigs_list,
-      sv_pipeline_base_docker=sv_pipeline_base_docker,
 
       linux_docker=linux_docker,
       sv_pipeline_docker=sv_pipeline_docker,
@@ -1342,7 +1339,7 @@ workflow GATKSVPipelineSingleSample {
       sample_counts = case_counts_file_,
       contig_list = primary_contigs_list,
       linux_docker = linux_docker,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_docker = sv_pipeline_docker
   }
 
   call utils.RunQC as SampleFilterQC {
@@ -1350,14 +1347,14 @@ workflow GATKSVPipelineSingleSample {
       name=batch,
       metrics=SampleFilterMetrics.metrics_file,
       qc_definitions = qc_definitions,
-      sv_pipeline_base_docker=sv_pipeline_base_docker
+      sv_pipeline_docker=sv_pipeline_docker
   }
 
   call SingleSampleFiltering.SampleQC as FilterSample {
     input:
       vcf=FilterVcfWithReferencePanelCalls.out,
       sample_filtering_qc_file=SampleFilterQC.out,
-      sv_pipeline_base_docker=sv_pipeline_base_docker,
+      sv_pipeline_docker=sv_pipeline_docker,
   }
 
   call annotate.AnnotateVcf {
@@ -1413,7 +1410,7 @@ workflow GATKSVPipelineSingleSample {
       non_genotyped_unique_depth_calls_vcf = GetUniqueNonGenotypedDepthCalls.out,
       contig_list = primary_contigs_list,
       linux_docker = linux_docker,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_docker = sv_pipeline_docker
   }
 
   call utils.RunQC as SingleSampleQC {
@@ -1421,7 +1418,7 @@ workflow GATKSVPipelineSingleSample {
       name = batch,
       metrics = SingleSampleMetrics.metrics_file,
       qc_definitions = qc_definitions,
-      sv_pipeline_base_docker = sv_pipeline_base_docker
+      sv_pipeline_docker = sv_pipeline_docker
   }
 
   output {

--- a/wdl/GATKSVPipelineSingleSampleMetrics.wdl
+++ b/wdl/GATKSVPipelineSingleSampleMetrics.wdl
@@ -27,7 +27,7 @@ workflow SingleSampleMetrics {
 
     File contig_list
     String linux_docker
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
 
     RuntimeAttr? runtime_attr_sr_metrics
     RuntimeAttr? runtime_attr_pe_metrics
@@ -47,7 +47,7 @@ workflow SingleSampleMetrics {
       input:
         sr_file = select_first([sample_sr]),
         samples = [case_sample],
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_sr_metrics
     }
   }
@@ -57,7 +57,7 @@ workflow SingleSampleMetrics {
       input:
         pe_file = select_first([sample_pe]),
         samples = [case_sample],
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_pe_metrics
     }
   }
@@ -67,7 +67,7 @@ workflow SingleSampleMetrics {
       input:
         counts_file = select_first([sample_counts]),
         sample_id = case_sample,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_counts_metrics
     }
   }
@@ -81,7 +81,7 @@ workflow SingleSampleMetrics {
         prefix = "cleaned",
         types = "DEL,DUP,INS,INV,CTX,CNV,CPX,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_vcf_metrics
     }
   }
@@ -95,7 +95,7 @@ workflow SingleSampleMetrics {
         prefix = "final",
         types = "DEL,DUP,INS,INV,CTX,CNV,CPX,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_vcf_metrics
     }
   }
@@ -109,7 +109,7 @@ workflow SingleSampleMetrics {
         prefix = "genotyped_pesr",
         types = "DEL,DUP,INS,INV,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_pesr_metrics
     }
   }
@@ -123,7 +123,7 @@ workflow SingleSampleMetrics {
         prefix = "genotyped_depth",
         types = "DEL,DUP",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_depth_metrics
     }
   }
@@ -137,7 +137,7 @@ workflow SingleSampleMetrics {
         prefix = "non_genotyped_uniq_depth",
         types = "DEL,DUP",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_unique_depth_metrics
     }
   }

--- a/wdl/GatherBatchEvidence.wdl
+++ b/wdl/GatherBatchEvidence.wdl
@@ -129,7 +129,6 @@ workflow GatherBatchEvidence {
     # Module metrics parameters
     # Run module metrics workflow at the end - off by default for GatherBatchEvidence because of runtime/expense
     Boolean? run_module_metrics
-    String? sv_pipeline_base_docker  # required if run_module_metrics = true
     File? primary_contigs_list  # required if run_module_metrics = true
 
     # baseline files are optional for metrics workflow
@@ -460,7 +459,7 @@ workflow GatherBatchEvidence {
         baseline_merged_dups = baseline_merged_dups,
         baseline_median_cov = baseline_median_cov,
         contig_list = select_first([primary_contigs_list]),
-        sv_pipeline_base_docker = select_first([sv_pipeline_base_docker]),
+        sv_pipeline_docker = sv_pipeline_docker,
         linux_docker = linux_docker
     }
   }

--- a/wdl/GatherBatchEvidenceMetrics.wdl
+++ b/wdl/GatherBatchEvidenceMetrics.wdl
@@ -20,7 +20,7 @@ workflow GatherBatchEvidenceMetrics {
     File? baseline_median_cov
 
     File contig_list
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     String linux_docker
 
     RuntimeAttr? runtime_attr_baf_metrics
@@ -40,28 +40,28 @@ workflow GatherBatchEvidenceMetrics {
     input:
       baf_file = merged_BAF,
       samples = samples,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = select_first([runtime_attr_baf_metrics, {"mem_gb": 30, "disk_gb": 100}])
   }
   call tu.SRMetrics {
     input:
       sr_file = merged_SR,
       samples = samples,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = select_first([runtime_attr_sr_metrics, {"mem_gb": 30, "disk_gb": 100, "preemptible_tries": 0}])
   }
   call tu.PEMetrics {
     input:
       pe_file = merged_PE,
       samples = samples,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = select_first([runtime_attr_pe_metrics, {"mem_gb": 15, "disk_gb": 100, "preemptible_tries": 0}])
   }
   call tu.BincovMetrics {
     input:
       bincov_matrix = merged_bincov,
       samples = samples,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_bincov_metrics
   }
   call tu.MedcovMetrics {
@@ -69,7 +69,7 @@ workflow GatherBatchEvidenceMetrics {
       medcov_file = median_cov,
       samples = samples,
       baseline_medcov_file = baseline_median_cov,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_medcov_metrics
   }
   if (defined(baseline_merged_dels)) {
@@ -79,7 +79,7 @@ workflow GatherBatchEvidenceMetrics {
         baseline_bed = select_first([baseline_merged_dels]),
         type = "DEL",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_merged_del
     }
   }
@@ -89,7 +89,7 @@ workflow GatherBatchEvidenceMetrics {
         bed = merged_dels,
         type = "DEL",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_merged_del
     }
   }
@@ -100,7 +100,7 @@ workflow GatherBatchEvidenceMetrics {
         baseline_bed = select_first([baseline_merged_dups]),
         type = "DUP",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_merged_dup
     }
   }
@@ -110,7 +110,7 @@ workflow GatherBatchEvidenceMetrics {
         bed = merged_dups,
         type = "DUP",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_merged_dup
     }
   }

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -83,7 +83,6 @@ workflow GatherSampleEvidence {
     # Run module metrics workflow at the end - on by default
     Boolean run_module_metrics = true
     File? primary_contigs_fai # required if run_module_metrics = true
-    String? sv_pipeline_base_docker  # required if run_module_metrics = true
     File? baseline_manta_vcf # baseline files are optional for metrics workflow
     File? baseline_wham_vcf
     File? baseline_melt_vcf
@@ -289,7 +288,7 @@ workflow GatherSampleEvidence {
         baseline_wham_vcf = baseline_wham_vcf,
         contig_list = primary_contigs_list,
         contig_index = select_first([primary_contigs_fai]),
-        sv_pipeline_base_docker = select_first([sv_pipeline_base_docker])
+        sv_pipeline_docker = sv_pipeline_docker
     }
   }
 

--- a/wdl/GatherSampleEvidenceBatch.wdl
+++ b/wdl/GatherSampleEvidenceBatch.wdl
@@ -61,7 +61,6 @@ workflow GatherSampleEvidenceBatch {
     # Run module metrics workflow at the end - on by default
     Boolean? run_module_metrics
     String? batch  # required if run_module_metrics = true
-    String? sv_pipeline_base_docker  # required if run_module_metrics = true
     String? linux_docker  # required if run_module_metrics = true
     File? baseline_manta_vcf # baseline files are optional for metrics workflow
     File? baseline_wham_vcf
@@ -135,7 +134,6 @@ workflow GatherSampleEvidenceBatch {
         scramble_part2_threads=scramble_part2_threads,
         wham_include_list_bed_file = wham_include_list_bed_file,
         run_module_metrics = run_module_metrics_,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
         baseline_manta_vcf = baseline_manta_vcf,
         baseline_melt_vcf = baseline_melt_vcf,
         baseline_scramble_vcf = baseline_scramble_vcf,

--- a/wdl/GatherSampleEvidenceMetrics.wdl
+++ b/wdl/GatherSampleEvidenceMetrics.wdl
@@ -21,7 +21,7 @@ workflow GatherSampleEvidenceMetrics {
     File contig_list
     File contig_index
     Int min_size = 50
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
 
     RuntimeAttr? runtime_attr_manta_std
     RuntimeAttr? runtime_attr_manta_metrics
@@ -43,7 +43,7 @@ workflow GatherSampleEvidenceMetrics {
         caller = "manta",
         contig_index = contig_index,
         min_size = min_size,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_manta_std
     }
     if (defined(baseline_manta_vcf)) {
@@ -54,7 +54,7 @@ workflow GatherSampleEvidenceMetrics {
           caller = "manta",
           contig_index = contig_index,
           min_size = min_size,
-          sv_pipeline_base_docker = sv_pipeline_base_docker,
+          sv_pipeline_docker = sv_pipeline_docker,
           runtime_attr_override = runtime_attr_manta_std
       }
     }
@@ -66,7 +66,7 @@ workflow GatherSampleEvidenceMetrics {
         prefix = "manta_" + sample,
         types = "DEL,DUP,INS,INV,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_manta_metrics
     }
   }
@@ -78,7 +78,7 @@ workflow GatherSampleEvidenceMetrics {
         caller = "melt",
         contig_index = contig_index,
         min_size = min_size,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_melt_std
     }
     if (defined(baseline_melt_vcf)) {
@@ -89,7 +89,7 @@ workflow GatherSampleEvidenceMetrics {
           caller = "melt",
           contig_index = contig_index,
           min_size = min_size,
-          sv_pipeline_base_docker = sv_pipeline_base_docker,
+          sv_pipeline_docker = sv_pipeline_docker,
           runtime_attr_override = runtime_attr_melt_std
       }
     }
@@ -101,7 +101,7 @@ workflow GatherSampleEvidenceMetrics {
         prefix = "melt_" + sample,
         types = "DEL,DUP,INS,INV,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_melt_metrics
     }
   }
@@ -114,7 +114,7 @@ workflow GatherSampleEvidenceMetrics {
         prefix = "scramble_" + sample,
         types = "INS",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_scramble_metrics
     }
   }
@@ -126,7 +126,7 @@ workflow GatherSampleEvidenceMetrics {
         caller = "wham",
         contig_index = contig_index,
         min_size = min_size,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_wham_std
     }
     if (defined(baseline_wham_vcf)) {
@@ -137,7 +137,7 @@ workflow GatherSampleEvidenceMetrics {
           caller = "wham",
           contig_index = contig_index,
           min_size = min_size,
-          sv_pipeline_base_docker = sv_pipeline_base_docker,
+          sv_pipeline_docker = sv_pipeline_docker,
           runtime_attr_override = runtime_attr_wham_std
       }
     }
@@ -149,7 +149,7 @@ workflow GatherSampleEvidenceMetrics {
         prefix = "wham_" + sample,
         types = "DEL,DUP,INS,INV,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_wham_metrics
     }
   }
@@ -158,7 +158,7 @@ workflow GatherSampleEvidenceMetrics {
       input:
         sr_file = select_first([pesr_split]),
         samples = [sample],
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_sr_metrics
     }
   }
@@ -167,7 +167,7 @@ workflow GatherSampleEvidenceMetrics {
       input:
         pe_file = select_first([pesr_disc]),
         samples = [sample],
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_pe_metrics
     }
   }
@@ -176,7 +176,7 @@ workflow GatherSampleEvidenceMetrics {
       input:
         counts_file = select_first([coverage_counts]),
         sample_id = sample,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_counts_metrics
     }
   }

--- a/wdl/GenerateBatchMetrics.wdl
+++ b/wdl/GenerateBatchMetrics.wdl
@@ -47,7 +47,6 @@ workflow GenerateBatchMetrics {
     String sv_pipeline_rdtest_docker
     String sv_base_mini_docker
     String sv_base_docker
-    String sv_pipeline_base_docker
     String linux_docker
 
     RuntimeAttr? runtime_attr_ids_from_vcf
@@ -255,7 +254,7 @@ workflow GenerateBatchMetrics {
       batch = batch,
       input_metrics = select_all(AggregateTests.metrics),
       common = false,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_aggregate_callers
   }
 
@@ -264,7 +263,7 @@ workflow GenerateBatchMetrics {
       batch = batch,
       input_metrics = select_all(AggregateTestsCommon.metrics),
       common = true,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_aggregate_callers
   }
 
@@ -277,7 +276,7 @@ workflow GenerateBatchMetrics {
         metrics_common = AggregateCallersCommon.metrics,
         contig_list = select_first([primary_contigs_list]),
         linux_docker = linux_docker,
-        sv_pipeline_base_docker = sv_pipeline_base_docker
+        sv_pipeline_docker = sv_pipeline_docker
     }
   }
 
@@ -442,7 +441,7 @@ task AggregateCallers {
     String batch
     Array[File] input_metrics
     Boolean common
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -480,7 +479,7 @@ task AggregateCallers {
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
     disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }

--- a/wdl/GenerateBatchMetricsMetrics.wdl
+++ b/wdl/GenerateBatchMetricsMetrics.wdl
@@ -8,7 +8,7 @@ workflow GenerateBatchMetricsMetrics {
     File metrics
     File metrics_common
     File contig_list
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     String linux_docker
 
     RuntimeAttr? runtime_attr_metrics_file_metrics
@@ -22,7 +22,7 @@ workflow GenerateBatchMetricsMetrics {
       contig_list = contig_list,
       common = false,
       prefix = "GenerateBatchMetrics.non_common." + name,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_metrics_file_metrics
   }
 
@@ -32,7 +32,7 @@ workflow GenerateBatchMetricsMetrics {
       contig_list = contig_list,
       common = true,
       prefix = "GenerateBatchMetrics.common." + name,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_common_metrics_metrics
   }
 

--- a/wdl/GenotypeBatch.wdl
+++ b/wdl/GenotypeBatch.wdl
@@ -42,7 +42,6 @@ workflow GenotypeBatch {
     # Module metrics parameters
     # Run module metrics workflow at the end - on by default
     Boolean? run_module_metrics
-    String? sv_pipeline_base_docker  # required if run_module_metrics = true
     File? primary_contigs_list  # required if run_module_metrics = true
     File? baseline_genotyped_depth_vcf  # baseline files are optional for metrics workflow
     File? baseline_genotyped_pesr_vcf
@@ -283,7 +282,7 @@ workflow GenotypeBatch {
         baseline_genotyped_depth_vcf = baseline_genotyped_depth_vcf,
         contig_list = select_first([primary_contigs_list]),
         linux_docker = linux_docker,
-        sv_pipeline_base_docker = select_first([sv_pipeline_base_docker])
+        sv_pipeline_docker = sv_pipeline_docker
     }
   }
 

--- a/wdl/GenotypeBatchMetrics.wdl
+++ b/wdl/GenotypeBatchMetrics.wdl
@@ -21,7 +21,7 @@ workflow GenotypeBatchMetrics {
 
     File contig_list
     String linux_docker
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
 
     RuntimeAttr? runtime_attr_pesr_metrics
     RuntimeAttr? runtime_attr_depth_metrics
@@ -38,7 +38,7 @@ workflow GenotypeBatchMetrics {
       prefix = "genotyped_pesr",
       types = "DEL,DUP,INS,INV,BND",
       contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_pesr_metrics
   }
 
@@ -50,7 +50,7 @@ workflow GenotypeBatchMetrics {
       prefix = "genotyped_depth",
       types = "DEL,DUP",
       contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_depth_metrics
   }
 
@@ -58,7 +58,7 @@ workflow GenotypeBatchMetrics {
     input:
       cutoffs = cutoffs_pesr_pesr,
       name = "pesr_pesr",
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_cutoff_metrics
   }
 
@@ -66,7 +66,7 @@ workflow GenotypeBatchMetrics {
     input:
       cutoffs = cutoffs_pesr_depth,
       name = "pesr_depth",
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_cutoff_metrics
   }
 
@@ -74,7 +74,7 @@ workflow GenotypeBatchMetrics {
     input:
       cutoffs = cutoffs_depth_pesr,
       name = "depth_pesr",
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_cutoff_metrics
   }
 
@@ -82,7 +82,7 @@ workflow GenotypeBatchMetrics {
     input:
       cutoffs = cutoffs_depth_depth,
       name = "depth_depth",
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_cutoff_metrics
   }
 

--- a/wdl/MakeCohortVcf.wdl
+++ b/wdl/MakeCohortVcf.wdl
@@ -69,7 +69,6 @@ workflow MakeCohortVcf {
     # Module metrics parameters
     # Run module metrics workflow at the end - on by default
     Boolean? run_module_metrics
-    String? sv_pipeline_base_docker  # required if run_module_metrics = true
     File? primary_contigs_list  # required if run_module_metrics = true
     File? baseline_cluster_vcf  # baseline files are optional for metrics workflow
     File? baseline_complex_resolve_vcf
@@ -398,7 +397,6 @@ workflow MakeCohortVcf {
       baseline_cleaned_vcf = baseline_cleaned_vcf,
       primary_contigs_list=primary_contigs_list,
       run_module_metrics=run_module_metrics,
-      sv_pipeline_base_docker=sv_pipeline_base_docker,
       linux_docker=linux_docker,
       sv_base_mini_docker=sv_base_mini_docker,
       sv_pipeline_hail_docker=sv_pipeline_hail_docker,

--- a/wdl/MakeCohortVcfMetrics.wdl
+++ b/wdl/MakeCohortVcfMetrics.wdl
@@ -20,7 +20,7 @@ workflow MakeCohortVcfMetrics {
 
     File contig_list
     String linux_docker
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     String? sv_base_mini_docker  # required if not providing samples array
 
     RuntimeAttr? runtime_attr_sample_ids_from_vcf
@@ -49,7 +49,7 @@ workflow MakeCohortVcfMetrics {
         prefix = "cluster",
         types = "DEL,DUP,INS,INV,CTX,CPX,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_vcf_metrics
     }
   }
@@ -63,7 +63,7 @@ workflow MakeCohortVcfMetrics {
         prefix = "cpx_resolve",
         types = "DEL,DUP,INS,INV,CTX,CPX,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_vcf_metrics
     }
   }
@@ -77,7 +77,7 @@ workflow MakeCohortVcfMetrics {
         prefix = "cpx_genotype",
         types = "DEL,DUP,INS,INV,CTX,CPX,BND",
         contig_list = contig_list,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
+        sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_vcf_metrics
     }
   }
@@ -90,7 +90,7 @@ workflow MakeCohortVcfMetrics {
       prefix = "cleaned",
       types = "DEL,DUP,INS,INV,CTX,CPX,BND,CNV",
       contig_list = contig_list,
-      sv_pipeline_base_docker = sv_pipeline_base_docker,
+      sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_override = runtime_attr_vcf_metrics
   }
 

--- a/wdl/RegenotypeCNVs.wdl
+++ b/wdl/RegenotypeCNVs.wdl
@@ -8,7 +8,6 @@ workflow RegenotypeCNVs {
   input {
     String sv_base_mini_docker
     String sv_pipeline_docker
-    String sv_pipeline_base_docker
     String sv_pipeline_rdtest_docker
     Array[File] depth_vcfs
     File cohort_depth_vcf
@@ -203,7 +202,6 @@ workflow RegenotypeCNVs {
         min_var_per_sample_outlier_threshold = min_var_per_sample_outlier_threshold,
         regeno_sample_overlap = regeno_sample_overlap,
         sv_pipeline_docker = sv_pipeline_docker,
-        sv_pipeline_base_docker = sv_pipeline_base_docker,
         runtime_attr_merge_list_creassess = runtime_attr_merge_list_creassess,
         runtime_attr_vcf2bed = runtime_attr_vcf2bed
     }

--- a/wdl/SingleSampleFiltering.wdl
+++ b/wdl/SingleSampleFiltering.wdl
@@ -598,7 +598,7 @@ task SampleQC {
   input {
     File vcf
     File sample_filtering_qc_file
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -653,7 +653,7 @@ task SampleQC {
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
     disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }

--- a/wdl/TestUtils.wdl
+++ b/wdl/TestUtils.wdl
@@ -51,7 +51,7 @@ task StandardizeVCF {
     String caller
     File contig_index
     Int min_size
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
   RuntimeAttr runtime_default = object {
@@ -79,7 +79,7 @@ task StandardizeVCF {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -92,7 +92,7 @@ task VCFMetrics {
     String types
     String prefix
     File contig_list
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -129,7 +129,7 @@ task VCFMetrics {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -138,7 +138,7 @@ task BAFMetrics {
   input {
     File baf_file
     Array[String] samples
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -169,7 +169,7 @@ task BAFMetrics {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -178,7 +178,7 @@ task SRMetrics {
   input {
     File sr_file
     Array[String] samples
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -209,7 +209,7 @@ task SRMetrics {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -218,7 +218,7 @@ task PEMetrics {
   input {
     File pe_file
     Array[String] samples
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -249,7 +249,7 @@ task PEMetrics {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -258,7 +258,7 @@ task CountsMetrics {
   input {
     File counts_file
     String sample_id
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -286,7 +286,7 @@ task CountsMetrics {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -295,7 +295,7 @@ task BincovMetrics {
   input {
     File bincov_matrix
     Array[String] samples
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -326,7 +326,7 @@ task BincovMetrics {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -336,7 +336,7 @@ task MedcovMetrics {
     File medcov_file
     Array[String] samples
     File? baseline_medcov_file
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -370,7 +370,7 @@ task MedcovMetrics {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -381,7 +381,7 @@ task MergedDepthMetricsWithBaseline {
     File baseline_bed
     String type
     File contig_list
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -419,7 +419,7 @@ task MergedDepthMetricsWithBaseline {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -429,7 +429,7 @@ task MergedDepthMetricsWithoutBaseline {
     File bed
     String type
     File contig_list
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -457,7 +457,7 @@ task MergedDepthMetricsWithoutBaseline {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -468,7 +468,7 @@ task MetricsFileMetrics {
     File contig_list
     Boolean common
     String prefix
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -498,7 +498,7 @@ task MetricsFileMetrics {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -509,7 +509,7 @@ task CutoffAndOutlierMetrics {
     File outlier_list
     File filtered_ped_file
     Array[String] samples
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -542,7 +542,7 @@ task CutoffAndOutlierMetrics {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -551,7 +551,7 @@ task GenotypingCutoffMetrics {
   input {
     File cutoffs
     String name
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
   RuntimeAttr runtime_default = object {
@@ -577,7 +577,7 @@ task GenotypingCutoffMetrics {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }
@@ -625,7 +625,7 @@ task PlotMetrics {
     File test_metrics
     File base_metrics
     Array[String] samples
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -656,7 +656,7 @@ task PlotMetrics {
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 }

--- a/wdl/TrainGCNV.wdl
+++ b/wdl/TrainGCNV.wdl
@@ -17,7 +17,7 @@ workflow TrainGCNV {
     File reference_index    # Index (.fai), must be in same dir as fasta
     File reference_dict     # Dictionary (.dict), must be in same dir as fasta
 
-    # Options for subsetting samples for training. Both options require providing sv_pipeline_base_docker
+    # Options for subsetting samples for training.
     # Assumes all other inputs correspond to the full sample list. Intended for Terra
     Int? n_samples_subsample # Number of samples to subsample from provided sample list for trainGCNV (rec: ~100)
     Int subsample_seed = 42
@@ -88,7 +88,7 @@ workflow TrainGCNV {
     String linux_docker
     String gatk_docker
     String condense_counts_docker
-    String? sv_pipeline_base_docker # required if using n_samples_subsample or sample_ids_training_subset to subset samples
+    String? sv_pipeline_docker # required if using n_samples_subsample or sample_ids_training_subset to subset samples
 
     # Runtime configuration overrides
     RuntimeAttr? condense_counts_runtime_attr
@@ -108,7 +108,7 @@ workflow TrainGCNV {
         all_strings = write_lines(samples),
         subset_strings = write_lines(select_first([sample_ids_training_subset])),
         prefix = cohort,
-        sv_pipeline_base_docker = select_first([sv_pipeline_base_docker])
+        sv_pipeline_docker = select_first([sv_pipeline_docker])
     }
   }
 
@@ -119,7 +119,7 @@ workflow TrainGCNV {
         seed = subsample_seed,
         subset_size = select_first([n_samples_subsample]),
         prefix = cohort,
-        sv_pipeline_base_docker = select_first([sv_pipeline_base_docker])
+        sv_pipeline_docker = select_first([sv_pipeline_docker])
     }
   }
 

--- a/wdl/Utils.wdl
+++ b/wdl/Utils.wdl
@@ -214,7 +214,7 @@ task RunQC {
     String name
     File metrics
     File qc_definitions
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     Float mem_gib = 1
     Int disk_gb = 10
     Int preemptible_attempts = 3
@@ -235,7 +235,7 @@ task RunQC {
     memory: "~{mem_gib} GiB"
     disks: "local-disk ~{disk_gb} HDD"
     bootDiskSizeGb: 10
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     preemptible: preemptible_attempts
     maxRetries: 1
   }
@@ -248,7 +248,7 @@ task RandomSubsampleStringArray {
     Int seed
     Int subset_size
     String prefix
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -297,7 +297,7 @@ task RandomSubsampleStringArray {
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
     disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }
@@ -308,7 +308,7 @@ task GetSubsampledIndices {
     File all_strings
     File subset_strings
     String prefix
-    String sv_pipeline_base_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -349,7 +349,7 @@ task GetSubsampledIndices {
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
     disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
-    docker: sv_pipeline_base_docker
+    docker: sv_pipeline_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }


### PR DESCRIPTION
A follow-up from https://github.com/broadinstitute/gatk-sv/pull/633

Since both `sv_pipeline_base_docker` and `sv_pipeline_docker` are references to the same docker image, this PR implements the following changes to consolidate them: 

- [x] If a workflow has both `sv_pipeline_docker` and `sv_pipeline_base_docker`,  remove `sv_pipeline_base_docker` and replaces all runtime references with `sv_pipeline_docker`. 
- [x] If a workflow does not have `sv_pipeline_docker`, then rename `sv_pipeline_base_docker` to `sv_pipeline_docker`.
- [x] Update all the templates according to the above changes.

A few other docker image variables also use the same image as `sv_pipeline_docker`. I will update these variables similarly in follow-up PRs. 