### PR TITLE
Replace hail docker with sv-pipeline image.

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CleanVcf.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CleanVcf.SingleBatch.json.tmpl
@@ -14,7 +14,6 @@
 
   "CleanVcf.linux_docker": "${workspace.linux_docker}",
   "CleanVcf.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
-  "CleanVcf.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
   "CleanVcf.sv_pipeline_updates_docker": "${workspace.sv_pipeline_updates_docker}",
   "CleanVcf.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
 

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CleanVcf.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CleanVcf.json.tmpl
@@ -14,7 +14,6 @@
 
   "CleanVcf.linux_docker": "${workspace.linux_docker}",
   "CleanVcf.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
-  "CleanVcf.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
   "CleanVcf.sv_pipeline_updates_docker": "${workspace.sv_pipeline_updates_docker}",
   "CleanVcf.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
 

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CombineBatches.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CombineBatches.SingleBatch.json.tmpl
@@ -6,7 +6,6 @@
 
   "CombineBatches.min_sr_background_fail_batches": 0.5,
   "CombineBatches.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
-  "CombineBatches.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
   "CombineBatches.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
 
   "CombineBatches.cohort_name": "${this.sample_set_id}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CombineBatches.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/CombineBatches.json.tmpl
@@ -6,7 +6,6 @@
 
   "CombineBatches.min_sr_background_fail_batches": 0.5,
   "CombineBatches.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
-  "CombineBatches.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
   "CombineBatches.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
 
   "CombineBatches.cohort_name": "${this.sample_set_set_id}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenotypeComplexVariants.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenotypeComplexVariants.SingleBatch.json.tmpl
@@ -5,7 +5,6 @@
 
   "GenotypeComplexVariants.linux_docker": "${workspace.linux_docker}",
   "GenotypeComplexVariants.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
-  "GenotypeComplexVariants.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
   "GenotypeComplexVariants.sv_pipeline_updates_docker": "${workspace.sv_pipeline_updates_docker}",
   "GenotypeComplexVariants.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
   "GenotypeComplexVariants.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenotypeComplexVariants.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/GenotypeComplexVariants.json.tmpl
@@ -5,7 +5,6 @@
 
   "GenotypeComplexVariants.linux_docker": "${workspace.linux_docker}",
   "GenotypeComplexVariants.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
-  "GenotypeComplexVariants.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
   "GenotypeComplexVariants.sv_pipeline_updates_docker": "${workspace.sv_pipeline_updates_docker}",
   "GenotypeComplexVariants.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
   "GenotypeComplexVariants.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MakeCohortVcf.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MakeCohortVcf.SingleBatch.json.tmpl
@@ -27,7 +27,6 @@
 
   "MakeCohortVcf.linux_docker": "${workspace.linux_docker}",
   "MakeCohortVcf.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
-  "MakeCohortVcf.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
   "MakeCohortVcf.sv_pipeline_updates_docker": "${workspace.sv_pipeline_updates_docker}",
   "MakeCohortVcf.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
   "MakeCohortVcf.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MakeCohortVcf.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MakeCohortVcf.json.tmpl
@@ -27,7 +27,6 @@
 
   "MakeCohortVcf.linux_docker": "${workspace.linux_docker}",
   "MakeCohortVcf.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
-  "MakeCohortVcf.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
   "MakeCohortVcf.sv_pipeline_updates_docker": "${workspace.sv_pipeline_updates_docker}",
   "MakeCohortVcf.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
   "MakeCohortVcf.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ResolveComplexVariants.SingleBatch.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ResolveComplexVariants.SingleBatch.json.tmpl
@@ -8,7 +8,6 @@
   "ResolveComplexVariants.max_shard_size" : 500,
   "ResolveComplexVariants.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
   "ResolveComplexVariants.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
-  "ResolveComplexVariants.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
 
   "ResolveComplexVariants.cohort_name": "${this.sample_set_id}",
   "ResolveComplexVariants.disc_files": "${this.merged_PE}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ResolveComplexVariants.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/ResolveComplexVariants.json.tmpl
@@ -8,7 +8,6 @@
   "ResolveComplexVariants.max_shard_size" : 500,
   "ResolveComplexVariants.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
   "ResolveComplexVariants.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
-  "ResolveComplexVariants.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
 
   "ResolveComplexVariants.cohort_name": "${this.sample_set_set_id}",
   "ResolveComplexVariants.disc_files": "${this.sample_sets.merged_PE}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workspace.tsv.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workspace.tsv.tmpl
@@ -11,7 +11,6 @@ samtools_cloud_docker	{{ dockers.samtools_cloud_docker }}
 sv_base_docker	{{ dockers.sv_base_docker }}
 sv_base_mini_docker	{{ dockers.sv_base_mini_docker }}
 sv_pipeline_docker	{{ dockers.sv_pipeline_docker }}
-sv_pipeline_hail_docker	{{ dockers.sv_pipeline_hail_docker }}
 sv_pipeline_updates_docker	{{ dockers.sv_pipeline_updates_docker }}
 sv_pipeline_qc_docker	{{ dockers.sv_pipeline_qc_docker }}
 sv_pipeline_rdtest_docker	{{ dockers.sv_pipeline_rdtest_docker }}

--- a/inputs/templates/terra_workspaces/single_sample/GATKSVPipelineSingleSample.no_melt.json.tmpl
+++ b/inputs/templates/terra_workspaces/single_sample/GATKSVPipelineSingleSample.no_melt.json.tmpl
@@ -35,7 +35,6 @@
   "GATKSVPipelineSingleSample.sv_base_docker": "${workspace.sv_base_docker}",
   "GATKSVPipelineSingleSample.sv_base_mini_docker": "${workspace.sv_base_mini_docker}",
   "GATKSVPipelineSingleSample.sv_pipeline_docker": "${workspace.sv_pipeline_docker}",
-  "GATKSVPipelineSingleSample.sv_pipeline_hail_docker": "${workspace.sv_pipeline_hail_docker}",
   "GATKSVPipelineSingleSample.sv_pipeline_updates_docker": "${workspace.sv_pipeline_updates_docker}",
   "GATKSVPipelineSingleSample.sv_pipeline_qc_docker": "${workspace.sv_pipeline_qc_docker}",
   "GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": "${workspace.sv_pipeline_rdtest_docker}",

--- a/inputs/templates/terra_workspaces/single_sample/workspace.tsv.tmpl
+++ b/inputs/templates/terra_workspaces/single_sample/workspace.tsv.tmpl
@@ -10,7 +10,6 @@ samtools_cloud_docker	{{ dockers.samtools_cloud_docker }}
 sv_base_docker	{{ dockers.sv_base_docker }}
 sv_base_mini_docker	{{ dockers.sv_base_mini_docker }}
 sv_pipeline_docker	{{ dockers.sv_pipeline_docker }}
-sv_pipeline_hail_docker	{{ dockers.sv_pipeline_hail_docker }}
 sv_pipeline_updates_docker	{{ dockers.sv_pipeline_updates_docker }}
 sv_pipeline_qc_docker	{{ dockers.sv_pipeline_qc_docker }}
 sv_pipeline_rdtest_docker	{{ dockers.sv_pipeline_rdtest_docker }}

--- a/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.FromSampleEvidence.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.FromSampleEvidence.json.tmpl
@@ -31,7 +31,6 @@
   "GATKSVPipelineBatch.sv_base_docker": {{ dockers.sv_base_docker | tojson }},
   "GATKSVPipelineBatch.sv_base_mini_docker": {{ dockers.sv_base_mini_docker | tojson }},
   "GATKSVPipelineBatch.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
-  "GATKSVPipelineBatch.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
   "GATKSVPipelineBatch.sv_pipeline_updates_docker": {{ dockers.sv_pipeline_updates_docker | tojson }},
   "GATKSVPipelineBatch.sv_pipeline_qc_docker": {{ dockers.sv_pipeline_qc_docker | tojson }},
   "GATKSVPipelineBatch.sv_pipeline_rdtest_docker": {{ dockers.sv_pipeline_rdtest_docker | tojson }},

--- a/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineBatch/GATKSVPipelineBatch.json.tmpl
@@ -25,7 +25,6 @@
   "GATKSVPipelineBatch.sv_base_docker": {{ dockers.sv_base_docker | tojson }},
   "GATKSVPipelineBatch.sv_base_mini_docker": {{ dockers.sv_base_mini_docker | tojson }},
   "GATKSVPipelineBatch.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
-  "GATKSVPipelineBatch.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
   "GATKSVPipelineBatch.sv_pipeline_updates_docker": {{ dockers.sv_pipeline_updates_docker | tojson }},
   "GATKSVPipelineBatch.sv_pipeline_qc_docker": {{ dockers.sv_pipeline_qc_docker | tojson }},
   "GATKSVPipelineBatch.sv_pipeline_rdtest_docker": {{ dockers.sv_pipeline_rdtest_docker | tojson }},

--- a/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.json.tmpl
@@ -33,7 +33,6 @@
   "GATKSVPipelineSingleSample.sv_base_docker": {{ dockers.sv_base_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_base_mini_docker": {{ dockers.sv_base_mini_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
-  "GATKSVPipelineSingleSample.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_pipeline_updates_docker": {{ dockers.sv_pipeline_updates_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_pipeline_qc_docker": {{ dockers.sv_pipeline_qc_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": {{ dockers.sv_pipeline_rdtest_docker | tojson }},

--- a/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.no_melt.json.tmpl
+++ b/inputs/templates/test/GATKSVPipelineSingleSample/GATKSVPipelineSingleSample.no_melt.json.tmpl
@@ -36,7 +36,6 @@
   "GATKSVPipelineSingleSample.sv_base_docker": {{ dockers.sv_base_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_base_mini_docker": {{ dockers.sv_base_mini_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
-  "GATKSVPipelineSingleSample.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_pipeline_updates_docker": {{ dockers.sv_pipeline_updates_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_pipeline_qc_docker": {{ dockers.sv_pipeline_qc_docker | tojson }},
   "GATKSVPipelineSingleSample.sv_pipeline_rdtest_docker": {{ dockers.sv_pipeline_rdtest_docker | tojson }},

--- a/inputs/templates/test/MakeCohortVcf/CleanVcf.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/CleanVcf.json.tmpl
@@ -14,7 +14,6 @@
 
   "CleanVcf.linux_docker": {{ dockers.linux_docker | tojson }},
   "CleanVcf.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
-  "CleanVcf.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
   "CleanVcf.sv_pipeline_updates_docker": {{ dockers.sv_pipeline_updates_docker | tojson }},
   "CleanVcf.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
 

--- a/inputs/templates/test/MakeCohortVcf/CombineBatches.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/CombineBatches.json.tmpl
@@ -6,7 +6,6 @@
 
   "CombineBatches.min_sr_background_fail_batches": 0.5,
   "CombineBatches.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
-  "CombineBatches.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
   "CombineBatches.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
 
   "CombineBatches.cohort_name": {{ test_batch.name | tojson }},

--- a/inputs/templates/test/MakeCohortVcf/GenotypeComplexVariants.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/GenotypeComplexVariants.json.tmpl
@@ -5,7 +5,6 @@
 
   "GenotypeComplexVariants.linux_docker": {{ dockers.linux_docker | tojson }},
   "GenotypeComplexVariants.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
-  "GenotypeComplexVariants.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
   "GenotypeComplexVariants.sv_pipeline_updates_docker": {{ dockers.sv_pipeline_updates_docker | tojson }},
   "GenotypeComplexVariants.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
   "GenotypeComplexVariants.sv_pipeline_rdtest_docker": {{ dockers.sv_pipeline_rdtest_docker | tojson }},

--- a/inputs/templates/test/MakeCohortVcf/MakeCohortVcf.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/MakeCohortVcf.json.tmpl
@@ -32,7 +32,6 @@
 
   "MakeCohortVcf.linux_docker": {{ dockers.linux_docker | tojson }},
   "MakeCohortVcf.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
-  "MakeCohortVcf.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
   "MakeCohortVcf.sv_pipeline_updates_docker": {{ dockers.sv_pipeline_updates_docker | tojson }},
   "MakeCohortVcf.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
   "MakeCohortVcf.sv_pipeline_rdtest_docker": {{ dockers.sv_pipeline_rdtest_docker | tojson }},

--- a/inputs/templates/test/MakeCohortVcf/ResolveComplexVariants.json.tmpl
+++ b/inputs/templates/test/MakeCohortVcf/ResolveComplexVariants.json.tmpl
@@ -8,7 +8,6 @@
   "ResolveComplexVariants.max_shard_size" : 500,
   "ResolveComplexVariants.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
   "ResolveComplexVariants.sv_base_mini_docker":{{ dockers.sv_base_mini_docker | tojson }},
-  "ResolveComplexVariants.sv_pipeline_hail_docker": {{ dockers.sv_pipeline_hail_docker | tojson }},
 
   "ResolveComplexVariants.cohort_name": {{ test_batch.name | tojson }},
   "ResolveComplexVariants.disc_files": [

--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -13,7 +13,6 @@
   "sv_base_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
-  "sv_pipeline_hail_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_updates_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_qc_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_rdtest_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",

--- a/inputs/values/dockers_azure.json
+++ b/inputs/values/dockers_azure.json
@@ -13,7 +13,6 @@
   "sv_base_docker": "vahid.azurecr.io/gatk-sv/sv-base:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_base_mini_docker": "vahid.azurecr.io/gatk-sv/sv-base-mini:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
-  "sv_pipeline_hail_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_updates_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_qc_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_rdtest_docker": "vahid.azurecr.io/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",

--- a/wdl/AnnotateVcf.wdl
+++ b/wdl/AnnotateVcf.wdl
@@ -33,7 +33,6 @@ workflow AnnotateVcf {
     String? gcs_project
 
     String sv_pipeline_docker
-    String? sv_pipeline_hail_docker
     String sv_base_mini_docker
     String gatk_docker
 
@@ -84,7 +83,6 @@ workflow AnnotateVcf {
         gatk_docker = gatk_docker,
         sv_pipeline_docker = sv_pipeline_docker,
         sv_base_mini_docker = sv_base_mini_docker,
-        sv_pipeline_hail_docker = sv_pipeline_hail_docker,
 
         runtime_attr_svannotate = runtime_attr_svannotate,
         runtime_attr_scatter_vcf = runtime_attr_scatter_vcf,
@@ -110,7 +108,6 @@ workflow AnnotateVcf {
         gcs_project=gcs_project,
         sv_base_mini_docker=sv_base_mini_docker,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=select_first([sv_pipeline_hail_docker]),
         runtime_override_preconcat=runtime_attr_preconcat,
         runtime_override_hail_merge=runtime_attr_hail_merge,
         runtime_override_fix_header=runtime_attr_fix_header

--- a/wdl/CleanVcf.wdl
+++ b/wdl/CleanVcf.wdl
@@ -47,7 +47,6 @@ workflow CleanVcf {
     String linux_docker
     String sv_base_mini_docker
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
     String sv_pipeline_updates_docker
 
     # overrides for mini tasks
@@ -141,7 +140,6 @@ workflow CleanVcf {
         sv_base_mini_docker=sv_base_mini_docker,
         sv_pipeline_updates_docker=sv_pipeline_updates_docker,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         runtime_override_clean_vcf_1a=runtime_override_clean_vcf_1a,
         runtime_override_clean_vcf_2=runtime_override_clean_vcf_2,
         runtime_override_clean_vcf_3=runtime_override_clean_vcf_3,
@@ -186,7 +184,6 @@ workflow CleanVcf {
         reset_cnv_gts=true,
         sv_base_mini_docker=sv_base_mini_docker,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         runtime_override_preconcat=runtime_override_preconcat_clean_final,
         runtime_override_hail_merge=runtime_override_hail_merge_clean_final,
         runtime_override_fix_header=runtime_override_fix_header_clean_final

--- a/wdl/CleanVcfChromosome.wdl
+++ b/wdl/CleanVcfChromosome.wdl
@@ -37,7 +37,6 @@ workflow CleanVcfChromosome {
     String linux_docker
     String sv_base_mini_docker
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
     String sv_pipeline_updates_docker
 
     # overrides for local tasks
@@ -119,7 +118,6 @@ workflow CleanVcfChromosome {
         gcs_project=gcs_project,
         sv_base_mini_docker=sv_base_mini_docker,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         runtime_override_preconcat=runtime_override_preconcat_step1,
         runtime_override_hail_merge=runtime_override_hail_merge_step1,
         runtime_override_fix_header=runtime_override_fix_header_step1
@@ -266,7 +264,6 @@ workflow CleanVcfChromosome {
         reset_cnv_gts=true,
         sv_base_mini_docker=sv_base_mini_docker,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         runtime_override_preconcat=runtime_override_preconcat_drc,
         runtime_override_hail_merge=runtime_override_hail_merge_drc,
         runtime_override_fix_header=runtime_override_fix_header_drc

--- a/wdl/ClusterSingleChromosome.wdl
+++ b/wdl/ClusterSingleChromosome.wdl
@@ -28,7 +28,6 @@ workflow ClusterSingleChrom {
     String? gcs_project
 
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
     String sv_base_mini_docker
 
     # overrides for MiniTasks
@@ -87,7 +86,6 @@ workflow ClusterSingleChrom {
         use_hail=use_hail,
         gcs_project=gcs_project,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         sv_base_mini_docker=sv_base_mini_docker,
         runtime_override_shard_clusters=runtime_override_shard_clusters,
         runtime_override_shard_vids=runtime_override_shard_vids,

--- a/wdl/CombineBatches.wdl
+++ b/wdl/CombineBatches.wdl
@@ -34,7 +34,6 @@ workflow CombineBatches {
 
     String sv_base_mini_docker
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
 
     # overrides for local tasks
     RuntimeAttr? runtime_override_update_sr_list
@@ -159,7 +158,6 @@ workflow CombineBatches {
         use_hail=use_hail,
         gcs_project=gcs_project,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         sv_base_mini_docker=sv_base_mini_docker,
         runtime_override_localize_vcfs = runtime_override_localize_vcfs,
         runtime_override_join_vcfs = runtime_override_join_vcfs,
@@ -207,7 +205,6 @@ workflow CombineBatches {
         use_hail=use_hail,
         gcs_project=gcs_project,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         sv_base_mini_docker=sv_base_mini_docker,
         runtime_override_localize_vcfs = runtime_override_localize_vcfs,
         runtime_override_join_vcfs = runtime_override_join_vcfs,
@@ -283,7 +280,6 @@ workflow CombineBatches {
         gcs_project=gcs_project,
         sv_base_mini_docker=sv_base_mini_docker,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         runtime_override_shard_clusters=runtime_override_shard_clusters_mpd,
         runtime_override_shard_vids=runtime_override_shard_vids_mpd,
         runtime_override_pull_vcf_shard=runtime_override_pull_vcf_shard_mpd,
@@ -315,7 +311,6 @@ workflow CombineBatches {
         gcs_project=gcs_project,
         sv_base_mini_docker=sv_base_mini_docker,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         runtime_override_shard_clusters=runtime_override_shard_clusters_mpd,
         runtime_override_shard_vids=runtime_override_shard_vids_mpd,
         runtime_override_pull_vcf_shard=runtime_override_pull_vcf_shard_mpd,
@@ -343,7 +338,6 @@ workflow CombineBatches {
           gcs_project=gcs_project,
           sv_base_mini_docker=sv_base_mini_docker,
           sv_pipeline_docker=sv_pipeline_docker,
-          sv_pipeline_hail_docker=sv_pipeline_hail_docker,
           runtime_override_preconcat=runtime_override_preconcat_pesr_depth,
           runtime_override_hail_merge=runtime_override_hail_merge_pesr_depth,
           runtime_override_fix_header=runtime_override_fix_header_pesr_depth

--- a/wdl/GATKSVPipelineBatch.wdl
+++ b/wdl/GATKSVPipelineBatch.wdl
@@ -89,7 +89,6 @@ workflow GATKSVPipelineBatch {
     String sv_base_mini_docker
     String sv_base_docker
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
     String sv_pipeline_updates_docker
     String sv_pipeline_rdtest_docker
     String sv_pipeline_qc_docker
@@ -304,7 +303,6 @@ workflow GATKSVPipelineBatch {
       primary_contigs_list = primary_contigs_list,
       linux_docker=linux_docker,
       sv_pipeline_docker=sv_pipeline_docker,
-      sv_pipeline_hail_docker=sv_pipeline_hail_docker,
       sv_pipeline_updates_docker=sv_pipeline_updates_docker,
       sv_pipeline_rdtest_docker=sv_pipeline_rdtest_docker,
       sv_pipeline_qc_docker=sv_pipeline_qc_docker,

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -66,7 +66,6 @@ workflow GATKSVPipelineSingleSample {
     String sv_base_mini_docker
     String sv_base_docker
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
     String sv_pipeline_updates_docker
     String sv_pipeline_rdtest_docker
     String sv_pipeline_qc_docker
@@ -1159,7 +1158,6 @@ workflow GATKSVPipelineSingleSample {
 
       linux_docker=linux_docker,
       sv_pipeline_docker=sv_pipeline_docker,
-      sv_pipeline_hail_docker=sv_pipeline_hail_docker,
       sv_pipeline_updates_docker=sv_pipeline_updates_docker,
       sv_pipeline_rdtest_docker=sv_pipeline_rdtest_docker,
       sv_pipeline_qc_docker=sv_pipeline_qc_docker,

--- a/wdl/GenotypeComplexVariants.wdl
+++ b/wdl/GenotypeComplexVariants.wdl
@@ -33,7 +33,6 @@ workflow GenotypeComplexVariants {
     String sv_base_mini_docker
     String sv_pipeline_updates_docker
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
     String sv_pipeline_rdtest_docker
 
     # overrides for mini tasks
@@ -102,7 +101,6 @@ workflow GenotypeComplexVariants {
         sv_pipeline_updates_docker=sv_pipeline_updates_docker,
         sv_base_mini_docker=sv_base_mini_docker,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         sv_pipeline_rdtest_docker=sv_pipeline_rdtest_docker,
         runtime_override_ids_from_median=runtime_override_ids_from_median,
         runtime_override_split_vcf_to_genotype=runtime_override_split_vcf_to_genotype,

--- a/wdl/HailMerge.wdl
+++ b/wdl/HailMerge.wdl
@@ -11,7 +11,6 @@ workflow HailMerge {
     Boolean? reset_cnv_gts
     String sv_base_mini_docker
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
     RuntimeAttr? runtime_override_preconcat
     RuntimeAttr? runtime_override_hail_merge
     RuntimeAttr? runtime_override_fix_header
@@ -35,7 +34,7 @@ workflow HailMerge {
       vcfs = [select_first([Preconcat.concat_vcf, vcfs[0]])],
       prefix = prefix,
       gcs_project = select_first([gcs_project]),
-      sv_pipeline_hail_docker=sv_pipeline_hail_docker,
+      sv_pipeline_docker=sv_pipeline_docker,
       runtime_attr_override=runtime_override_hail_merge
   }
 
@@ -61,7 +60,7 @@ task HailMergeTask {
     String prefix
     String gcs_project
     String region = "us-central1"
-    String sv_pipeline_hail_docker
+    String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }
 
@@ -88,7 +87,7 @@ task HailMergeTask {
     cpu: select_first([runtime_attr.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_attr.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_attr.max_retries, runtime_default.max_retries])
-    docker: sv_pipeline_hail_docker
+    docker: sv_pipeline_docker
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, runtime_default.boot_disk_gb])
   }
 

--- a/wdl/MakeCohortVcf.wdl
+++ b/wdl/MakeCohortVcf.wdl
@@ -78,7 +78,6 @@ workflow MakeCohortVcf {
     String linux_docker
     String sv_base_mini_docker
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
     String sv_pipeline_updates_docker
     String sv_pipeline_rdtest_docker
     String sv_pipeline_qc_docker
@@ -252,7 +251,6 @@ workflow MakeCohortVcf {
       empty_file=empty_file,
       use_hail=use_hail,
       gcs_project=gcs_project,
-      sv_pipeline_hail_docker=sv_pipeline_hail_docker,
       sv_base_mini_docker=sv_base_mini_docker,
       sv_pipeline_docker=sv_pipeline_docker,
       runtime_override_update_sr_list=runtime_override_update_sr_list_cluster,
@@ -294,7 +292,6 @@ workflow MakeCohortVcf {
       ref_dict=ref_dict,
       use_hail=use_hail,
       gcs_project=gcs_project,
-      sv_pipeline_hail_docker=sv_pipeline_hail_docker,
       max_shard_size=max_shard_size_resolve,
       sv_base_mini_docker=sv_base_mini_docker,
       sv_pipeline_docker=sv_pipeline_docker,
@@ -348,7 +345,6 @@ workflow MakeCohortVcf {
       ref_dict=ref_dict,
       linux_docker=linux_docker,
       sv_base_mini_docker=sv_base_mini_docker,
-      sv_pipeline_hail_docker=sv_pipeline_hail_docker,
       sv_pipeline_docker=sv_pipeline_docker,
       sv_pipeline_updates_docker=sv_pipeline_updates_docker,
       sv_pipeline_rdtest_docker=sv_pipeline_rdtest_docker,
@@ -399,7 +395,6 @@ workflow MakeCohortVcf {
       run_module_metrics=run_module_metrics,
       linux_docker=linux_docker,
       sv_base_mini_docker=sv_base_mini_docker,
-      sv_pipeline_hail_docker=sv_pipeline_hail_docker,
       sv_pipeline_docker=sv_pipeline_docker,
       sv_pipeline_updates_docker=sv_pipeline_updates_docker,
       runtime_override_preconcat_clean_final=runtime_override_preconcat_clean_final,

--- a/wdl/MergePesrDepth.wdl
+++ b/wdl/MergePesrDepth.wdl
@@ -22,7 +22,6 @@ workflow MergePesrDepth {
         String? gcs_project
 
         String sv_pipeline_docker
-        String sv_pipeline_hail_docker
         String sv_base_mini_docker
 
         # overrides for local tasks
@@ -79,7 +78,6 @@ workflow MergePesrDepth {
                 gcs_project=gcs_project,
                 sv_base_mini_docker=sv_base_mini_docker,
                 sv_pipeline_docker=sv_pipeline_docker,
-                sv_pipeline_hail_docker=sv_pipeline_hail_docker,
                 runtime_override_preconcat=runtime_override_preconcat_large_pesr_depth,
                 runtime_override_hail_merge=runtime_override_hail_merge_large_pesr_depth,
                 runtime_override_fix_header=runtime_override_fix_header_large_pesr_depth
@@ -164,7 +162,6 @@ workflow MergePesrDepth {
                 gcs_project=gcs_project,
                 sv_base_mini_docker=sv_base_mini_docker,
                 sv_pipeline_docker=sv_pipeline_docker,
-                sv_pipeline_hail_docker=sv_pipeline_hail_docker,
                 runtime_override_preconcat=runtime_override_preconcat_pesr_depth_shards,
                 runtime_override_hail_merge=runtime_override_hail_merge_pesr_depth_shards,
                 runtime_override_fix_header=runtime_override_fix_header_pesr_depth_shards

--- a/wdl/ResolveComplexVariants.wdl
+++ b/wdl/ResolveComplexVariants.wdl
@@ -28,7 +28,6 @@ workflow ResolveComplexVariants {
 
     String sv_base_mini_docker
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
 
     # overrides for local tasks
     RuntimeAttr? runtime_override_update_sr_list_pass
@@ -101,7 +100,6 @@ workflow ResolveComplexVariants {
         use_hail=use_hail,
         gcs_project=gcs_project,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         sv_base_mini_docker=sv_base_mini_docker,
         runtime_override_get_se_cutoff=runtime_override_get_se_cutoff_inv,
         runtime_override_shard_vcf_cpx=runtime_override_shard_vcf_cpx_inv,
@@ -147,7 +145,6 @@ workflow ResolveComplexVariants {
         use_hail=use_hail,
         gcs_project=gcs_project,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         sv_base_mini_docker=sv_base_mini_docker,
         runtime_override_get_se_cutoff=runtime_override_get_se_cutoff,
         runtime_override_shard_vcf_cpx=runtime_override_shard_vcf_cpx,

--- a/wdl/ResolveCpxSv.wdl
+++ b/wdl/ResolveCpxSv.wdl
@@ -27,7 +27,6 @@ workflow ResolveComplexSv {
     String? gcs_project
 
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
     String sv_base_mini_docker
 
     # overrides for local tasks
@@ -146,7 +145,6 @@ workflow ResolveComplexSv {
           gcs_project=gcs_project,
           sv_base_mini_docker=sv_base_mini_docker,
           sv_pipeline_docker=sv_pipeline_docker,
-          sv_pipeline_hail_docker=sv_pipeline_hail_docker,
           runtime_override_preconcat=runtime_override_preconcat,
           runtime_override_hail_merge=runtime_override_hail_merge,
           runtime_override_fix_header=runtime_override_fix_header

--- a/wdl/ScatterCpxGenotyping.wdl
+++ b/wdl/ScatterCpxGenotyping.wdl
@@ -33,7 +33,6 @@ workflow ScatterCpxGenotyping {
     String sv_base_mini_docker
     String sv_pipeline_updates_docker
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
     String sv_pipeline_rdtest_docker
 
     # overrides for MiniTasks
@@ -107,7 +106,6 @@ workflow ScatterCpxGenotyping {
         gcs_project=gcs_project,
         sv_base_mini_docker=sv_base_mini_docker,
         sv_pipeline_docker=sv_pipeline_docker,
-        sv_pipeline_hail_docker=sv_pipeline_hail_docker,
         runtime_override_preconcat=runtime_override_preconcat,
         runtime_override_hail_merge=runtime_override_hail_merge,
         runtime_override_fix_header=runtime_override_fix_header

--- a/wdl/ShardedAnnotateVcf.wdl
+++ b/wdl/ShardedAnnotateVcf.wdl
@@ -38,7 +38,6 @@ workflow ShardedAnnotateVcf {
     String? gcs_project
 
     String sv_pipeline_docker
-    String? sv_pipeline_hail_docker
     String sv_base_mini_docker
     String gatk_docker
 

--- a/wdl/ShardedCluster.wdl
+++ b/wdl/ShardedCluster.wdl
@@ -29,7 +29,6 @@ workflow ShardedCluster {
     String? gcs_project
 
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
     String sv_base_mini_docker
 
     # overrides for local tasks
@@ -150,7 +149,6 @@ workflow ShardedCluster {
           gcs_project=gcs_project,
           sv_base_mini_docker=sv_base_mini_docker,
           sv_pipeline_docker=sv_pipeline_docker,
-          sv_pipeline_hail_docker=sv_pipeline_hail_docker,
           runtime_override_preconcat=runtime_override_preconcat_sharded_cluster,
           runtime_override_hail_merge=runtime_override_hail_merge_sharded_cluster,
           runtime_override_fix_header=runtime_override_fix_header_sharded_cluster

--- a/wdl/VcfClusterSingleChromsome.wdl
+++ b/wdl/VcfClusterSingleChromsome.wdl
@@ -32,7 +32,6 @@ workflow VcfClusterSingleChrom {
     String? gcs_project
 
     String sv_pipeline_docker
-    String sv_pipeline_hail_docker
     String sv_base_mini_docker
 
     # overrides for local tasks
@@ -136,7 +135,6 @@ workflow VcfClusterSingleChrom {
       use_hail=use_hail,
       gcs_project=gcs_project,
       sv_pipeline_docker=sv_pipeline_docker,
-      sv_pipeline_hail_docker=sv_pipeline_hail_docker,
       sv_base_mini_docker=sv_base_mini_docker,
       runtime_override_subset_sv_type=runtime_override_subset_sv_type,
       runtime_override_shard_clusters=runtime_override_shard_clusters,


### PR DESCRIPTION
A follow up from #634 & #633 

Similar to #634:

- if a workflow has both `sv_pipeline_hail_docker` and `sv_pipeline_docker`, then remove `sv_pipeline_hail_docker` and replace all runtime docker image references with `sv_pipeline_docker`;
- if the workflow does not have  `sv_pipeline_docker` in its inputs, replace `sv_pipeline_hail_docker` with `sv_pipeline_docker`.