### PR TITLE
Prevent sample ID mangling in WGD computation

### DIFF
--- a/src/WGD/bin/scoreDosageBiases.R
+++ b/src/WGD/bin/scoreDosageBiases.R
@@ -15,9 +15,9 @@ options(scipen=1000,stringsAsFactors=F)
 #####Helper function to load coverage matrix
 ############################################
 readMatrix <- function(INFILE){
-  dat <- read.table(INFILE,comment.char="",header=T)
+  dat <- read.table(INFILE,check.names=FALSE,comment.char="",header=T)
   colnames(dat)[1] <- "Chr"
-  dat[,-1] <- t(apply(dat[,-1],1,as.numeric))
+  dat[,-1] <- apply(dat[,-1],2,as.double)
   return(dat)
 }
 


### PR DESCRIPTION
When reading a file in R via read.table, the default is to convert all column names into syntactically valid identifiers. Identifiers can only start with a letter or a dot, but a dot cannot be followed by a number. To "fix" these column names, read.table will prepend them with an X. Because the column names in the WGD scoring matrix are sample IDs, which could begin with a non-letter character, sample IDs become mangled when scoring dosage biases. This results in fragmented rows in the final QC table generated by 02-EvidenceQC. This commit changes the way the dosage bias scoring script reads the WGD scoring matrix so that sample IDs are not changed.

One assumption of this commit is that all the sample IDs are unique.

Fixes #683