### PR TITLE
Make MELT scripts independent of the execution path.

### DIFF
--- a/dockerfiles/melt/run_MELT_2.0.5.sh
+++ b/dockerfiles/melt/run_MELT_2.0.5.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 ##### Usage statement
 usage(){
 cat <<EOF
-  usage: runMELT.sh bam ref cov read_len mean_is MELT_DIR RUN_DIR REF_VER
+  usage: runMELT.sh bam ref cov read_len mean_is MELT_DIR REF_VER
   Runs MELT for mobile element detection. Requires paired-end deep (>10X) WGS data mapped with BWA.
   Positional arguments (all required):
     bam        Full path to mapped bam file (bam.bai assumed accompanying the BAM)
@@ -28,7 +28,6 @@ cat <<EOF
     read_len   Mean read length of library
     mean_is    Mean insert size of library
     MELT_DIR   Full path to MELT install directory
-    RUN_DIR    Full path to directory for MELT output
     REF_VER    Reference version (19|38)
 EOF
 }
@@ -51,11 +50,10 @@ cov=$3
 read_len=$4
 mean_is=$5
 MELT_DIR=$6
-RUN_DIR=$7
-REF_VER=$8
+REF_VER=$7
 
 ##### Check for required input (unset or empty)
-if [ -z "${bam}" ] || [ -z "${ref}" ] || [ -z "${cov}" ] || [ -z "${read_len}" ] || [ -z "${mean_is}" ] || [ -z "${MELT_DIR}" ] || [ -z "${RUN_DIR}" ] || [ -z "${REF_VER}" ]; then
+if [ -z "${bam}" ] || [ -z "${ref}" ] || [ -z "${cov}" ] || [ -z "${read_len}" ] || [ -z "${mean_is}" ] || [ -z "${MELT_DIR}" ] || [ -z "${REF_VER}" ]; then
   echo "At least one of the required parameters is not properly set by the given command:"
   temp_args="$@" && echo "$0 ${temp_args}" && exit 1; # non-zero exit because it indicates user errror
 fi
@@ -76,20 +74,18 @@ read_len=$( echo "${read_len}" | cut -f1 -d\. )
 mean_is=$( echo "${mean_is}" | cut -f1 -d\. )
 
 ##### remove trailing slash just to make sure
-RUN_DIR="${RUN_DIR%/}"
 MELT_DIR="${MELT_DIR%/}"
 
 ##### Create transposons reference list
 if [[ "$REF_VER" == "38" ]]; then
-  ls "${MELT_DIR}"/me_refs/Hg38/*zip | sed 's/\*//g' > "${RUN_DIR}/transposon_reference.list"
+  ls "${MELT_DIR}"/me_refs/Hg38/*zip | sed 's/\*//g' > "transposon_reference.list"
   GENE_BED_FILE="${MELT_DIR}/add_bed_files/Hg38/Hg38.genes.bed"
 elif [[ "$REF_VER" == "19" ]]; then
-  ls "${MELT_DIR}"/me_refs/1KGP_Hg19/*zip | sed 's/\*//g' > "${RUN_DIR}/transposon_reference.list"
+  ls "${MELT_DIR}"/me_refs/1KGP_Hg19/*zip | sed 's/\*//g' > "transposon_reference.list"
   GENE_BED_FILE="${MELT_DIR}/add_bed_files/1KGP_Hg19/hg19.genes.bed"
 fi
 
 ##### Create output directory if it doesn't exist. then run MELT Single
-mkdir -p "${RUN_DIR}" && cd "${RUN_DIR}"
 java -Xmx"${JVM_MAX_MEM}" \
   -jar "${MELT_DIR}/MELT.jar" \
   Single \
@@ -99,6 +95,6 @@ java -Xmx"${JVM_MAX_MEM}" \
   -r "${read_len}" \
   -e "${mean_is}" \
   -d "${MIN_CHR_LENGTH}" \
-  -t "${RUN_DIR}/transposon_reference.list" \
+  -t "transposon_reference.list" \
   -n "${GENE_BED_FILE}" \
-  -w "${RUN_DIR}"
+  -w "."

--- a/wdl/MELT.wdl
+++ b/wdl/MELT.wdl
@@ -511,24 +511,6 @@ task RunMELT {
     # these locations should be stable
     MELT_DIR="/MELT"
 
-    # `cromwell_root` and `cromwell-executions` are the **default**
-    # root directory for cromwell deployments on GCP and Azure respectively.
-    # The last option, i.e., $PWD, is the fall back option if the
-    # default root directory of the cromwell instance was changed,
-    # however, it is not a reliable option as it fails on GCP.
-    # It does not seem Cromwell sets a runtime environment variable
-    # exposing the configured value of the root directory,
-    # which could have provided a portable solution for this.
-    # The following solution works with the Cromwell deployments
-    # we are currently using on GCP and Azure.
-    if [ -d "/cromwell_root" ]; then
-      CROMWELL_ROOT="/cromwell_root"
-    elif [ -d "/cromwell-executions" ]; then
-      CROMWELL_ROOT="/cromwell-executions"
-    else
-      CROMWELL_ROOT="$PWD"
-    fi
-
     # these locations may vary based on MELT version number, so find them:
     MELT_ROOT=$(find "$MELT_DIR" -name "MELT.jar" | xargs -n1 dirname)
     MELT_SCRIPT=$(ls "$MELT_DIR/run_MELT"*.sh)
@@ -541,7 +523,6 @@ task RunMELT {
       ~{read_length} \
       ~{insert_size} \
       "$MELT_ROOT" \
-      "$CROMWELL_ROOT" \
       ~{reference_version}
 
     cat "~{melt_standard_vcf_header}" \


### PR DESCRIPTION
MELT scripts build logic dependent on the script invocation path. The invocation path on Cromwell is a deployment-specific configuration, and currently, the default settings on GCP and Azure differ, which breaks MELT execution. We have two possible tracks to address this: (1) update the scripts to match the currently configured invocation path on Azure and GCP, or (2) update the scripts to be independent of the invocation path. This PR implements the latter approach as it seems more portable and invariant to deployment-specific configurations of Cromwell. 

Specifically, this PR implements the following: 

- [x] Remove invocation path-dependent logic from MELT script and WDL;
- [ ] Update MELT docker and update `dockers*.json` accordingly. 