### PR TITLE
Update deprecated Pandas append operation for log analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A structural variation discovery pipeline for Illumina short-read whole-genome s
 
 ## <a name="requirements">Requirements</a>
 
+
 ### Deployment and execution:
 * A [Google Cloud](https://cloud.google.com/) account.
 * A workflow execution system supporting the [Workflow Description Language](https://openwdl.org/) (WDL), either:
@@ -77,6 +78,7 @@ To validate the PED file, you may use `src/sv-pipeline/scripts/validate_ped.py -
 We recommend filtering out samples with a high percentage of improperly paired reads (>10% or an outlier for your data) as technical outliers prior to running [GatherSampleEvidence](#gather-sample-evidence). A high percentage of improperly paired reads may indicate issues with library prep, degradation, or contamination. Artifactual improperly paired reads could cause incorrect SV calls, and these samples have been observed to have longer runtimes and higher compute costs for [GatherSampleEvidence](#gather-sample-evidence).
 
 #### <a name="sampleids">Sample ID requirements:</a>
+
 Sample IDs must:
 * Be unique within the cohort
 * Contain only alphanumeric characters and underscores (no dashes, whitespace, or special characters)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ A structural variation discovery pipeline for Illumina short-read whole-genome s
 
 ## <a name="requirements">Requirements</a>
 
-
 ### Deployment and execution:
 * A [Google Cloud](https://cloud.google.com/) account.
 * A workflow execution system supporting the [Workflow Description Language](https://openwdl.org/) (WDL), either:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ To validate the PED file, you may use `src/sv-pipeline/scripts/validate_ped.py -
 We recommend filtering out samples with a high percentage of improperly paired reads (>10% or an outlier for your data) as technical outliers prior to running [GatherSampleEvidence](#gather-sample-evidence). A high percentage of improperly paired reads may indicate issues with library prep, degradation, or contamination. Artifactual improperly paired reads could cause incorrect SV calls, and these samples have been observed to have longer runtimes and higher compute costs for [GatherSampleEvidence](#gather-sample-evidence).
 
 #### <a name="sampleids">Sample ID requirements:</a>
-
 Sample IDs must:
 * Be unique within the cohort
 * Contain only alphanumeric characters and underscores (no dashes, whitespace, or special characters)

--- a/scripts/cromwell/analyze_monitoring_logs2.py
+++ b/scripts/cromwell/analyze_monitoring_logs2.py
@@ -177,7 +177,7 @@ def estimate_costs_per_group(data):
         group_data['DynCost'] = sum(
             (group_data['DynCPUCost'], group_data['DynMemCost'], group_data['DynDiskCost']))
 
-        data_grouped = data_grouped.append(group_data, ignore_index=True)
+        data_grouped = pd.concat([data_grouped, pd.DataFrame([group_data])], ignore_index=True)
 
     data_grouped.sort_values(by='TotCost', inplace=True, ascending=False)
     return data_grouped


### PR DESCRIPTION
`analyze_monitoring_logs2.py` currently uses the `append` operation of Pandas, though this has been deprecated since Pandas 1.4.0. 

Updates this reference to instead use Pandas' new `concat` operator.