### PR TITLE
fix: add sd_locs_vcf_index input to SDtoBAF

### DIFF
--- a/wdl/BatchEvidenceMerging.wdl
+++ b/wdl/BatchEvidenceMerging.wdl
@@ -63,11 +63,13 @@ workflow BatchEvidenceMerging {
     }
   }
   if (!defined(BAF_files)) {
+    File sd_locs_vcf_index = select_first([sd_locs_vcf]) + ".tbi"
+
     call SDtoBAF {
       input:
         SD_files = select_first([SD_files]),
         sd_locs_vcf = select_first([sd_locs_vcf]),
-        sd_locs_vcf_index = select_first([sd_locs_vcf]) + ".tbi",
+        sd_locs_vcf_index = sd_locs_vcf_index,
         batch = batch,
         samples = samples,
         rename_samples=rename_samples,

--- a/wdl/BatchEvidenceMerging.wdl
+++ b/wdl/BatchEvidenceMerging.wdl
@@ -67,6 +67,7 @@ workflow BatchEvidenceMerging {
       input:
         SD_files = select_first([SD_files]),
         sd_locs_vcf = select_first([sd_locs_vcf]),
+        sd_locs_vcf_index = select_first([sd_locs_vcf]) + ".tbi",
         batch = batch,
         samples = samples,
         rename_samples=rename_samples,
@@ -179,6 +180,7 @@ task SDtoBAF {
   input {
     Array[File] SD_files
     File sd_locs_vcf
+    File sd_locs_vcf_index
     String batch
     Array[String] samples
     Boolean rename_samples


### PR DESCRIPTION
Fixes #643 

Adding the index in-place from the main file name.

I have not found any other reference to SDtoBAF that needs to be updated.