### PR TITLE
Make the ploidy table output a necessary output instead of an intermediate …

### DIFF
--- a/wdl/JoinRawCalls.wdl
+++ b/wdl/JoinRawCalls.wdl
@@ -120,6 +120,6 @@ workflow JoinRawCalls {
   output {
     File joined_raw_calls_vcf = ConcatVcfs.concat_vcf
     File joined_raw_calls_vcf_index = ConcatVcfs.concat_vcf_idx
-    File joined_raw_calls_ploidy_table = SVCluster.ploidy_table
+    File joined_raw_calls_ploidy_table = CreatePloidyTableFromPed.out
   }
 }

--- a/wdl/JoinRawCalls.wdl
+++ b/wdl/JoinRawCalls.wdl
@@ -120,6 +120,6 @@ workflow JoinRawCalls {
   output {
     File joined_raw_calls_vcf = ConcatVcfs.concat_vcf
     File joined_raw_calls_vcf_index = ConcatVcfs.concat_vcf_idx
-    File joined_raw_calls_ploidy_table = CreatePloidyTableFromPed.out
+    File ploidy_table = CreatePloidyTableFromPed.out
   }
 }

--- a/wdl/JoinRawCalls.wdl
+++ b/wdl/JoinRawCalls.wdl
@@ -120,5 +120,6 @@ workflow JoinRawCalls {
   output {
     File joined_raw_calls_vcf = ConcatVcfs.concat_vcf
     File joined_raw_calls_vcf_index = ConcatVcfs.concat_vcf_idx
+    File joined_raw_calls_ploidy_table = SVCluster.ploidy_table
   }
 }


### PR DESCRIPTION
The ploidy_table is an intermediate output in the JoinRawCalls workflow but is necessary for further downstream analysis. This file is required for further downstream analysis and is a necessary input for FilterGenotypes. Thus it should be a final output of the workflow.
The JoinRawCalls.wdl has been modified to make the ploidy table generated by calling CreatePloidyTableFromPed from the TasksClusterBatch.wdl a final output of the entire wdl.
This passed validation with both womtool and cromshell against the reference panel. This addresses issue #636 [https://github.com/broadinstitute/gatk-sv/issues/636#issue-2119378008]. 