### PR TITLE
Update gatk docker with changes to handle CPX_TYPE for CTX

### DIFF
--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -2,7 +2,7 @@
   "name": "dockers",
   "cnmops_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/cnmops:2024-06-04-v0.28.5-beta-a8dfecba",
   "condense_counts_docker": "us.gcr.io/broad-dsde-methods/tsharpe/gatk:4.2.6.1-57-g9e03432",
-  "gatk_docker": "us.gcr.io/broad-dsde-methods/eph/gatk:2024-02-16-4.5.0.0-8-gcfd4d87ec-NIGHTLY-SNAPSHOT",
+  "gatk_docker": "us.gcr.io/broad-dsde-methods/eph/gatk:2024-07-02-4.6.0.0-1-g4af2b49e9-NIGHTLY-SNAPSHOT",
   "gatk_docker_pesr_override": "us.gcr.io/broad-dsde-methods/tsharpe/gatk:4.2.6.1-57-g9e03432",
   "genomes_in_the_cloud_docker": "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "marketplace.gcr.io/google/ubuntu1804",

--- a/inputs/values/dockers_azure.json
+++ b/inputs/values/dockers_azure.json
@@ -2,7 +2,7 @@
   "name": "dockers",
   "cnmops_docker": "vahid.azurecr.io/gatk-sv/cnmops:2024-06-04-v0.28.5-beta-a8dfecba",
   "condense_counts_docker": "vahid.azurecr.io/tsharpe/gatk:4.2.6.1-57-g9e03432",
-  "gatk_docker": "http://vahid.azurecr.io/gatk-sv/gatk:2024-07-02-4.6.0.0-1-g4af2b49e9-NIGHTLY-SNAPSHOT",
+  "gatk_docker": "vahid.azurecr.io/gatk-sv/gatk:2024-07-02-4.6.0.0-1-g4af2b49e9-NIGHTLY-SNAPSHOT",
   "gatk_docker_pesr_override": "vahid.azurecr.io/tsharpe/gatk:4.2.6.1-57-g9e03432",
   "genomes_in_the_cloud_docker": "vahid.azurecr.io/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "vahid.azurecr.io/google/ubuntu1804",

--- a/inputs/values/dockers_azure.json
+++ b/inputs/values/dockers_azure.json
@@ -2,7 +2,7 @@
   "name": "dockers",
   "cnmops_docker": "vahid.azurecr.io/gatk-sv/cnmops:2024-06-04-v0.28.5-beta-a8dfecba",
   "condense_counts_docker": "vahid.azurecr.io/tsharpe/gatk:4.2.6.1-57-g9e03432",
-  "gatk_docker": "vahid.azurecr.io/gatk-sv/gatk:2024-02-16-4.5.0.0-8-gcfd4d87ec-NIGHTLY-SNAPSHOT",
+  "gatk_docker": "http://vahid.azurecr.io/gatk-sv/gatk:2024-07-02-4.6.0.0-1-g4af2b49e9-NIGHTLY-SNAPSHOT",
   "gatk_docker_pesr_override": "vahid.azurecr.io/tsharpe/gatk:4.2.6.1-57-g9e03432",
   "genomes_in_the_cloud_docker": "vahid.azurecr.io/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "vahid.azurecr.io/google/ubuntu1804",


### PR DESCRIPTION
### Updates

Update GATK docker in dockers.json and dockers_azure.json with changes to handle CPX_TYPE for CTX events in SVConcordance from https://github.com/broadinstitute/gatk/pull/8885. This PR addresses #664.

### Testing
* GATK unit testing
* Validated all WDLs and JSONs with womtool and Terra validation script
* Ran SVConcordance with new GATK docker (on GCP) and verified that CPX_TYPE for CTX events was retained