### PR TITLE
Workflow to apply NCR and reference artifact filters and remove zero-carrier sites

### DIFF
--- a/inputs/templates/test/ApplyNCRAndRefArtifactFilters/ApplyNCRAndRefArtifactFilters.json.tmpl
+++ b/inputs/templates/test/ApplyNCRAndRefArtifactFilters/ApplyNCRAndRefArtifactFilters.json.tmpl
@@ -1,0 +1,12 @@
+{
+  "ApplyNCRAndRefArtifactFilters.vcfs": [ {{ test_batch.genotype_filtered_vcf | tojson }} ],
+  "ApplyNCRAndRefArtifactFilters.apply_filters_script": "gs://broad-dsde-methods-eph/apply_ncr_and_ref_artifact_filters.py",
+  "ApplyNCRAndRefArtifactFilters.ploidy_table": {{ test_batch.ploidy_table | tojson }},
+
+  "ApplyNCRAndRefArtifactFilters.sv_base_mini_docker": {{ dockers.sv_base_mini_docker | tojson }},
+  "ApplyNCRAndRefArtifactFilters.sv_pipeline_docker": {{ dockers.sv_pipeline_docker | tojson }},
+
+  "ApplyNCRAndRefArtifactFilters.ApplyNCRAndRefArtifactFiltersPerContig.no_call_rate_cutoff": 0.05,
+  "ApplyNCRAndRefArtifactFilters.ApplyNCRAndRefArtifactFiltersPerContig.filter_reference_artifacts": "true",
+  "ApplyNCRAndRefArtifactFilters.ApplyNCRAndRefArtifactFiltersPerContig.remove_zero_carrier_sites": "true"
+}

--- a/src/sv-pipeline/scripts/apply_ncr_and_ref_artifact_filters.py
+++ b/src/sv-pipeline/scripts/apply_ncr_and_ref_artifact_filters.py
@@ -69,9 +69,13 @@ def _apply_filters(record, ploidy_dict, ncr_threshold, filter_reference_artifact
     record.info['NCR'] = n_no_call / n_samples if n_samples > 0 else None
     if ncr_threshold is not None and record.info['NCR'] is not None and record.info['NCR'] >= ncr_threshold:
         record.filter.add(_HIGH_NCR_FILTER)
+        if 'PASS' in record.filter:
+            record.filter.pop('PASS')
 
     if filter_reference_artifacts and n_hom_var / n_samples > _REFERENCE_ARTIFACT_THRESHOLD:
         record.filter.add(_REFERENCE_ARTIFACT_FILTER)
+        if 'PASS' in record.filter:
+            record.filter.pop('PASS')
 
     # Clean out AF metrics since they're no longer valid
     for field in ['AC', 'AF']:

--- a/src/sv-pipeline/scripts/apply_ncr_and_ref_artifact_filters.py
+++ b/src/sv-pipeline/scripts/apply_ncr_and_ref_artifact_filters.py
@@ -1,0 +1,171 @@
+#!/bin/env python
+
+import argparse
+import sys
+import pysam
+import math
+from typing import List, Text, Dict, Optional
+
+
+_HIGH_NCR_FILTER = "HIGH_NCR"
+_REFERENCE_ARTIFACT_FILTER = "REFERENCE_ARTIFACT"
+_REFERENCE_ARTIFACT_THRESHOLD = 0.99
+
+
+def _is_no_call(gt):
+    s = _gt_no_call_map.get(gt, None)
+    if s is None:
+        s = all([a is None for a in gt])
+        _gt_no_call_map[gt] = s
+    return s
+
+
+def _is_hom_ref(gt):
+    s = _gt_ref_map.get(gt, None)
+    if s is None:
+        s = all([a is not None and a == 0 for a in gt])
+        _gt_ref_map[gt] = s
+    return s
+
+
+def _is_hom_var(gt):
+    s = _gt_hom_var_map.get(gt, None)
+    if s is None:
+        s = all([a is not None and a > 0 for a in gt])
+        _gt_hom_var_map[gt] = s
+    return s
+
+
+def _apply_filters(record, ploidy_dict, ncr_threshold, filter_reference_artifacts, remove_zero_carrier_sites):
+    if record.info['SVTYPE'] == 'CNV':
+        return True # skip checks and annotations for mCNVs due to lack of GT
+
+    n_samples = 0
+    n_no_call = 0
+    n_hom_var = 0
+    has_carrier = False
+    for s, gt in record.samples.items():
+        # Count every sample where ploidy > 0
+        if ploidy_dict[s][record.chrom] == 0:
+            continue
+        n_samples += 1
+        # Count no-calls and hom vars
+        if _is_no_call(gt['GT']):
+            n_no_call += 1
+        elif _is_hom_var(gt['GT']):
+            n_hom_var += 1
+            has_carrier = True
+        elif not _is_hom_ref(gt['GT']):
+            has_carrier = True
+
+    # hard filter sites with no carriers
+    if remove_zero_carrier_sites and not has_carrier:
+        return False
+
+    # Annotate metrics and apply filters
+    record.info['NCN'] = n_no_call
+    record.info['NCR'] = n_no_call / n_samples if n_samples > 0 else None
+    if ncr_threshold is not None and record.info['NCR'] is not None and record.info['NCR'] >= ncr_threshold:
+        record.filter.add(_HIGH_NCR_FILTER)
+
+    if filter_reference_artifacts and n_hom_var / n_samples > _REFERENCE_ARTIFACT_THRESHOLD:
+        record.filter.add(_REFERENCE_ARTIFACT_FILTER)
+
+    # Clean out AF metrics since they're no longer valid
+    for field in ['AC', 'AF']:
+        if field in record.info:
+            del record.info[field]
+    return True
+
+
+def process(vcf, fout, ploidy_dict, thresholds, args):
+    n_samples = float(len(fout.header.samples))
+    if n_samples == 0:
+        raise ValueError("This is a sites-only vcf")
+    for record in vcf:
+        keep = _apply_filters(record=record,
+                      ploidy_dict=ploidy_dict,
+                      ncr_threshold=args.ncr_threshold,
+                      filter_reference_artifacts=args.filter_reference_artifacts,
+                      remove_zero_carrier_sites=args.remove_zero_carrier_sites)
+        if keep:
+            fout.write(record)
+
+
+def _parse_ploidy_table(path: Text) -> Dict[Text, Dict[Text, int]]:
+    """
+    Parses tsv of sample ploidy values.
+
+    Parameters
+    ----------
+    path: Text
+        table path
+
+    Returns
+    -------
+    header: Dict[Text, Dict[Text, int]]
+        map of sample to contig to ploidy, i.e. Dict[sample][contig] = ploidy
+    """
+    ploidy_dict = dict()
+    with open(path, 'r') as f:
+        header = f.readline().strip().split('\t')
+        for line in f:
+            tokens = line.strip().split('\t')
+            sample = tokens[0]
+            ploidy_dict[sample] = {header[i]: int(tokens[i]) for i in range(1, len(header))}
+    return ploidy_dict
+
+
+def _parse_arguments(argv: List[Text]) -> argparse.Namespace:
+    # noinspection PyTypeChecker
+    parser = argparse.ArgumentParser(
+        description="Apply class-specific genotype filtering using SL scores and annotates NCR",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('--vcf', type=str, help='Input vcf (defaults to stdin)')
+    parser.add_argument('--out', type=str, help='Output file (defaults to stdout)')
+    parser.add_argument('--ploidy-table', type=str, required=True, help='Ploidy table tsv')
+    parser.add_argument("--ncr-threshold", type=float,
+                        help=f"If provided, adds {_HIGH_NCR_FILTER} filter to records with no-call rates equal to or "
+                             f"exceeding this threshold")
+    parser.add_argument("--filter-reference-artifacts", type=bool, action='store_true', default=False,
+                        help=f"If provided, adds {_REFERENCE_ARTIFACT_FILTER} filter to records that are hom alt in "
+                             f">{_REFERENCE_ARTIFACT_THRESHOLD*100}% of samples>")
+    parser.add_argument("--remove-zero-carrier-sites", type=bool, action='store_true', default=False,
+                        help=f"If provided, hard filters sites with zero carriers>")
+    if len(argv) <= 1:
+        parser.parse_args(["--help"])
+        sys.exit(0)
+    parsed_arguments = parser.parse_args(argv[1:])
+    return parsed_arguments
+
+
+def main(argv: Optional[List[Text]] = None):
+    if argv is None:
+        argv = sys.argv
+    args = _parse_arguments(argv)
+
+    if args.vcf is None:
+        vcf = pysam.VariantFile(sys.stdin)
+    else:
+        vcf = pysam.VariantFile(args.vcf)
+
+    header = vcf.header
+    header.add_line('##INFO=<ID=NCN,Number=1,Type=Integer,Description="Number of no-call genotypes">')
+    header.add_line('##INFO=<ID=NCR,Number=1,Type=Float,Description="Rate of no-call genotypes">')
+    if args.ncr_threshold is not None:
+        header.add_line(f"##FILTER=<ID={_HIGH_NCR_FILTER},Description=\"Unacceptably high rate of no-call GTs\">")
+    if args.filter_reference_artifacts:
+        header.add_line(f"##FILTER=<ID={_REFERENCE_ARTIFACT_FILTER},Description=\"Likely reference artifact sites that are homozygous alternative in over 99% of the samples\">")
+    if args.out is None:
+        fout = pysam.VariantFile(sys.stdout, 'w', header=header)
+    else:
+        fout = pysam.VariantFile(args.out, 'w', header=header)
+
+    ploidy_dict = _parse_ploidy_table(args.ploidy_table)
+    process(vcf, fout, ploidy_dict, args)
+    fout.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sv-pipeline/scripts/apply_ncr_and_ref_artifact_filters.py
+++ b/src/sv-pipeline/scripts/apply_ncr_and_ref_artifact_filters.py
@@ -6,7 +6,9 @@ import pysam
 import math
 from typing import List, Text, Dict, Optional
 
-
+_gt_no_call_map = dict()
+_gt_hom_var_map = dict()
+_gt_ref_map = dict()
 _HIGH_NCR_FILTER = "HIGH_NCR"
 _REFERENCE_ARTIFACT_FILTER = "REFERENCE_ARTIFACT"
 _REFERENCE_ARTIFACT_THRESHOLD = 0.99
@@ -78,7 +80,7 @@ def _apply_filters(record, ploidy_dict, ncr_threshold, filter_reference_artifact
     return True
 
 
-def process(vcf, fout, ploidy_dict, thresholds, args):
+def process(vcf, fout, ploidy_dict, args):
     n_samples = float(len(fout.header.samples))
     if n_samples == 0:
         raise ValueError("This is a sites-only vcf")
@@ -128,10 +130,10 @@ def _parse_arguments(argv: List[Text]) -> argparse.Namespace:
     parser.add_argument("--ncr-threshold", type=float,
                         help=f"If provided, adds {_HIGH_NCR_FILTER} filter to records with no-call rates equal to or "
                              f"exceeding this threshold")
-    parser.add_argument("--filter-reference-artifacts", type=bool, action='store_true', default=False,
+    parser.add_argument("--filter-reference-artifacts", action='store_true', default=False,
                         help=f"If provided, adds {_REFERENCE_ARTIFACT_FILTER} filter to records that are hom alt in "
                              f">{_REFERENCE_ARTIFACT_THRESHOLD*100}% of samples>")
-    parser.add_argument("--remove-zero-carrier-sites", type=bool, action='store_true', default=False,
+    parser.add_argument("--remove-zero-carrier-sites", action='store_true', default=False,
                         help=f"If provided, hard filters sites with zero carriers>")
     if len(argv) <= 1:
         parser.parse_args(["--help"])

--- a/wdl/ApplyNCRAndRefArtifactFilters.wdl
+++ b/wdl/ApplyNCRAndRefArtifactFilters.wdl
@@ -1,0 +1,33 @@
+version 1.0
+
+import "ApplyNCRAndRefArtifactFiltersPerContig.wdl" as per_contig
+
+workflow ApplyNCRAndRefArtifactFilters {
+  input {
+    Array[File] vcfs
+    String label = "ncr_and_refartifact"
+
+    File? apply_filters_script
+
+    String sv_pipeline_docker
+    String sv_base_mini_docker
+  }
+
+  scatter (vcf in vcfs) {
+    String base = basename(vcf, ".vcf.gz")
+    call per_contig.ApplyNCRAndRefArtifactFiltersPerContig {
+      input:
+        vcf = vcf,
+        prefix = "~{base}.~{label}",
+        apply_filters_script = apply_filters_script,
+        sv_pipeline_docker = sv_pipeline_docker,
+        sv_base_mini_docker = sv_base_mini_docker
+    }
+  }
+
+
+  output {
+    Array[File] filtered_vcfs = ApplyNCRAndRefArtifactFiltersPerContig.filtered_vcf
+    Array[File] filtered_vcf_indexes = ApplyNCRAndRefArtifactFiltersPerContig.filtered_vcf_index
+  }
+}

--- a/wdl/ApplyNCRAndRefArtifactFilters.wdl
+++ b/wdl/ApplyNCRAndRefArtifactFilters.wdl
@@ -6,6 +6,7 @@ workflow ApplyNCRAndRefArtifactFilters {
   input {
     Array[File] vcfs
     String label = "ncr_and_refartifact"
+    File ploidy_table
 
     File? apply_filters_script
 
@@ -19,6 +20,7 @@ workflow ApplyNCRAndRefArtifactFilters {
       input:
         vcf = vcf,
         prefix = "~{base}.~{label}",
+        ploidy_table = ploidy_table,
         apply_filters_script = apply_filters_script,
         sv_pipeline_docker = sv_pipeline_docker,
         sv_base_mini_docker = sv_base_mini_docker

--- a/wdl/ApplyNCRAndRefArtifactFiltersPerContig.wdl
+++ b/wdl/ApplyNCRAndRefArtifactFiltersPerContig.wdl
@@ -12,8 +12,8 @@ workflow ApplyNCRAndRefArtifactFiltersPerContig {
     Int records_per_shard = 20000
 
     Float? no_call_rate_cutoff
-    Boolean filter_reference_artifacts
-    Boolean remove_zero_carrier_sites
+    Boolean filter_reference_artifacts = true
+    Boolean remove_zero_carrier_sites = true
 
     File? apply_filters_script
 

--- a/wdl/ApplyNCRAndRefArtifactFiltersPerContig.wdl
+++ b/wdl/ApplyNCRAndRefArtifactFiltersPerContig.wdl
@@ -73,7 +73,7 @@ task ApplyFilters {
     Float? no_call_rate_cutoff
     Boolean filter_reference_artifacts
     Boolean remove_zero_carrier_sites
-    String? apply_filters_script
+    File? apply_filters_script
     String sv_pipeline_docker
     RuntimeAttr? runtime_attr_override
   }

--- a/wdl/ApplyNCRAndRefArtifactFiltersPerContig.wdl
+++ b/wdl/ApplyNCRAndRefArtifactFiltersPerContig.wdl
@@ -1,0 +1,118 @@
+version 1.0
+
+import "TasksMakeCohortVcf.wdl" as tasks
+import "Structs.wdl"
+
+workflow ApplyNCRAndRefArtifactFiltersPerContig {
+  input {
+    File vcf
+    String prefix
+
+    File ploidy_table
+    Int records_per_shard = 20000
+
+    Float? no_call_rate_cutoff
+    Boolean filter_reference_artifacts
+    Boolean remove_zero_carrier_sites
+
+    File? apply_filters_script
+
+    String sv_pipeline_docker
+    String sv_base_mini_docker
+
+    RuntimeAttr? runtime_attr_scatter_vcf
+    RuntimeAttr? runtime_attr_apply_filters
+    RuntimeAttr? runtime_attr_concat_vcfs
+  }
+
+  call tasks.ScatterVcf {
+    input:
+      vcf = vcf,
+      records_per_shard = records_per_shard,
+      prefix = "~{prefix}.scatter",
+      sv_pipeline_docker = sv_pipeline_docker,
+      runtime_attr_override = runtime_attr_scatter_vcf
+  }
+
+  scatter (i in range(length(ScatterVcf.shards))) {
+    call ApplyFilters {
+      input:
+        vcf = ScatterVcf.shards[i],
+        prefix = "~{prefix}.shard_~{i}",
+        ploidy_table = ploidy_table,
+        no_call_rate_cutoff = no_call_rate_cutoff,
+        filter_reference_artifacts = filter_reference_artifacts,
+        remove_zero_carrier_sites = remove_zero_carrier_sites,
+        apply_filters_script = apply_filters_script,
+        sv_pipeline_docker = sv_pipeline_docker,
+        runtime_attr_override = runtime_attr_apply_filters
+    }
+  }
+
+  call tasks.ConcatVcfs {
+    input:
+      vcfs = ApplyFilters.filtered_vcf,
+      naive = true,
+      outfile_prefix = prefix,
+      sv_base_mini_docker = sv_base_mini_docker,
+      runtime_attr_override = runtime_attr_concat_vcfs
+  }
+
+  output {
+    File filtered_vcf = ConcatVcfs.concat_vcf
+    File filtered_vcf_index = ConcatVcfs.concat_vcf_idx
+  }
+}
+
+
+task ApplyFilters {
+  input {
+    File vcf
+    String prefix
+    File ploidy_table
+    Float? no_call_rate_cutoff
+    Boolean filter_reference_artifacts
+    Boolean remove_zero_carrier_sites
+    String? apply_filters_script
+    String sv_pipeline_docker
+    RuntimeAttr? runtime_attr_override
+  }
+
+  RuntimeAttr default_attr = object {
+    cpu_cores: 1,
+    mem_gb: 5,
+    disk_gb: ceil(10.0 + 2 * size(vcf, "GiB")),
+    boot_disk_gb: 30,
+    preemptible_tries: 1,
+    max_retries: 1
+  }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+  command <<<
+    set -euo pipefail
+
+    python ~{select_first([apply_filters_script, "/opt/sv-pipeline/scripts/apply_ncr_and_ref_artifact_filters.py"])} \
+      --vcf ~{vcf} \
+      --out ~{prefix}.vcf.gz \
+      --ploidy-table ~{ploidy_table} \
+      --ncr-threshold ~{no_call_rate_cutoff} \
+      ~{if (filter_reference_artifacts) then "--filter-reference-artifacts" else ""} \
+      ~{if (remove_zero_carrier_sites) then "--remove-zero-carrier-sites" else ""}
+
+  >>>
+
+  output {
+    File filtered_vcf = "~{prefix}.vcf.gz"
+  }
+
+  runtime {
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
+    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
+    docker: sv_pipeline_docker
+    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
+  }
+}
+


### PR DESCRIPTION
### Updates

Create a standalone WDL for NCR and reference artifact filters. Also removes sites with zero carriers. This script pulls code from the existing NCR calculation in apply_sl_filter.py but applies it independently from genotype filtering to allow for intervening steps like outlier removal and CPX filtering which impact the NCR calculation.

Marked as draft while AoU Phase 2 downstream steps development is ongoing.