### PR TITLE
Integer-conformant AF values

### DIFF
--- a/src/sv-pipeline/05_annotation/scripts/compute_AFs.py
+++ b/src/sv-pipeline/05_annotation/scripts/compute_AFs.py
@@ -180,7 +180,7 @@ def calc_allele_freq(record, samples, prefix=None, hemi=False):
 
         # Adjust hemizygous allele number and allele count, if optioned
         if hemi:
-            AN = AN / 2
+            AN = round(AN / 2)
             # For hemizygous sites, AC must be the sum of all non-reference *genotypes*, not alleles
             AC = n_gts_with_gt_0_alts
 


### PR DESCRIPTION
Docker image this failure was identified in: australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-pipeline:2023-09-13-v0.28.3-beta-af8362e3

Relevant Workflow: ShardedAnnotateVcf.ComputeAFs
https://github.com/broadinstitute/gatk-sv/blob/d37e453038e425acba9683da503218fe3d4b1033/wdl/ShardedAnnotateVcf.wdl#L146


I've recently seen deterministic failures during AnnotateVCF running on CNV data. I've tracked the error to this line - 

```python3
if hemi:
    AN = AN / 2
```

if Hemi (chrX & MALE & non-par), AN = AN/2. If the AN was an odd number, the result is a float. This value is added to the Variant entity as `MALE_AN`, which is described in the header as an INTEGER. PySam doesn't support adding a float value to an Integer field:

```text
Traceback (most recent call last):
  File "/data/script.py", line 506, in <module>
    main()
  File "/data/script.py", line 498, in main
    newrec = gather_allele_freqs(r, samples_list, males_set, females_set, parbt, pop_dict,
  File "/data/script.py", line 105, in gather_allele_freqs
    calc_allele_freq(record, males_set, prefix='MALE', hemi=True)
  File "/data/script.py", line 195, in calc_allele_freq
    record.info[(prefix + '_' if prefix else '') + 'AN'] = AN
  File "pysam/libcbcf.pyx", line 2586, in pysam.libcbcf.VariantRecordInfo.__setitem__
  File "pysam/libcbcf.pyx", line 687, in pysam.libcbcf.bcf_info_set_value
  File "pysam/libcbcf.pyx", line 592, in pysam.libcbcf.bcf_check_values
TypeError: invalid value for Integer format
```

There is an additional later call implicated here, `adj_an = m_an + f_an`, where if the male AN is a float, the overall `AN` field would become a float, though this single change also addresses that, as `MALE_AN` is fixed as an Integer.

I'm not sure if I'm running into this now due to some weird data, previous data run through the same pipeline has never hit this issue, but based on the data I have this is a possible point of failure and I'm surprised nobody has hit it yet.