### PR TITLE
Trigger WDL tests on changes to /inputs and fix Terra config tests

### DIFF
--- a/.github/workflows/testwdls.yaml
+++ b/.github/workflows/testwdls.yaml
@@ -7,12 +7,20 @@ on:
     paths:
       - 'wdl/**'
       - 'inputs/**'
+      - 'scripts/inputs/build_default_inputs.sh'
+      - 'scripts/test/terra_validation.py'
+      - 'scripts/test/miniwdl_validation.py'
+      - 'scripts/test/validate.sh'
   pull_request:
     branches:
       - main
     paths:
       - 'wdl/**'
       - 'inputs/**'
+      - 'scripts/inputs/build_default_inputs.sh'
+      - 'scripts/test/terra_validation.py'
+      - 'scripts/test/miniwdl_validation.py'
+      - 'scripts/test/validate.sh'
 
 jobs:
   syntax_test_job:

--- a/.github/workflows/testwdls.yaml
+++ b/.github/workflows/testwdls.yaml
@@ -6,11 +6,13 @@ on:
       - main
     paths:
       - 'wdl/**'
+      - 'inputs/**'
   pull_request:
     branches:
       - main
     paths:
       - 'wdl/**'
+      - 'inputs/**'
 
 jobs:
   syntax_test_job:

--- a/scripts/test/terra_validation.py
+++ b/scripts/test/terra_validation.py
@@ -113,7 +113,7 @@ def main():
     parser.add_argument("-j", "--womtool-jar", help="Path to womtool jar", required=True)
     parser.add_argument("-n", "--num-input-jsons",
                         help="Number of Terra input JSONs expected",
-                        required=False, default=30, type=int)
+                        required=False, default=21, type=int)
     parser.add_argument("--log-level",
                         help="Specify level of logging information, ie. info, warning, error (not case-sensitive)",
                         required=False, default="INFO")


### PR DESCRIPTION
Another [PR](https://github.com/broadinstitute/gatk-sv/pull/614) testing is failing with this error:
```
RUNNING TERRA INPUT VALIDATION NOW
Traceback (most recent call last):
  File "./scripts/test/terra_validation.py", line 135, in <module>
    main()
  File "./scripts/test/terra_validation.py", line 131, in main
    validate_all_terra_jsons(base_dir, womtool_jar, expected_num_inputs)
  File "./scripts/test/terra_validation.py", line 92, in validate_all_terra_jsons
    for wdl, json_file in get_wdl_json_pairs(os.path.join(base_dir, WDLS_PATH),
  File "./scripts/test/terra_validation.py", line 51, in get_wdl_json_pairs
    jsons = list_jsons(terra_inputs_paths, expected_num_inputs)
  File "./scripts/test/terra_validation.py", line 45, in list_jsons
    raise Exception(f"Expected {expected_num_jsons} Terra input JSONs but found {num_input_jsons}. To proceed anyway, edit the expected number of JSONs with the -n input.")
Exception: Expected 30 Terra input JSONs but found 21. To proceed anyway, edit the expected number of JSONs with the -n input.
```
This is seems to be the result of [removing the single-batch workflow Terra configurations](https://github.com/broadinstitute/gatk-sv/pull/689). 

This PR fixes the error and also adds push/PR paths to include `inputs/**` changes for WDL testing on Github.

Edit: Also added dependent testing scripts to the trigger paths.