### PR TITLE
Grouped MEI's with insertions in splitvariants.py

### DIFF
--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -12,8 +12,8 @@ def process_bed_file(input_bed, n_per_split, bca=True):
     condition_prefixes = {
         'gt5kb': {'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) >= 5000)},
         'lt5kb': {'condition': lambda line: (line[SVTYPE_FIELD] == 'DEL' or line[SVTYPE_FIELD] == 'DUP') and (int(line[END_FIELD]) - int(line[START_FIELD]) < 5000)},
-        'bca': {'condition': lambda line: bca and line[SVTYPE_FIELD] not in ['DEL', 'DUP', 'INS']},
-        'ins': {'condition': lambda line: bca and line[SVTYPE_FIELD] == 'INS'}
+        'bca': {'condition': lambda line: bca and line[SVTYPE_FIELD] not in ['DEL', 'DUP'] and not line[SVTYPE_FIELD].startswith('INS')},
+        'ins': {'condition': lambda line: bca and line[SVTYPE_FIELD].startswith('INS')}
     }
 
     # Create trackers for the current file information


### PR DESCRIPTION
This address issue [649](https://github.com/broadinstitute/gatk-sv/issues/649). svtk vcf2bed uses the ALT field to produce the svtype column in the output BED file. This means that the svtype column includes BND alt alleles and values like INS:ME for MEIs. However, the [current](https://github.com/broadinstitute/gatk-sv/blob/0cad1662db0522dee17ae6d874a51cab6b739cae/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py#L20) and [previous](https://github.com/broadinstitute/gatk-sv/blob/v0.28.4-beta/wdl/TasksGenotypeBatch.wdl#L44) SplitVariants tasks in GenotypeBatch matched exactly on the string "INS" when creating insertion-specific BED files, so the MEIs were grouped with BCAs instead. Here the MEI's are grouped together with the insertions when creating the insertion-specific BED files instead of the BCA's. This can allow for further evaluation the impact of this on genotyping. This has been successfully been validated with womtool and cromshell using the 1kgp reference panel inputs. The results of the previous script and docker and the results of the updated script and docker can be found [here](https://console.cloud.google.com/storage/browser/broad-dsde-methods-kv/splitvariants_ins?authuser=0&project=broad-dsde-methods&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22)))