### PR TITLE
Make manta region bed index required

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GatherSampleEvidence.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GatherSampleEvidence.json.tmpl
@@ -11,6 +11,7 @@
   "GatherSampleEvidence.preprocessed_intervals": "${workspace.preprocessed_intervals}",
 
   "GatherSampleEvidence.manta_region_bed": "${workspace.manta_region_bed}",
+  "GatherSampleEvidence.manta_region_bed_index": "${workspace.manta_region_bed_index}",
   "GatherSampleEvidence.sd_locs_vcf": "${workspace.sd_locs_vcf}",
   "GatherSampleEvidence.melt_standard_vcf_header": "${workspace.melt_standard_vcf_header}",
 

--- a/inputs/templates/terra_workspaces/cohort_mode/workspace.tsv.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workspace.tsv.tmpl
@@ -32,6 +32,7 @@ external_af_ref_bed	{{ reference_resources.external_af_ref_bed }}
 external_af_ref_bed_prefix	{{ reference_resources.external_af_ref_bed_prefix }}
 genome_file	{{ reference_resources.genome_file }}
 manta_region_bed	{{ reference_resources.manta_region_bed }}
+manta_region_bed_index	{{ reference_resources.manta_region_bed_index }}
 mei_bed	{{ reference_resources.mei_bed }}
 melt_standard_vcf_header	{{ reference_resources.melt_std_vcf_header }}
 noncoding_bed	{{ reference_resources.noncoding_bed }}

--- a/inputs/templates/terra_workspaces/single_sample/GATKSVPipelineSingleSample.no_melt.json.tmpl
+++ b/inputs/templates/terra_workspaces/single_sample/GATKSVPipelineSingleSample.no_melt.json.tmpl
@@ -51,6 +51,7 @@
   "GATKSVPipelineSingleSample.genome_file" : "${workspace.reference_genome_file}",
   "GATKSVPipelineSingleSample.max_ref_panel_carrier_freq": 0.03,
   "GATKSVPipelineSingleSample.manta_region_bed" : "${workspace.reference_manta_region_bed}",
+  "GATKSVPipelineSingleSample.manta_region_bed_index" : "${workspace.reference_manta_region_bed_index}",
   "GATKSVPipelineSingleSample.sd_locs_vcf" : "${workspace.reference_sd_locs_vcf}",
   "GATKSVPipelineSingleSample.reference_dict" : "${workspace.reference_dict}",
   "GATKSVPipelineSingleSample.reference_fasta" : "${workspace.reference_fasta}",

--- a/inputs/templates/terra_workspaces/single_sample/workspace.tsv.tmpl
+++ b/inputs/templates/terra_workspaces/single_sample/workspace.tsv.tmpl
@@ -53,6 +53,7 @@ reference_external_af_ref_bed	{{ reference_resources.external_af_ref_bed }}
 reference_external_af_ref_bed_prefix	{{ reference_resources.external_af_ref_bed_prefix }}
 reference_genome_file	{{ reference_resources.genome_file }}
 reference_manta_region_bed	{{ reference_resources.manta_region_bed }}
+reference_manta_region_bed_index	{{ reference_resources.manta_region_bed_index }}
 reference_mei_bed	{{ reference_resources.mei_bed }}
 reference_melt_std_vcf_header	{{ reference_resources.melt_std_vcf_header }}
 reference_noncoding_bed	{{ reference_resources.noncoding_bed }}

--- a/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.FromSampleEvidence.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.FromSampleEvidence.json.tmpl
@@ -52,6 +52,7 @@
 
   "GATKSVPipelineBatch.GatherSampleEvidenceBatch.reference_version": {{ reference_resources.reference_version | tojson }},
   "GATKSVPipelineBatch.GatherSampleEvidenceBatch.manta_region_bed": {{ reference_resources.manta_region_bed | tojson }},
+  "GATKSVPipelineBatch.GatherSampleEvidenceBatch.manta_region_bed_index": {{ reference_resources.manta_region_bed_index | tojson }},
   "GATKSVPipelineBatch.GatherSampleEvidenceBatch.sd_locs_vcf": {{ reference_resources.sd_locs_vcf | tojson }},
   "GATKSVPipelineBatch.GatherSampleEvidenceBatch.melt_standard_vcf_header": {{ reference_resources.melt_std_vcf_header | tojson }},
   "GATKSVPipelineBatch.GatherSampleEvidenceBatch.wham_include_list_bed_file": {{ reference_resources.wham_include_list_bed_file | tojson }},

--- a/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
@@ -46,6 +46,7 @@
 
   "GATKSVPipelineBatch.GatherSampleEvidenceBatch.reference_version": {{ reference_resources.reference_version | tojson }},
   "GATKSVPipelineBatch.GatherSampleEvidenceBatch.manta_region_bed": {{ reference_resources.manta_region_bed | tojson }},
+  "GATKSVPipelineBatch.GatherSampleEvidenceBatch.manta_region_bed_index": {{ reference_resources.manta_region_bed_index | tojson }},
   "GATKSVPipelineBatch.GatherSampleEvidenceBatch.sd_locs_vcf": {{ reference_resources.sd_locs_vcf | tojson }},
   "GATKSVPipelineBatch.GatherSampleEvidenceBatch.melt_standard_vcf_header": {{ reference_resources.melt_std_vcf_header | tojson }},
   "GATKSVPipelineBatch.GatherSampleEvidenceBatch.wham_include_list_bed_file": {{ reference_resources.wham_include_list_bed_file | tojson }},

--- a/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.json.tmpl
@@ -50,6 +50,7 @@
   "GATKSVPipelineSingleSample.genome_file" : {{ reference_resources.genome_file | tojson }},
   "GATKSVPipelineSingleSample.max_ref_panel_carrier_freq": 0.03,
   "GATKSVPipelineSingleSample.manta_region_bed" : {{ reference_resources.manta_region_bed | tojson }},
+  "GATKSVPipelineSingleSample.manta_region_bed_index" : {{ reference_resources.manta_region_bed_index | tojson }},
   "GATKSVPipelineSingleSample.melt_standard_vcf_header": {{ reference_resources.melt_std_vcf_header | tojson }},
   "GATKSVPipelineSingleSample.sd_locs_vcf": {{ reference_resources.sd_locs_vcf | tojson }},
   "GATKSVPipelineSingleSample.reference_dict" : {{ reference_resources.reference_dict | tojson }},

--- a/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.no_melt.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.no_melt.json.tmpl
@@ -53,6 +53,7 @@
   "GATKSVPipelineSingleSample.genome_file" : {{ reference_resources.genome_file | tojson }},
   "GATKSVPipelineSingleSample.max_ref_panel_carrier_freq": 0.03,
   "GATKSVPipelineSingleSample.manta_region_bed" : {{ reference_resources.manta_region_bed | tojson }},
+  "GATKSVPipelineSingleSample.manta_region_bed_index" : {{ reference_resources.manta_region_bed_index | tojson }},
   "GATKSVPipelineSingleSample.sd_locs_vcf" : {{ reference_resources.sd_locs_vcf | tojson }},
   "GATKSVPipelineSingleSample.reference_dict" : {{ reference_resources.reference_dict | tojson }},
   "GATKSVPipelineSingleSample.reference_fasta" : {{ reference_resources.reference_fasta | tojson }},

--- a/inputs/templates/test/GatherSampleEvidence/GatherSampleEvidence.json.tmpl
+++ b/inputs/templates/test/GatherSampleEvidence/GatherSampleEvidence.json.tmpl
@@ -14,6 +14,7 @@
 
   "GatherSampleEvidence.preprocessed_intervals": {{ reference_resources.preprocessed_intervals | tojson }},
   "GatherSampleEvidence.manta_region_bed": {{ reference_resources.manta_region_bed | tojson }},
+  "GatherSampleEvidence.manta_region_bed_index": {{ reference_resources.manta_region_bed_index | tojson }},
   "GatherSampleEvidence.sd_locs_vcf": {{ reference_resources.sd_locs_vcf | tojson }},
   "GatherSampleEvidence.melt_standard_vcf_header": {{ reference_resources.melt_std_vcf_header | tojson }},
   "GatherSampleEvidence.wham_include_list_bed_file": {{ reference_resources.wham_include_list_bed_file | tojson }},

--- a/inputs/templates/test/GatherSampleEvidenceBatch/GatherSampleEvidenceBatch.json.tmpl
+++ b/inputs/templates/test/GatherSampleEvidenceBatch/GatherSampleEvidenceBatch.json.tmpl
@@ -11,6 +11,7 @@
   "GatherSampleEvidenceBatch.preprocessed_intervals": {{ reference_resources.preprocessed_intervals | tojson }},
 
   "GatherSampleEvidenceBatch.manta_region_bed": {{ reference_resources.manta_region_bed | tojson }},
+  "GatherSampleEvidenceBatch.manta_region_bed_index": {{ reference_resources.manta_region_bed_index | tojson }},
   "GatherSampleEvidenceBatch.sd_locs_vcf": {{ reference_resources.sd_locs_vcf | tojson }},
   "GatherSampleEvidenceBatch.melt_standard_vcf_header": {{ reference_resources.melt_std_vcf_header | tojson }},
 

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -103,7 +103,7 @@ workflow GATKSVPipelineSingleSample {
 
     # Manta inputs
     File manta_region_bed
-    File? manta_region_bed_index
+    File manta_region_bed_index
     Float? manta_jobs_per_cpu
     Int? manta_mem_gb_per_job
 

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -55,7 +55,7 @@ workflow GatherSampleEvidence {
 
     # Manta inputs
     File manta_region_bed
-    File? manta_region_bed_index
+    File manta_region_bed_index
     Float? manta_jobs_per_cpu
     Int? manta_mem_gb_per_job
 

--- a/wdl/GatherSampleEvidenceBatch.wdl
+++ b/wdl/GatherSampleEvidenceBatch.wdl
@@ -33,7 +33,7 @@ workflow GatherSampleEvidenceBatch {
 
     # Manta inputs
     File manta_region_bed
-    File? manta_region_bed_index
+    File manta_region_bed_index
     Float? manta_jobs_per_cpu
     Int? manta_mem_gb_per_job
 

--- a/wdl/Manta.wdl
+++ b/wdl/Manta.wdl
@@ -15,7 +15,7 @@ workflow Manta {
     File reference_fasta
     File? reference_index
     File region_bed
-    File? region_bed_index
+    File region_bed_index
     Float? jobs_per_cpu
     Int? mem_gb_per_job
     String manta_docker
@@ -28,8 +28,8 @@ workflow Manta {
     sample_id: "sample name. Outputs will be sample_name + 'manta.vcf.gz' and sample_name + 'manta.vcf.gz.tbi'"
     reference_fasta: ".fasta file with reference used to align bam or cram file"
     reference_index: "[optional] If omitted, the WDL will look for an index by appending .fai to the .fasta file"
-    region_bed: "[optional] gzipped bed file with included regions where manta should make SV calls."
-    region_bed_index: "[optional]If omitted, the WDL will look for an index by appending .tbi to the region_bed file"
+    region_bed: "gzipped bed file with included regions where manta should make SV calls."
+    region_bed_index: "A .tbi file for the region_bed file"
     jobs_per_cpu: "[optional] number of manta threads, i.e. num_jobs = round(num_cpu * jobs_per_cpu). If omitted, defaults to 1.3."
     mem_gb_per_job: "[optional] Memory to request for VM (in GB) = round(num_jobs * mem_gb_per_job). If omitted, defaults to 2."
   }
@@ -63,7 +63,7 @@ task RunManta {
     File reference_fasta
     File? reference_index
     File region_bed
-    File? region_bed_index
+    File region_bed_index
     Float? jobs_per_cpu
     Int? mem_gb_per_job
     String manta_docker
@@ -74,7 +74,6 @@ task RunManta {
   String bam_ext = if is_bam then ".bam" else ".cram"
   String index_ext = if is_bam then ".bai" else ".crai"
   File ref_index = select_first([reference_index, reference_fasta + ".fai"])
-  File bed_index = select_first([region_bed_index, region_bed + ".tbi"])
 
   # select number of cpus and jobs
   Int num_cpu_use = if defined(runtime_attr_override) then select_first([select_first([runtime_attr_override]).cpu_cores, 8]) else 8


### PR DESCRIPTION
The manta workflow fails if the index file does not exist; hence, following the discussion in https://github.com/broadinstitute/gatk-sv/issues/578, we are making this input required. Specifically:

The workflow fails to evaluate `vm_disk_size` and results in `EXECUTOR_ERROR` on CoA, which, since it occurs at the TES level, is a more challenging error to debug than task-level errors. 

The alternative approach to the changes implemented in this PR is to adjust the `vm_disk_size` calculation to exclude the index file size from the calculation (which would not impact much since the file is small). The main drawback of this approach is that the `/usr/local/bin/manta/bin/configManta.py` script may fail if the optional file does not exist. Hence, making the file required seems a better option. 



