### PR TITLE
Make SplitVariants task in TasksGenotypeBatch.wdl  compatible with downstream analysis

### DIFF
--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -12,7 +12,7 @@
   "samtools_cloud_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/samtools-cloud:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_base_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:2024-01-24-v0.28.4-beta-9debd6d7",
-  "sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
+  "sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:kv-splitvariants-fix-ac21ab6",
   "sv_pipeline_hail_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_updates_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_qc_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",

--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -12,7 +12,7 @@
   "samtools_cloud_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/samtools-cloud:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_base_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_base_mini_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-base-mini:2024-01-24-v0.28.4-beta-9debd6d7",
-  "sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:kv-splitvariants-fix-ac21ab6",
+  "sv_pipeline_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_hail_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_updates_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",
   "sv_pipeline_qc_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/sv-pipeline:2024-01-24-v0.28.4-beta-9debd6d7",

--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -2,14 +2,17 @@
 import argparse
 import logging
 
+
 def process_bed_file(input_bed, n_per_split, bca=True):
     SVTYPE_FIELD = 4
     END_FIELD = 2
     START_FIELD = 1
 
     condition_prefixes = {
-        'gt5kb': {'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
-        'lt5kb': {'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
+        'gt5kb': {'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (
+                    int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
+        'lt5kb': {'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (
+                    int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
         'bca': {'condition': lambda line: bca and line[SVTYPE_FIELD] not in ['DEL', 'DUP', 'INS']},
         'ins': {'condition': lambda line: bca and line[SVTYPE_FIELD] == 'INS'}
     }
@@ -45,6 +48,7 @@ def process_bed_file(input_bed, n_per_split, bca=True):
                 outfile.write('\n'.join(lines))
             logging.info(f"File '{output_file}' written.")
 
+
 def increment_suffix(suffix):
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
     if suffix == 'z' * 6:
@@ -54,11 +58,13 @@ def increment_suffix(suffix):
         next_char = alphabet[(index + 1) % 26]
         return next_char + suffix[1:]
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--bed", help="Path to input bed file", required=True)
     parser.add_argument("--n", help="number of variants per file", required=True, type=int)
-    parser.add_argument("--bca", default=False, help="Flag to set to True if the VCF contains BCAs", action='store_true')
+    parser.add_argument("--bca", default=False, help="Flag to set to True if the VCF contains BCAs",
+                        action='store_true')
     parser.add_argument("--log-level", required=False, default="INFO", help="Specify level of logging information")
     args = parser.parse_args()
 
@@ -68,6 +74,7 @@ def main():
         raise ValueError('Invalid log level: %s' % log_level)
     logging.basicConfig(level=numeric_level, format='%(levelname)s: %(message)s')
     process_bed_file(args.bed, args.n, args.bca)
+
 
 if __name__ == '__main__':
     main()

--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -2,20 +2,15 @@
 import argparse
 import logging
 
-
-# Function to process the bed file by checking for conditions
 def process_bed_file(input_bed, n_per_split, bca=True):
     SVTYPE_FIELD = 4
     END_FIELD = 2
     START_FIELD = 1
 
-    # Dictionary to store the conditions to be checked with matching prefixes
     condition_prefixes = {
-        'gt5kb': {
-            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
-        'lt5kb': {
-            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
-        'bca': {'condition': lambda line: bca and (line[SVTYPE_FIELD] != 'DEL' and line[SVTYPE_FIELD] != 'DUP' and line[SVTYPE_FIELD] != 'INS')},
+        'gt5kb': {'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
+        'lt5kb': {'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
+        'bca': {'condition': lambda line: bca and line[SVTYPE_FIELD] not in ['DEL', 'DUP', 'INS']},
         'ins': {'condition': lambda line: bca and line[SVTYPE_FIELD] == 'INS'}
     }
 
@@ -23,75 +18,56 @@ def process_bed_file(input_bed, n_per_split, bca=True):
     current_counts = {prefix: 0 for prefix in condition_prefixes.keys()}
     current_suffixes = {prefix: 'a' for prefix in condition_prefixes.keys()}
 
-    # Open the bed file and process
     with open(input_bed, 'r') as infile:
         for line in infile:
-            # process bed file line by line
             line = line.strip('\n').split('\t')
-
-            # Checks which condition and prefix the current line matches and appends it to the corresponding
-            # array and increments the counter for that array
+            line[4], line[5] = line[5], line[4]
+            SVTYPE_FIELD = 5
             for prefix, conditions in condition_prefixes.items():
                 if conditions['condition'](line):
-                    # switch columns so that the samples are in the fifth column and SV type in the sixth column
-                    line[4], line[5] = line[5], line[4]
                     current_lines[prefix].append('\t'.join(line))
                     current_counts[prefix] += 1
-
-                    # If the current array has the maximum allowed lines added to it create a new array
-                    # with the preceding suffix and write the current array to a file
                     if current_counts[prefix] == n_per_split:
                         output_suffix = current_suffixes[prefix].rjust(6, 'a')
                         output_file = f"{prefix}.{output_suffix}.bed"
                         with open(output_file, 'w') as outfile:
                             outfile.write('\n'.join(current_lines[prefix]))
-
                         logging.info(f"File '{output_file}' written.")
                         current_lines[prefix] = []
                         current_counts[prefix] = 0
                         current_suffixes[prefix] = increment_suffix(current_suffixes[prefix])
 
-    # Handle remaining lines after the loop
     for prefix, lines in current_lines.items():
         if lines:
             output_suffix = current_suffixes[prefix].rjust(6, 'a')
             output_file = f"{prefix}.{output_suffix}.bed"
             with open(output_file, 'w') as outfile:
                 outfile.write('\n'.join(lines))
-
             logging.info(f"File '{output_file}' written.")
 
-
-# Function to generate the pattern for suffixes
 def increment_suffix(suffix):
-    # define the alphabet and ending
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
     if suffix == 'z' * 6:
         raise ValueError('All possible files generated.')
     else:
-        # if there are available suffixes increment to next available suffix
         index = alphabet.index(suffix[0])
         next_char = alphabet[(index + 1) % 26]
         return next_char + suffix[1:]
 
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--bed", help="Path to input bed file", required=True)
-    parser.add_argument("--n", help="number of variants per file", required=True)
-    parser.add_argument("--bca", default=False, help="Flag to set to True if the VCF contains BCAs",
-                        action='store_true')
+    parser.add_argument("--n", help="number of variants per file", required=True, type=int)
+    parser.add_argument("--bca", default=False, help="Flag to set to True if the VCF contains BCAs", action='store_true')
     parser.add_argument("--log-level", required=False, default="INFO", help="Specify level of logging information")
     args = parser.parse_args()
 
-    # Set logging level from --log-level input
     log_level = args.log_level
     numeric_level = getattr(logging, log_level.upper(), None)
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: %s' % log_level)
     logging.basicConfig(level=numeric_level, format='%(levelname)s: %(message)s')
     process_bed_file(args.bed, args.n, args.bca)
-
 
 if __name__ == '__main__':
     main()

--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -34,7 +34,7 @@ def process_bed_file(input_bed, n_per_split, bca=True):
             # array and increments the counter for that array
             for prefix, conditions in condition_prefixes.items():
                 if conditions['condition'](line):
-                    line[4],line[5]=line[5],line[4]
+                    line[4], line[5] = line[5], line[4]
                     current_lines[prefix].append('\t'.join(line))
                     current_counts[prefix] += 1
 
@@ -60,6 +60,18 @@ def process_bed_file(input_bed, n_per_split, bca=True):
                 outfile.write('\n'.join(lines))
 
             logging.info(f"File '{output_file}' written.")
+
+# Function to generate the pattern for suffixes
+def increment_suffix(suffix):
+    # define the alphabet and ending
+    alphabet = 'abcdefghijklmnopqrstuvwxyz'
+    if suffix == 'z' * 6:
+        raise ValueError('All possible files generated.')
+    else:
+        # if there are available suffixes increment to next available suffix
+        index = alphabet.index(suffix[0])
+        next_char = alphabet[(index + 1) % 26]
+        return next_char + suffix[1:]
 
 
 def main():

--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -12,13 +12,10 @@ def process_bed_file(input_bed, n_per_split, bca=True):
     # Dictionary to store the conditions to be checked with matching prefixes
     condition_prefixes = {
         'gt5kb': {
-            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (
-                        int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
+            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
         'lt5kb': {
-            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (
-                        int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
-        'bca': {'condition': lambda line: bca and (
-                line[SVTYPE_FIELD] != 'DEL' and line[SVTYPE_FIELD] != 'DUP' and line[SVTYPE_FIELD] != 'INS')},
+            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
+        'bca': {'condition': lambda line: bca and (line[SVTYPE_FIELD] != 'DEL' and line[SVTYPE_FIELD] != 'DUP' and line[SVTYPE_FIELD] != 'INS')},
         'ins': {'condition': lambda line: bca and line[SVTYPE_FIELD] == 'INS'}
     }
 

--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -9,10 +9,8 @@ def process_bed_file(input_bed, n_per_split, bca=True):
     START_FIELD = 1
 
     condition_prefixes = {
-        'gt5kb': {'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (
-                    int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
-        'lt5kb': {'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (
-                    int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
+        'gt5kb': {'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
+        'lt5kb': {'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
         'bca': {'condition': lambda line: bca and line[SVTYPE_FIELD] not in ['DEL', 'DUP', 'INS']},
         'ins': {'condition': lambda line: bca and line[SVTYPE_FIELD] == 'INS'}
     }

--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -28,12 +28,13 @@ def process_bed_file(input_bed, n_per_split, bca=True):
     with open(input_bed, 'r') as infile:
         for line in infile:
             # process bed file line by line
-            line = line.strip().split('\t')
+            line = line.strip('\n').split('\t')
 
             # Checks which condition and prefix the current line matches and appends it to the corresponding
             # array and increments the counter for that array
             for prefix, conditions in condition_prefixes.items():
                 if conditions['condition'](line):
+                    line[4],line[5]=line[5],line[4]
                     current_lines[prefix].append('\t'.join(line))
                     current_counts[prefix] += 1
 
@@ -59,19 +60,6 @@ def process_bed_file(input_bed, n_per_split, bca=True):
                 outfile.write('\n'.join(lines))
 
             logging.info(f"File '{output_file}' written.")
-
-
-# Function to generate the pattern for suffixes
-def increment_suffix(suffix):
-    # define the alphabet and ending
-    alphabet = 'abcdefghijklmnopqrstuvwxyz'
-    if suffix == 'z' * 6:
-        raise ValueError('All possible files generated.')
-    else:
-        # if there are available suffixes increment to next available suffix
-        index = alphabet.index(suffix[0])
-        next_char = alphabet[(index + 1) % 26]
-        return next_char + suffix[1:]
 
 
 def main():

--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -12,13 +12,10 @@ def process_bed_file(input_bed, n_per_split, bca=True):
     # Dictionary to store the conditions to be checked with matching prefixes
     condition_prefixes = {
         'gt5kb': {
-            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (
-                        int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
+            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
         'lt5kb': {
-            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (
-                        int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
-        'bca': {'condition': lambda line: bca and (
-                    line[SVTYPE_FIELD] != 'DEL' and line[SVTYPE_FIELD] != 'DUP' and line[SVTYPE_FIELD] != 'INS')},
+            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
+        'bca': {'condition': lambda line: bca and (line[SVTYPE_FIELD] != 'DEL' and line[SVTYPE_FIELD] != 'DUP' and line[SVTYPE_FIELD] != 'INS')},
         'ins': {'condition': lambda line: bca and line[SVTYPE_FIELD] == 'INS'}
     }
 

--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -12,9 +12,11 @@ def process_bed_file(input_bed, n_per_split, bca=True):
     # Dictionary to store the conditions to be checked with matching prefixes
     condition_prefixes = {
         'gt5kb': {
-            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
+            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (
+                        int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
         'lt5kb': {
-            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
+            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (
+                        int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
         'bca': {'condition': lambda line: bca and (
                 line[SVTYPE_FIELD] != 'DEL' and line[SVTYPE_FIELD] != 'DUP' and line[SVTYPE_FIELD] != 'INS')},
         'ins': {'condition': lambda line: bca and line[SVTYPE_FIELD] == 'INS'}
@@ -61,6 +63,7 @@ def process_bed_file(input_bed, n_per_split, bca=True):
 
             logging.info(f"File '{output_file}' written.")
 
+
 # Function to generate the pattern for suffixes
 def increment_suffix(suffix):
     # define the alphabet and ending
@@ -78,7 +81,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--bed", help="Path to input bed file", required=True)
     parser.add_argument("--n", help="number of variants per file", required=True)
-    parser.add_argument("--bca", default=False, help="Flag to set to True if the VCF contains BCAs", action='store_true')
+    parser.add_argument("--bca", default=False, help="Flag to set to True if the VCF contains BCAs",
+                        action='store_true')
     parser.add_argument("--log-level", required=False, default="INFO", help="Specify level of logging information")
     args = parser.parse_args()
 

--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -12,10 +12,13 @@ def process_bed_file(input_bed, n_per_split, bca=True):
     # Dictionary to store the conditions to be checked with matching prefixes
     condition_prefixes = {
         'gt5kb': {
-            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
+            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (
+                        int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
         'lt5kb': {
-            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
-        'bca': {'condition': lambda line: bca and (line[SVTYPE_FIELD] != 'DEL' and line[SVTYPE_FIELD] != 'DUP' and line[SVTYPE_FIELD] != 'INS')},
+            'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (
+                        int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
+        'bca': {'condition': lambda line: bca and (
+                    line[SVTYPE_FIELD] != 'DEL' and line[SVTYPE_FIELD] != 'DUP' and line[SVTYPE_FIELD] != 'INS')},
         'ins': {'condition': lambda line: bca and line[SVTYPE_FIELD] == 'INS'}
     }
 
@@ -33,6 +36,7 @@ def process_bed_file(input_bed, n_per_split, bca=True):
             # array and increments the counter for that array
             for prefix, conditions in condition_prefixes.items():
                 if conditions['condition'](line):
+                    # switch columns so that the samples are in the fifth column and SV type in the sixth column
                     line[4], line[5] = line[5], line[4]
                     current_lines[prefix].append('\t'.join(line))
                     current_counts[prefix] += 1


### PR DESCRIPTION
The SplitVariants task used to have some lines to switch columns 5 and 6 of the bed file output, which is read in downstream tasks of TrainRDGenotyping.GenotypePESR. This causes the TrainRDGenotyping.GenotypePESR to error out reporting.

Error: WARNING: Incorrect CNV type specified
1: stop("WARNING: Incorrect CNV type specified")
The python script splitvariants.py was modified to switch the columns to the appropriate order to be compatible with downstream analysis requirements. The script passed testing with both womtool and cromshell on the 1kg reference panel with the bca flag set to both True and False.