### PR TITLE
Fix SplitVariants task in TasksGenotypeBatch.wdl to be compatible with downstream analysis

### DIFF
--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -28,12 +28,13 @@ def process_bed_file(input_bed, n_per_split, bca=True):
     with open(input_bed, 'r') as infile:
         for line in infile:
             # process bed file line by line
-            line = line.strip().split('\t')
+            line = line.strip('\n').split('\t')
 
             # Checks which condition and prefix the current line matches and appends it to the corresponding
             # array and increments the counter for that array
             for prefix, conditions in condition_prefixes.items():
                 if conditions['condition'](line):
+                    line[4],line[5]=line[5],line[4]
                     current_lines[prefix].append('\t'.join(line))
                     current_counts[prefix] += 1
 
@@ -59,19 +60,6 @@ def process_bed_file(input_bed, n_per_split, bca=True):
                 outfile.write('\n'.join(lines))
 
             logging.info(f"File '{output_file}' written.")
-
-
-# Function to generate the pattern for suffixes
-def increment_suffix(suffix):
-    # define the alphabet and ending
-    alphabet = 'abcdefghijklmnopqrstuvwxyz'
-    if suffix == 'z' * 6:
-        raise ValueError('All possible files generated.')
-    else:
-        # if there are available suffixes increment to next available suffix
-        index = alphabet.index(suffix[0])
-        next_char = alphabet[(index + 1) % 26]
-        return next_char + suffix[1:]
 
 
 def main():


### PR DESCRIPTION
The SplitVariants task used to have some lines to switch columns 5 and 6 of the bed file output, which is read in downstream tasks of TrainRDGenotyping.GenotypePESR. This causes the TrainRDGenotyping.GenotypePESR to error out reporting.

Error: WARNING: Incorrect CNV type specified
1: stop("WARNING: Incorrect CNV type specified")
The python script splitvariants.py was modified to switch the columns to the appropriate order to be compatible with downstream analysis requirements.