### PR TITLE
Making the Vapor plots optional to store as a final output

### DIFF
--- a/inputs/templates/test/Vapor/Vapor.json.tmpl
+++ b/inputs/templates/test/Vapor/Vapor.json.tmpl
@@ -7,7 +7,7 @@
     "Vapor.ref_fai" : {{ reference_resources.reference_index | tojson }},
     "Vapor.ref_dict": {{ reference_resources.reference_dict | tojson }},
     "Vapor.save_plots": "false",
-    
+
     "Vapor.prefix": {{ test_batch.example_pacbio_sample_id | tojson }},
     "Vapor.sample_id": {{ test_batch.example_pacbio_sample_id | tojson }},
     "Vapor.bam_or_cram_file": {{ test_batch.example_pacbio_cram | tojson }},

--- a/inputs/templates/test/Vapor/Vapor.json.tmpl
+++ b/inputs/templates/test/Vapor/Vapor.json.tmpl
@@ -6,7 +6,8 @@
     "Vapor.ref_fasta" : {{ reference_resources.reference_fasta | tojson }},
     "Vapor.ref_fai" : {{ reference_resources.reference_index | tojson }},
     "Vapor.ref_dict": {{ reference_resources.reference_dict | tojson }},
-
+    "Vapor.save_plots": "false",
+    
     "Vapor.prefix": {{ test_batch.example_pacbio_sample_id | tojson }},
     "Vapor.sample_id": {{ test_batch.example_pacbio_sample_id | tojson }},
     "Vapor.bam_or_cram_file": {{ test_batch.example_pacbio_cram | tojson }},

--- a/inputs/templates/test/Vapor/VaporBatch.json.tmpl
+++ b/inputs/templates/test/Vapor/VaporBatch.json.tmpl
@@ -6,6 +6,7 @@
     "VaporBatch.ref_fasta" : {{ reference_resources.reference_fasta | tojson }},
     "VaporBatch.ref_fai" : {{ reference_resources.reference_index | tojson }},
     "VaporBatch.ref_dict": {{ reference_resources.reference_dict | tojson }},
+    "VaporBatch.save_plots": "false",
 
     "VaporBatch.samples": {{ test_batch.pacbio_samples | tojson }},
     "VaporBatch.bam_or_cram_files": {{ test_batch.pacbio_crams | tojson }},

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -28,7 +28,7 @@ workflow Vapor {
     RuntimeAttr? runtime_attr_LocalizeCram
 
     Boolean save_plots  # New input to control whether plots are final output
-     File NONE_FILE = write_lines([])  # Create an empty file
+    File? NONE_FILE_ # Create an empty file
   }
 
   scatter (contig in read_lines(contigs)) {
@@ -69,7 +69,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    File vapor_plots = if save_plots then ConcatVapor.merged_bed_plot else NONE_FILE
+    File vapor_plots = if save_plots then select_first(ConcatVapor.merged_bed_plot) else NONE_FILE_
   }
 }
 

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -69,7 +69,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    Array[File]? vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else NONE_FILE_
+    File? vapor_plots = if save_plots then ConcatVapor.merged_bed_plot else NONE_FILE_
   }
 }
 

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -69,7 +69,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    File vapor_plots = if save_plots then select_first(ConcatVapor.merged_bed_plot) else [NONE_FILE_]
+    Array[File]? vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else []
   }
 }
 

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -48,7 +48,7 @@ workflow Vapor {
         contig = contig,
         bam_or_cram_file = bam_or_cram_file,
         bam_or_cram_index = bam_or_cram_index,
-        bed = PreprocessBedForVapor.contig_bed,
+        bed = select_first([PreprocessBedForVapor.contig_bed, []]),
         ref_fasta = ref_fasta,
         ref_fai = ref_fai,
         ref_dict = ref_dict,
@@ -59,7 +59,7 @@ workflow Vapor {
 
   call tasks10.ConcatVapor {
     input:
-      shard_bed_files = RunVaporWithCram.vapor,
+      shard_bed_files = select_all(RunVaporWithCram.vapor),
       shard_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else [],
       prefix = prefix,
       sv_base_mini_docker = sv_base_mini_docker,
@@ -134,4 +134,3 @@ task RunVaporWithCram {
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }
 }
-

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -70,7 +70,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    File? vapor_plots = if save_plots then ConcatVapor.merged_bed_plot else NONE_FILE
+    File vapor_plots = if save_plots then ConcatVapor.merged_bed_plot else NONE_FILE
   }
 }
 

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -69,7 +69,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    Array[File]? vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else []
+    File? vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else NONE_FILE
   }
 }
 
@@ -99,7 +99,7 @@ task RunVaporWithCram {
 
   output {
     File vapor = "~{prefix}.~{contig}.vapor.gz"
-    File? vapor_plot = "~{prefix}.~{contig}.tar.gz"
+    File vapor_plot = "~{prefix}.~{contig}.tar.gz"
   }
 
   command <<<

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -28,7 +28,7 @@ workflow Vapor {
     RuntimeAttr? runtime_attr_LocalizeCram
 
     Boolean save_plots
-    File? NONE_FILE
+    File NONE_FILE
   }
 
   scatter (contig in read_lines(contigs)) {
@@ -69,7 +69,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    File vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else NONE_FILE
+    File vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else [NONE_FILE]
   }
 }
 

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -11,6 +11,8 @@ workflow Vapor {
     File bed_file
     String sample_id
 
+    Boolean save_plots  # Control whether plots are produced in final output
+
     File ref_fasta
     File ref_fai
     File ref_dict
@@ -27,8 +29,7 @@ workflow Vapor {
     RuntimeAttr? runtime_attr_concat_beds
     RuntimeAttr? runtime_attr_LocalizeCram
 
-    Boolean save_plots  # New input to control whether plots are final output
-    File? NONE_FILE_ # Create an empty file
+    File? NONE_FILE_ # Create a null file - do not use this input
   }
 
   scatter (contig in read_lines(contigs)) {

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "Structs.wdl"
 import "TasksBenchmark.wdl" as tasks10
 
@@ -132,3 +134,4 @@ task RunVaporWithCram {
     maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
   }
 }
+

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -11,7 +11,7 @@ workflow Vapor {
     File bed_file
     String sample_id
 
-    Boolean save_plots  # Control whether plots are produced in final output
+    Boolean save_plots  # Control whether plots are final output
 
     File ref_fasta
     File ref_fai

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -17,7 +17,8 @@ workflow Vapor {
     File contigs
 
     # If set to true, the plots are produced in final output
-    Boolean produce_plots
+    Boolean save_plots
+    File? NONE_FILE
 
     String vapor_docker
     String sv_base_mini_docker
@@ -69,7 +70,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    File? vapor_plots = if produce_plots then ConcatVapor.merged_bed_plot else "null"
+    File? vapor_plots = if save_plots then ConcatVapor.merged_bed_plot else NONE_FILE
   }
 }
 

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -62,7 +62,7 @@ workflow Vapor {
   call tasks10.ConcatVapor {
     input:
       shard_bed_files = RunVaporWithCram.vapor,
-      shard_plots = RunVaporWithCram.vapor_plot,
+      shard_plots = if save_plots then RunVaporWithCram.vapor_plot else [],
       prefix = prefix,
       sv_base_mini_docker = sv_base_mini_docker,
       runtime_attr_override = runtime_attr_concat_beds
@@ -70,7 +70,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    File vapor_plots = if save_plots then ConcatVapor.merged_bed_plot else NONE_FILE
+    File? vapor_plots = if save_plots then ConcatVapor.merged_bed_plot else NONE_FILE
   }
 }
 

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -69,7 +69,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    File vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else [NONE_FILE]
+    File vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else NONE_FILE
   }
 }
 

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -69,7 +69,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    File? vapor_plots = if save_plots then ConcatVapor.merged_bed_plot else NONE_FILE
+    Array[File]? vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else []
   }
 }
 
@@ -99,7 +99,7 @@ task RunVaporWithCram {
 
   output {
     File vapor = "~{prefix}.~{contig}.vapor.gz"
-    File vapor_plot = "~{prefix}.~{contig}.tar.gz"
+    File? vapor_plot = "~{prefix}.~{contig}.tar.gz"
   }
 
   command <<<

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -28,6 +28,7 @@ workflow Vapor {
     RuntimeAttr? runtime_attr_LocalizeCram
 
     Boolean save_plots
+    File NONE_FILE
   }
 
   scatter (contig in read_lines(contigs)) {
@@ -48,7 +49,7 @@ workflow Vapor {
         contig = contig,
         bam_or_cram_file = bam_or_cram_file,
         bam_or_cram_index = bam_or_cram_index,
-        bed = select_first([PreprocessBedForVapor.contig_bed, []]),
+        bed = PreprocessBedForVapor.contig_bed,
         ref_fasta = ref_fasta,
         ref_fai = ref_fai,
         ref_dict = ref_dict,
@@ -68,7 +69,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    Array[File]? vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else []
+    File? vapor_plots = if save_plots then ConcatVapor.merged_bed_plot else NONE_FILE
   }
 }
 

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -28,7 +28,7 @@ workflow Vapor {
     RuntimeAttr? runtime_attr_LocalizeCram
 
     Boolean save_plots
-    File NONE_FILE=""
+    File? NONE_FILE
   }
 
   scatter (contig in read_lines(contigs)) {
@@ -61,7 +61,7 @@ workflow Vapor {
   call tasks10.ConcatVapor {
     input:
       shard_bed_files = select_all(RunVaporWithCram.vapor),
-      shard_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else [],
+      shard_plots = select_all(RunVaporWithCram.vapor_plot),
       prefix = prefix,
       sv_base_mini_docker = sv_base_mini_docker,
       runtime_attr_override = runtime_attr_concat_beds

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -69,7 +69,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    File? vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else NONE_FILE
+    File vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else NONE_FILE
   }
 }
 

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -28,7 +28,7 @@ workflow Vapor {
     RuntimeAttr? runtime_attr_LocalizeCram
 
     Boolean save_plots
-    File NONE_FILE
+    File NONE_FILE=""
   }
 
   scatter (contig in read_lines(contigs)) {

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -69,7 +69,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    Array[File]? vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else []
+    Array[File]? vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else NONE_FILE_
   }
 }
 

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -69,7 +69,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    File vapor_plots = if save_plots then select_first(ConcatVapor.merged_bed_plot) else NONE_FILE_
+    File vapor_plots = if save_plots then select_first(ConcatVapor.merged_bed_plot) else [NONE_FILE_]
   }
 }
 

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -69,7 +69,7 @@ workflow Vapor {
 
   output {
     File vapor_bed = ConcatVapor.merged_bed_file
-    File vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else NONE_FILE
+    File vapor_plots = if save_plots then select_all(RunVaporWithCram.vapor_plot) else [NONE_FILE]
   }
 }
 

--- a/wdl/VaporBatch.wdl
+++ b/wdl/VaporBatch.wdl
@@ -19,6 +19,8 @@ workflow VaporBatch {
     String sv_base_mini_docker
     String sv_pipeline_docker
 
+    Boolean save_plots
+    
     RuntimeAttr? runtime_attr_vapor
     RuntimeAttr? runtime_attr_bcf2vcf
     RuntimeAttr? runtime_attr_vcf2bed
@@ -50,7 +52,7 @@ workflow VaporBatch {
   }
   output {
     Array[File] vapor_batch_beds = Vapor.vapor_bed
-    Array[File] vapor_batch_plots = Vapor.vapor_plots
+    Array[File?] vapor_batch_plots = Vapor.vapor_plots
   }
 }
 

--- a/wdl/VaporBatch.wdl
+++ b/wdl/VaporBatch.wdl
@@ -20,7 +20,7 @@ workflow VaporBatch {
     String sv_pipeline_docker
 
     Boolean save_plots
-    
+
     RuntimeAttr? runtime_attr_vapor
     RuntimeAttr? runtime_attr_bcf2vcf
     RuntimeAttr? runtime_attr_vcf2bed
@@ -40,6 +40,7 @@ workflow VaporBatch {
         ref_fai = ref_fai,
         ref_dict = ref_dict,
         contigs = contigs,
+        save_plots = save_plots,
         vapor_docker = vapor_docker,
         sv_base_mini_docker = sv_base_mini_docker,
         sv_pipeline_docker = sv_pipeline_docker,


### PR DESCRIPTION
This PR addresses issue [586](https://github.com/broadinstitute/gatk-sv/issues/586). Vapor produces a large amount of storage (~1.5 GiB per sample), 99% of which is related to the plots. To reduce storage, a boolean parameter 'save_plots' was added to the WDL to toggle whether those plots are kept as a final workflow output or not. When set to false, the plots are not produced as a final output. When set to true, the plots are produced as a final output. 
The updated wdl and json were tested using womtool with the 1kgp data for both instances, when the parameter is set to false and when it is set to true. Testing was also done by running updated script in Terra with the boolean set to "true" and "false" to ensure the plots were generated or not as per the input. 