### PR TITLE
Add NonZeroReferenceLengthAlignmentReadFilter read filter to CollectSVEvidence

### DIFF
--- a/wdl/CollectSVEvidence.wdl
+++ b/wdl/CollectSVEvidence.wdl
@@ -113,7 +113,8 @@ task RunCollectSVEvidence {
         --site-depth-min-mapq "~{site_depth_min_mapq}" \
         --site-depth-min-baseq "~{site_depth_min_baseq}" \
         ~{"-R " + reference_fasta} \
-        ~{"-L " + primary_contigs_list}
+        ~{"-L " + primary_contigs_list} \
+        --read-filter NonZeroReferenceLengthAlignmentReadFilter
 
   >>>
   runtime {


### PR DESCRIPTION
Addresses a [known bug](https://gatk.broadinstitute.org/hc/en-us/community/posts/14862533894171-CollectSVEvidence-failing-for-some-bam-files?page=1#community_comment_17323582043931) in `CollectSVEvidence` when encountering an alignment consisting of a single insertion, i.e. `a 151I` cigar.  This causes the `CollectSVEvidence` GATK tool to throw an error:
```
java.lang.IllegalArgumentException: Invalid interval. Contig:chr2 start:644282 end:644281
```
A workaround is to enable GATK's `NonZeroReferenceLengthAlignmentReadFilter`.

Tested on 5 samples from the 1KGP reference panel and confirmed bit-wise parity on all (decompressed) outputs.