### PR TITLE
Set the default disk size in AnnotateIntervals as a function of input files size

### DIFF
--- a/wdl/GermlineCNVTasks.wdl
+++ b/wdl/GermlineCNVTasks.wdl
@@ -18,10 +18,12 @@ task AnnotateIntervals {
       RuntimeAttr? runtime_attr_override
     }
 
+    Float input_size = size(select_all([intervals, ref_fasta, mappability_track_bed, segmental_duplication_track_bed]), "GB")
+
     RuntimeAttr default_attr = object {
       cpu_cores: 1,
       mem_gb: 1.7,
-      disk_gb: 10,
+      disk_gb: ceil(10.0 + input_size),
       boot_disk_gb: 10,
       preemptible_tries: 3,
       max_retries: 1


### PR DESCRIPTION
The `AnnotateIntervals`, called as part of the TrainGCNV workflow, is running out of disk on ToA. The default disk size is set to a fixed value, `10 GiB`. This PR updates that to be computed as a function of input files size. 

Tested successfully on GCP: `45d20c60-8a80-47c7-8298-c77f2d3d18d1`