### PR TITLE
Update gnomad-v2 sample-level benchmarking data path

### DIFF
--- a/inputs/values/resources_hg38.json
+++ b/inputs/values/resources_hg38.json
@@ -65,7 +65,7 @@
   ],
 
   "ccdg_abel_site_level_benchmarking_dataset" : ["CCDG_abel", "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/CCDG_Abel"],
-  "gnomad_v2_collins_sample_level_benchmarking_dataset": ["gnomAD_v2_Collins", "gs://gatk-sv-resources-secure/hg38/v0/sv-resources/resources/v1/gnomAD_v2_Collins_perSample.tar.gz"],
+  "gnomad_v2_collins_sample_level_benchmarking_dataset": ["gnomAD_v2_Collins", "gs://gatk-sv-resources-secure/resources/hg38_benchmarking/gnomAD_v2_Collins_perSample.tar.gz"],
   "gnomad_v2_collins_site_level_benchmarking_dataset" : ["gnomAD_v2_Collins", "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/gnomAD_v2_Collins"],
   "hgsv_byrska_bishop_sample_level_benchmarking_dataset": ["HGSV_ByrskaBishop", "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/HGSV_ByrskaBishop_GATKSV_perSample.tar.gz"],
   "hgsv_byrska_bishop_sample_renaming_tsv": "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/rename_sample_ids_HGSV_ByrskaBishop.tsv",


### PR DESCRIPTION
### Updates

Updated path for gnomAD-v2 sample-level benchmarking tarball used in MainVcfQc to reflect directory reorganization.

### Testing

Built and validated all input JSONs with womtool and Terra validation script.