### PR TITLE
Make per-sample QC plots optional in MainVcfQc

### DIFF
--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -21,6 +21,7 @@ workflow MainVcfQc {
     String prefix
     Int sv_per_shard
     Int samples_per_shard
+    Boolean do_per_sample_qc = true
     Array[Array[String]]? site_level_comparison_datasets    # Array of two-element arrays, one per dataset, each of format [prefix, gs:// path to directory with one BED per population]
     Array[Array[String]]? sample_level_comparison_datasets  # Array of two-element arrays, one per dataset, each of format [prefix, gs:// path to per-sample tarballs]
     File primary_contigs_fai
@@ -169,105 +170,107 @@ workflow MainVcfQc {
     }
   }
 
-  # Shard sample list
-  call MiniTasks.SplitUncompressed as SplitSamplesList {
-    input:
-      whole_file=CollectQcVcfWide.samples_list[0],
-      lines_per_shard=samples_per_shard,
-      shard_prefix="~{prefix}.list_shard.",
-      sv_pipeline_docker=sv_pipeline_docker,
-      runtime_attr_override=runtime_override_split_samples_list
-  }
-
-  # Collect per-sample VID lists for each sample shard
-  scatter ( shard in SplitSamplesList.shards ) {
-    call persample.CollectQcPerSample {
+  if (do_per_sample_qc) {
+    # Shard sample list
+    call MiniTasks.SplitUncompressed as SplitSamplesList {
       input:
-        vcfs=vcfs_for_qc,
-        vcf_format_has_cn=vcf_format_has_cn,
-        samples_list=shard,
-        prefix=prefix,
-        sv_base_mini_docker=sv_base_mini_docker,
+        whole_file=CollectQcVcfWide.samples_list[0],
+        lines_per_shard=samples_per_shard,
+        shard_prefix="~{prefix}.list_shard.",
         sv_pipeline_docker=sv_pipeline_docker,
-        runtime_override_collect_vids_per_sample=runtime_override_collect_vids_per_sample,
-        runtime_override_merge_sharded_per_sample_vid_lists=runtime_override_merge_sharded_per_sample_vid_lists
+        runtime_attr_override=runtime_override_split_samples_list
     }
-  }
-  
-  # Merge all VID lists into single output directory and tar it
-  call TarShardVidLists {
-    input:
-      in_tarballs=CollectQcPerSample.vid_lists,
-      folder_name="~{prefix}_perSample_VIDs_merged",
-      tarball_prefix="~{prefix}_perSample_VIDs",
-      sv_base_mini_docker=sv_base_mini_docker,
-      runtime_attr_override=runtime_override_tar_shard_vid_lists
-  }
-  
-  Int max_gq_ = select_first([max_gq, 99])
-  # Plot per-sample stats
-  call PlotQcPerSample {
-    input:
-      vcf_stats=MergeVcfWideStats.merged_bed_file,
-      samples_list=CollectQcVcfWide.samples_list[0],
-      per_sample_tarball=TarShardVidLists.vid_lists,
-      prefix=prefix,
-      max_gq=max_gq_,
-      downsample_qc_per_sample=downsample_qc_per_sample,
-      sv_pipeline_qc_docker=sv_pipeline_qc_docker,
-      runtime_attr_override=runtime_override_plot_qc_per_sample
-  }
 
-  # Plot per-family stats if .ped file provided as input
-  if (defined(ped_file)) {
-    call PlotQcPerFamily {
+    # Collect per-sample VID lists for each sample shard
+    scatter ( shard in SplitSamplesList.shards ) {
+      call persample.CollectQcPerSample {
+        input:
+          vcfs=vcfs_for_qc,
+          vcf_format_has_cn=vcf_format_has_cn,
+          samples_list=shard,
+          prefix=prefix,
+          sv_base_mini_docker=sv_base_mini_docker,
+          sv_pipeline_docker=sv_pipeline_docker,
+          runtime_override_collect_vids_per_sample=runtime_override_collect_vids_per_sample,
+          runtime_override_merge_sharded_per_sample_vid_lists=runtime_override_merge_sharded_per_sample_vid_lists
+      }
+    }
+
+    # Merge all VID lists into single output directory and tar it
+    call TarShardVidLists {
+      input:
+        in_tarballs=CollectQcPerSample.vid_lists,
+        folder_name="~{prefix}_perSample_VIDs_merged",
+        tarball_prefix="~{prefix}_perSample_VIDs",
+        sv_base_mini_docker=sv_base_mini_docker,
+        runtime_attr_override=runtime_override_tar_shard_vid_lists
+    }
+
+    Int max_gq_ = select_first([max_gq, 99])
+    # Plot per-sample stats
+    call PlotQcPerSample {
       input:
         vcf_stats=MergeVcfWideStats.merged_bed_file,
         samples_list=CollectQcVcfWide.samples_list[0],
-        ped_file=select_first([ped_file]),
-        max_trios=max_trios,
         per_sample_tarball=TarShardVidLists.vid_lists,
         prefix=prefix,
         max_gq=max_gq_,
+        downsample_qc_per_sample=downsample_qc_per_sample,
         sv_pipeline_qc_docker=sv_pipeline_qc_docker,
-        runtime_attr_override=runtime_override_plot_qc_per_family
+        runtime_attr_override=runtime_override_plot_qc_per_sample
     }
-  }
 
-  # Collect and plot per-sample benchmarking vs. external callsets
-  if (defined(sample_level_comparison_datasets)) {
-    scatter ( comparison_dataset_info in select_first([sample_level_comparison_datasets, 
-                                                       [[], []]]) ) {
-      # Collect per-sample external benchmarking data
-      call samplebench.CollectPerSampleBenchmarking {
+    # Plot per-family stats if .ped file provided as input
+    if (defined(ped_file)) {
+      call PlotQcPerFamily {
         input:
           vcf_stats=MergeVcfWideStats.merged_bed_file,
           samples_list=CollectQcVcfWide.samples_list[0],
+          ped_file=select_first([ped_file]),
+          max_trios=max_trios,
           per_sample_tarball=TarShardVidLists.vid_lists,
-          comparison_tarball=comparison_dataset_info[1],
-          sample_renaming_tsv=sample_renaming_tsv,
           prefix=prefix,
-          contigs=contigs,
-          comparison_set_name=comparison_dataset_info[0],
-          samples_per_shard=samples_per_shard,
-          random_seed=random_seed,
-          sv_base_mini_docker=sv_base_mini_docker,
-          sv_pipeline_docker=sv_pipeline_docker,
+          max_gq=max_gq_,
           sv_pipeline_qc_docker=sv_pipeline_qc_docker,
-          runtime_override_benchmark_samples=runtime_override_benchmark_samples,
-          runtime_override_split_shuffled_list=runtime_override_split_shuffled_list,
-          runtime_override_merge_and_tar_shard_benchmarks=runtime_override_merge_and_tar_shard_benchmarks
+          runtime_attr_override=runtime_override_plot_qc_per_family
       }
+    }
 
-      # Plot per-sample benchmarking results
-      call PlotPerSampleBenchmarking {
-        input:
-          per_sample_benchmarking_tarball=CollectPerSampleBenchmarking.benchmarking_results_tarball,
-          samples_list=CollectQcVcfWide.samples_list[0],
-          comparison_set_name=comparison_dataset_info[0],
-          prefix=prefix,
-          sv_pipeline_qc_docker=sv_pipeline_qc_docker,
-          runtime_attr_override=runtime_override_per_sample_benchmark_plot
+    # Collect and plot per-sample benchmarking vs. external callsets
+    if (defined(sample_level_comparison_datasets)) {
+      scatter ( comparison_dataset_info in select_first([sample_level_comparison_datasets,
+                                                         [[], []]]) ) {
+        # Collect per-sample external benchmarking data
+        call samplebench.CollectPerSampleBenchmarking {
+          input:
+            vcf_stats=MergeVcfWideStats.merged_bed_file,
+            samples_list=CollectQcVcfWide.samples_list[0],
+            per_sample_tarball=TarShardVidLists.vid_lists,
+            comparison_tarball=comparison_dataset_info[1],
+            sample_renaming_tsv=sample_renaming_tsv,
+            prefix=prefix,
+            contigs=contigs,
+            comparison_set_name=comparison_dataset_info[0],
+            samples_per_shard=samples_per_shard,
+            random_seed=random_seed,
+            sv_base_mini_docker=sv_base_mini_docker,
+            sv_pipeline_docker=sv_pipeline_docker,
+            sv_pipeline_qc_docker=sv_pipeline_qc_docker,
+            runtime_override_benchmark_samples=runtime_override_benchmark_samples,
+            runtime_override_split_shuffled_list=runtime_override_split_shuffled_list,
+            runtime_override_merge_and_tar_shard_benchmarks=runtime_override_merge_and_tar_shard_benchmarks
+        }
+
+        # Plot per-sample benchmarking results
+        call PlotPerSampleBenchmarking {
+          input:
+            per_sample_benchmarking_tarball=CollectPerSampleBenchmarking.benchmarking_results_tarball,
+            samples_list=CollectQcVcfWide.samples_list[0],
+            comparison_set_name=comparison_dataset_info[0],
+            prefix=prefix,
+            sv_pipeline_qc_docker=sv_pipeline_qc_docker,
+            runtime_attr_override=runtime_override_per_sample_benchmark_plot
+        }
       }
     }
   }
@@ -718,7 +721,7 @@ task SanitizeOutputs {
     File vcf_stats_idx
     File plot_qc_vcfwide_tarball
     Array[File]? plot_qc_site_level_external_benchmarking_tarballs
-    File plot_qc_per_sample_tarball
+    File? plot_qc_per_sample_tarball
     File? plot_qc_per_family_tarball
     File? cleaned_fam_file
     Array[File]? plot_qc_per_sample_external_benchmarking_tarballs
@@ -727,11 +730,12 @@ task SanitizeOutputs {
   }
 
   # simple compress + tar workflow
-  Float isize_1 = size([samples_list, vcf_stats, vcf_stats_idx, plot_qc_vcfwide_tarball, plot_qc_per_sample_tarball], "GiB")
+  Float isize_1 = size([samples_list, vcf_stats, vcf_stats_idx, plot_qc_vcfwide_tarball], "GiB")
   Float isize_2 = size(select_first([plot_qc_site_level_external_benchmarking_tarballs, []]), "GiB")
   Float isize_3 = size(select_first([plot_qc_per_family_tarball, []]), "GiB")
   Float isize_4 = size(select_first([plot_qc_per_sample_external_benchmarking_tarballs, []]), "GiB")
-  Float input_size = isize_1 + isize_2 + isize_3 + isize_4
+  Float isize_5 = size(select_first([plot_qc_per_sample_tarball, []]), "GiB")
+  Float input_size = isize_1 + isize_2 + isize_3 + isize_4 + isize_5
   RuntimeAttr runtime_default = object {
     mem_gb: 2.0,
     disk_gb: ceil(10.0 + input_size * 5.0),
@@ -765,7 +769,9 @@ task SanitizeOutputs {
       dname="$( basename -s '.tar.gz' $tarball_fname )_site_level_benchmarking_plots/"
       mkdir ~{prefix}_SV_VCF_QC_output/plots/supplementary_plots/$dname
     done
-    mkdir ~{prefix}_SV_VCF_QC_output/plots/supplementary_plots/per_sample_plots/
+    if ~{defined(plot_qc_per_sample_tarball)}; then
+      mkdir ~{prefix}_SV_VCF_QC_output/plots/supplementary_plots/per_sample_plots/
+    fi
     if ~{defined(plot_qc_per_family_tarball)}; then
       mkdir ~{prefix}_SV_VCF_QC_output/plots/supplementary_plots/sv_inheritance_plots/
     fi
@@ -804,11 +810,13 @@ task SanitizeOutputs {
     fi
 
     # Process per-sample plots
-    tar -xzvf ~{plot_qc_per_sample_tarball}
-    cp ~{prefix}_perSample_plots/main_plots/* \
-      ~{prefix}_SV_VCF_QC_output/plots/main_plots/
-    cp ~{prefix}_perSample_plots/supporting_plots/per_sample_plots/* \
-      ~{prefix}_SV_VCF_QC_output/plots/supplementary_plots/per_sample_plots/
+    if ~{defined(plot_qc_per_sample_tarball)}; then
+      tar -xzvf ~{plot_qc_per_sample_tarball}
+      cp ~{prefix}_perSample_plots/main_plots/* \
+        ~{prefix}_SV_VCF_QC_output/plots/main_plots/
+      cp ~{prefix}_perSample_plots/supporting_plots/per_sample_plots/* \
+        ~{prefix}_SV_VCF_QC_output/plots/supplementary_plots/per_sample_plots/
+    fi
 
     # Process per-family plots
     if ~{defined(plot_qc_per_family_tarball)}; then


### PR DESCRIPTION
### Updates
Added a boolean input `do_per_sample_qc` to MainVcfQc, which is set to true by default. When set to false, it does not perform per-sample QC plotting (or per-family, or per-sample benchmarking as those are dependent on the outputs of per-sample QC). This can help save money when only site-level plots are needed.

### Testing
* Validated all WDLs and JSONs with womtool and the Terra validation script
* Tested on the reference panel with `do_per_sample_qc` set to `false` and verified that the sample-level steps did not run and only the site-level outputs were in the tarball.