### PR TITLE
Add check for duplicate records to MainVcfQc

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -150,6 +150,7 @@ workflows:
     filters:
       branches: 
         - main
+        - kj/701_vcf_qc_duplicates
       tags:
         - /.*/
 

--- a/src/sv-pipeline/scripts/identify_duplicates.py
+++ b/src/sv-pipeline/scripts/identify_duplicates.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Identify and classify duplicated variants from a sorted input VCF
+Identify and classify duplicated variants from an input VCF.
 """
 
 from typing import List, Text, Optional

--- a/src/sv-pipeline/scripts/identify_duplicates.py
+++ b/src/sv-pipeline/scripts/identify_duplicates.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Identify and classify duplicated variants from a sorted input VCF
+"""
+
+from typing import List, Text, Optional
+from collections import defaultdict
+from itertools import combinations
+
+import argparse
+import sys
+import pysam
+
+
+def process_duplicates(vcf, fout):
+    # Initialize counters and buffers
+    counts = defaultdict(int)
+    exact_buffer = []
+    ins_buffer = []
+    current_chrom = None
+    current_pos = None
+
+    # Create output files
+    with open(f"{fout}_records.tsv", 'w') as f_records, open(f"{fout}_counts.tsv", 'w') as f_counts:
+        f_records.write("TYPE\tDUP_RECORDS\n")
+        f_counts.write("TYPE\tDUP_COUNTS\n")
+
+        # Iterate through all records
+        for record in vcf.fetch():
+            # Process current buffers if we've reached a new chrom or pos
+            if record.chrom != current_chrom or record.pos != current_pos:
+                process_buffers(exact_buffer, ins_buffer, counts, f_records)
+                exact_buffer = []
+                ins_buffer = []
+                current_chrom = record.chrom
+                current_pos = record.pos
+
+            # Update buffers with new record
+            exact_key = (
+                record.chrom, 
+                record.pos, 
+                record.stop,
+                record.info.get('SVTYPE'), 
+                record.info.get('SVLEN'),
+                record.info.get('CHR2'), 
+                record.info.get('END2'),
+                record.info.get('STRANDS'), 
+                record.info.get('CPX_TYPE'),
+                record.info.get('CPX_INTERVALS')
+            )
+            exact_buffer.append((exact_key, record.id))
+
+            if record.info.get('SVTYPE') == 'INS':
+                insert_key = (
+                    record.id, 
+                    record.info.get('SVLEN'), 
+                    record.alts[0]
+                )
+                ins_buffer.append(insert_key)
+
+        # Process remaining records in the buffer
+        process_buffers(exact_buffer, ins_buffer, counts, f_records)
+
+        # Write counts to file
+        for match_type in sorted(counts.keys()):
+            f_counts.write(f"{match_type}\t{counts[match_type]}\n")
+
+
+def process_buffers(exact_buffer, ins_buffer, counts, f_records):
+    # Process exact matches
+    exact_matches = defaultdict(list)
+    for key, record_id in exact_buffer:
+        exact_matches[key].append(record_id)
+
+    for records in exact_matches.values():
+        if len(records) > 1:
+            counts['Exact'] += 1
+            f_records.write(f"Exact\t{','.join(sorted(records))}\n")
+
+    # Process INS matches
+    for i in range(len(ins_buffer)):
+        for j in range(i+1, len(ins_buffer)):
+            rec1, rec2 = ins_buffer[i], ins_buffer[j]
+            
+            # Size comparison
+            if rec1[1] == rec2[1]:
+                counts['INS 100%'] += 1
+                f_records.write(f"INS 100%\t{rec1[0]},{rec2[0]}\n")
+            elif abs(rec1[1] - rec2[1]) <= 0.5 * max(rec1[1], rec2[1]):
+                counts['INS 50%'] += 1
+                f_records.write(f"INS 50%\t{rec1[0]},{rec2[0]}\n")
+            else:
+                counts['INS 0%'] += 1
+                f_records.write(f"INS 0%\t{rec1[0]},{rec2[0]}\n")
+            
+            # ALT comparison
+            if rec1[2] == rec2[2]:
+                counts['INS ALT Identical'] += 1
+                f_records.write(f"INS ALT Identical\t{rec1[0]},{rec2[0]}\n")
+            elif ('<INS>' in (rec1[2], rec2[2])) and ('<INS:' in (rec1[2] + rec2[2])):
+                counts['INS ALT Subtype'] += 1
+                f_records.write(f"INS ALT Subtype\t{rec1[0]},{rec2[0]}\n")
+            elif rec1[2].startswith('<INS:') and rec2[2].startswith('<INS:') and rec1[2] != rec2[2]:
+                counts['INS ALT Different Subtype'] += 1
+                f_records.write(f"INS ALT Different Subtype\t{rec1[0]},{rec2[0]}\n")
+
+
+def _parse_arguments(argv: List[Text]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Identify duplicated records from a sorted input VCF",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('-v', '--vcf', required=True, help='Input VCF.')
+    parser.add_argument('-f', '--fout', required=True, help='Output file name.')
+    parsed_arguments = parser.parse_args(argv[1:])
+    return parsed_arguments
+
+
+def main(argv: Optional[List[Text]] = None):
+    if argv is None:
+        argv = sys.argv
+    args = _parse_arguments(argv)
+
+    vcf = pysam.VariantFile(args.vcf)
+    process_duplicates(vcf, args.fout)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/sv-pipeline/scripts/identify_duplicates.py
+++ b/src/sv-pipeline/scripts/identify_duplicates.py
@@ -66,7 +66,6 @@ def process_duplicates(vcf, fout):
         # Write counts to file
         for match_type in sorted(counts.keys()):
             f_counts.write(f"{match_type}\t{counts[match_type]}\n")
-            print(f"{match_type}: {counts[match_type]}")
 
 
 def process_buffers(exact_buffer, ins_buffer, counts, f_records):

--- a/src/sv-pipeline/scripts/identify_duplicates.py
+++ b/src/sv-pipeline/scripts/identify_duplicates.py
@@ -23,7 +23,7 @@ def process_duplicates(vcf, fout):
     current_pos = None
 
     # Create output files
-    with open(f"{fout}_records.tsv", 'w') as f_records, open(f"{fout}_counts.tsv", 'w') as f_counts:
+    with open(f"{fout}_duplicate_records.tsv", 'w') as f_records, open(f"{fout}_duplicate_counts.tsv", 'w') as f_counts:
         f_records.write("TYPE\tDUP_RECORDS\n")
         f_counts.write("TYPE\tDUP_COUNTS\n")
 

--- a/src/sv-pipeline/scripts/identify_duplicates.py
+++ b/src/sv-pipeline/scripts/identify_duplicates.py
@@ -66,6 +66,7 @@ def process_duplicates(vcf, fout):
         # Write counts to file
         for match_type in sorted(counts.keys()):
             f_counts.write(f"{match_type}\t{counts[match_type]}\n")
+            print(f"{match_type}: {counts[match_type]}")
 
 
 def process_buffers(exact_buffer, ins_buffer, counts, f_records):

--- a/src/sv-pipeline/scripts/merge_duplicates.py
+++ b/src/sv-pipeline/scripts/merge_duplicates.py
@@ -15,7 +15,7 @@ import csv
 
 def merge_duplicates(record_files: List[str], count_files: List[str], fout: str):
     # Merge records
-    with open(f"{fout}_records.tsv", 'w', newline='') as out_records:
+    with open(f"{fout}_duplicate_records.tsv", 'w', newline='') as out_records:
         writer = csv.writer(out_records, delimiter='\t')
 
         # Write header
@@ -39,7 +39,7 @@ def merge_duplicates(record_files: List[str], count_files: List[str], fout: str)
                 counts[row[0]] += int(row[1])
 
     # Merge counts
-    with open(f"{fout}_counts.tsv", 'w', newline='') as out_counts:
+    with open(f"{fout}_duplicate_counts.tsv", 'w', newline='') as out_counts:
         writer = csv.writer(out_counts, delimiter='\t')
 
         # Write header

--- a/src/sv-pipeline/scripts/merge_duplicates.py
+++ b/src/sv-pipeline/scripts/merge_duplicates.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Merge duplicate records and counts files across multiple TSVs
+Merge duplicate records and counts files across multiple TSVs.
 """
 
 from typing import List, Text, Optional

--- a/src/sv-pipeline/scripts/merge_duplicates.py
+++ b/src/sv-pipeline/scripts/merge_duplicates.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Merge duplicate records and counts files across multiple TSVs
+"""
+
+from typing import List, Text, Optional
+from collections import defaultdict
+
+import argparse
+import sys
+import csv
+
+
+def merge_duplicates(record_files: List[str], count_files: List[str], fout: str):
+    # Merge records
+    with open(f"{fout}_records.tsv", 'w', newline='') as out_records:
+        writer = csv.writer(out_records, delimiter='\t')
+
+        # Write header
+        writer.writerow(['TYPE', 'DUP_RECORDS'])
+        
+        # Append records from each file
+        for record_file in record_files:
+            with open(record_file, 'r') as f:
+                reader = csv.reader(f, delimiter='\t')
+                next(reader) 
+                for row in reader:
+                    writer.writerow(row)
+
+    # Sum counts
+    counts = defaultdict(int)
+    for count_file in count_files:
+        with open(count_file, 'r') as f:
+            reader = csv.reader(f, delimiter='\t')
+            next(reader)
+            for row in reader:
+                counts[row[0]] += int(row[1])
+
+    # Merge counts
+    with open(f"{fout}_counts.tsv", 'w', newline='') as out_counts:
+        writer = csv.writer(out_counts, delimiter='\t')
+
+        # Write header
+        writer.writerow(['TYPE', 'DUP_COUNTS'])
+
+        # Append each row from merged counts
+        for category, count in counts.items():
+            writer.writerow([category, count])
+    
+
+def _parse_arguments(argv: List[Text]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Merge duplicate records and counts files across multiple TSVs",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('-r', '--records', nargs='+', required=True, help='Input duplicated record TSV files.')
+    parser.add_argument('-c', '--counts', nargs='+', required=True, help='Input duplicated counts TSV files.')
+    parser.add_argument('-f', '--fout', required=True, help='Output file name.')
+    parsed_arguments = parser.parse_args(argv[1:])
+    return parsed_arguments
+
+
+def main(argv: Optional[List[Text]] = None):
+    if argv is None:
+        argv = sys.argv
+    args = _parse_arguments(argv)
+
+    merge_duplicates(args.records, args.counts, args.fout)
+
+
+if __name__ == '__main__':
+    main()

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -931,9 +931,13 @@ task IdentifyDuplicates {
         --fout "$fout_name"
     done
 
+    echo "Listing working directory:"
+    pwd
+    echo "Listing files in working directory:"
+    ls
     echo "Listing generated files:"
-    ls -l ~{prefix}_*_duplicate_records.tsv
-    ls -l ~{prefix}_*_duplicate_counts.tsv
+    ls -l "~{prefix}_*_duplicate_records.tsv"
+    ls -l "~{prefix}_*_duplicate_counts.tsv"
 
     echo "All VCFs processed."
   >>>
@@ -991,6 +995,6 @@ task MergeDuplicates {
 
   output {
     File duplicate_records = "~{prefix}_agg_duplicate_records.tsv"
-    File duplicate_counts = "~{prefix}_agg_duplicates_counts.tsv"
+    File duplicate_counts = "~{prefix}_agg_duplicate_counts.tsv"
   }
 }

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -923,7 +923,7 @@ task IdentifyDuplicates {
 
     for vcf in ~{sep=' ' vcfs}; do
       vcf_name=$(basename "$vcf" .vcf.gz)
-      fout_name="~{prefix}_${vcf_name}"
+      fout_name="~{prefix}.${vcf_name}"
 
       echo "Processing $vcf..."
       python "$SCRIPT_PATH" \
@@ -936,15 +936,15 @@ task IdentifyDuplicates {
     echo "Listing files in working directory:"
     ls
     echo "Listing generated files:"
-    ls -l "~{prefix}_*_duplicate_records.tsv"
-    ls -l "~{prefix}_*_duplicate_counts.tsv"
+    ls -l "~{prefix}.*_duplicate_records.tsv"
+    ls -l "~{prefix}.*_duplicate_counts.tsv"
 
     echo "All VCFs processed."
   >>>
 
   output {
-    Array[File] duplicate_records = glob("~{prefix}_*_duplicate_records.tsv")
-    Array[File] duplicate_counts = glob("~{prefix}_*_duplicate_counts.tsv")
+    Array[File] duplicate_records = glob("~{prefix}.*_duplicate_records.tsv")
+    Array[File] duplicate_counts = glob("~{prefix}.*_duplicate_counts.tsv")
   }
 }
 
@@ -988,13 +988,13 @@ task MergeDuplicates {
     python "$SCRIPT_PATH" \
       --records ~{sep=' ' tsv_records} \
       --counts ~{sep=' ' tsv_counts} \
-      --fout "~{prefix}_agg"
+      --fout "~{prefix}.agg"
 
     echo "All TSVs processed."
   >>>
 
   output {
-    File duplicate_records = "~{prefix}_agg_duplicate_records.tsv"
-    File duplicate_counts = "~{prefix}_agg_duplicate_counts.tsv"
+    File duplicate_records = "~{prefix}.agg_duplicate_records.tsv"
+    File duplicate_counts = "~{prefix}.agg_duplicate_counts.tsv"
   }
 }

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -291,7 +291,6 @@ workflow MainVcfQc {
     }
   }
 
-
   # Merge duplicates
   call MergeDuplicates {
     input:
@@ -937,8 +936,8 @@ task IdentifyDuplicates {
   >>>
 
   output {
-    File duplicate_records = "~{full_prefix}_duplicated_records.tsv"
-    File duplicate_counts = "~{full_prefix}_duplicated_counts.tsv"
+    File duplicate_records = "~{full_prefix}_duplicate_records.tsv"
+    File duplicate_counts = "~{full_prefix}_duplicate_counts.tsv"
   }
 }
 

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -280,7 +280,7 @@ workflow MainVcfQc {
   }
 
   # Identify all duplicates
-  scatter(vcf in vcfs_for_qc) {
+  scatter(vcf in select_first([SubsetVcfBySamplesList.vcf_subset, vcfs])) {
     call IdentifyDuplicates {
       input:
         prefix=prefix,
@@ -978,6 +978,10 @@ task MergeDuplicates {
 
   command <<<
     set -euo pipefail
+
+    echo "Merging all TSV files into one..."
+    echo "Records: ~{sep=', ' tsv_records}"
+    echo "Counts: ~{sep=', ' tsv_counts}"
 
     python ~{custom_script} \
       --records ~{sep=' ' tsv_records} \

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -897,7 +897,7 @@ task IdentifyDuplicates {
     RuntimeAttr? runtime_attr_override
   }
 
-  File default_script = "/opt/sv-pipeline/scripts/merge_duplicates.py"
+  File default_script = "/src/sv-pipeline/scripts/merge_duplicates.py"
   File active_script = select_first([custom_script, default_script])
 
   String vcf_basename = basename(vcf, ".vcf.gz")
@@ -953,7 +953,7 @@ task MergeDuplicates {
     RuntimeAttr? runtime_attr_override
   }
 
-  File default_script = "/opt/sv-pipeline/scripts/merge_duplicates.py"
+  File default_script = "/src/sv-pipeline/scripts/merge_duplicates.py"
   File active_script = select_first([custom_script, default_script])
 
   RuntimeAttr runtime_default = object {

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -39,6 +39,8 @@ workflow MainVcfQc {
     RuntimeAttr? runtime_override_plot_qc_per_sample
     RuntimeAttr? runtime_override_plot_qc_per_family
     RuntimeAttr? runtime_override_per_sample_benchmark_plot
+    RuntimeAttr? runtime_override_identify_duplicates
+    RuntimeAttr? runtime_override_merge_duplicates
     RuntimeAttr? runtime_override_sanitize_outputs
 
     # overrides for MiniTasks or Utils
@@ -275,6 +277,25 @@ workflow MainVcfQc {
     }
   }
 
+  # Identify all duplicates
+  call IdentifyDuplicates {
+    input:
+      prefix=prefix,
+      vcfs=vcfs_for_qc,
+      sv_pipeline_qc_docker=sv_pipeline_qc_docker,
+      runtime_attr_override=runtime_override_identify_duplicates
+  }
+
+  # Merge duplicates
+  call MergeDuplicates {
+    input:
+      prefix=prefix,
+      tsvs=IdentifyDuplicates.duplicates,
+      tsvs_counts=IdentifyDuplicates.duplicates_counts,
+      sv_pipeline_qc_docker=sv_pipeline_qc_docker,
+      runtime_attr_override=runtime_override_merge_duplicates
+  }
+
   # Sanitize all outputs
   call SanitizeOutputs {
     input:
@@ -296,6 +317,8 @@ workflow MainVcfQc {
   output {
     File sv_vcf_qc_output = SanitizeOutputs.vcf_qc_tarball
     File vcf2bed_output = MergeVcf2Bed.merged_bed_file
+    File duplicates_output = MergeDuplicates.duplicates
+    File duplicates_counts_output = MergeDuplicates.duplicates_counts
   }
 }
 
@@ -858,3 +881,102 @@ task SanitizeOutputs {
   }
 }
 
+
+# Identify all duplicates
+task IdentifyDuplicates {
+  input {
+    String prefix
+    Array[File] vcfs
+    String sv_pipeline_qc_docker
+    RuntimeAttr? runtime_attr_override
+  }
+
+  RuntimeAttr runtime_default = object {
+    mem_gb: 3.75,
+    disk_gb: 5 + ceil(size(vcfs, "GiB")),
+    cpu_cores: 1,
+    preemptible_tries: 1,
+    max_retries: 1,
+    boot_disk_gb: 10
+  }
+
+  RuntimeAttr runtime_override = select_first([runtime_attr_override, runtime_default])
+  runtime {
+    memory: "~{select_first([runtime_override.mem_gb, runtime_default.mem_gb])} GiB"
+    disks: "local-disk ~{select_first([runtime_override.disk_gb, runtime_default.disk_gb])} HDD"
+    cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
+    preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
+    maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
+    docker: sv_pipeline_qc_docker
+    bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
+  }
+
+  command <<<
+    set -euo pipefail
+
+    for vcf in ~{sep=' ' vcfs}; do
+      vcf_name=$(basename "$vcf" .vcf.gz)
+      fout_name="~{prefix}_duplicate_${vcf_name}"
+
+      echo "Processing $vcf..."
+      python /opt/sv-pipeline/scripts/identify_duplicates.py \
+        --vcf "$vcf" \
+        --fout "$fout_name"
+    done
+
+    echo "All VCFs processed."
+  >>>
+
+  output {
+    Array[File] duplicates = glob("~{prefix}_duplicate_records_*.tsv")
+    Array[File] duplicates_counts = glob("~{prefix}_duplicate_counts_*.tsv")
+  }
+}
+
+
+# Aggregate distinct duplicate summary files
+task MergeDuplicates {
+  input {
+    String prefix
+    Array[File] tsvs
+    Array[File] tsvs_counts
+    String sv_pipeline_qc_docker
+    RuntimeAttr? runtime_attr_override
+  }
+
+  RuntimeAttr runtime_default = object {
+    mem_gb: 3.75,
+    disk_gb: 5 + ceil(size(tsvs, "GiB")) + ceil(size(tsvs_counts, "GiB")),
+    cpu_cores: 1,
+    preemptible_tries: 1,
+    max_retries: 1,
+    boot_disk_gb: 10
+  }
+
+  RuntimeAttr runtime_override = select_first([runtime_attr_override, runtime_default])
+  runtime {
+    memory: "~{select_first([runtime_override.mem_gb, runtime_default.mem_gb])} GiB"
+    disks: "local-disk ~{select_first([runtime_override.disk_gb, runtime_default.disk_gb])} HDD"
+    cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
+    preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
+    maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
+    docker: sv_pipeline_qc_docker
+    bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
+  }
+
+  command <<<
+    set -euo pipefail
+
+    python /opt/sv-pipeline/scripts/merge_duplicates.py \
+      --records ~{sep=' ' tsvs} \
+      --counts ~{sep=' ' tsvs_counts} \
+      --fout "~{prefix}_agg_duplicate"
+
+    echo "All TSVs processed."
+  >>>
+
+  output {
+    File duplicates = "~{prefix}_agg_duplicates.tsv"
+    File duplicates_counts = "~{prefix}_agg_duplicates_counts.tsv"
+  }
+}

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -930,11 +930,7 @@ task IdentifyDuplicates {
         --vcf "$vcf" \
         --fout "$fout_name"
     done
-
-    echo "Listing working directory:"
-    pwd
-    echo "Listing files in working directory:"
-    ls
+    
     echo "Listing generated files:"
     ls -l "~{prefix}.*_duplicate_records.tsv"
     ls -l "~{prefix}.*_duplicate_counts.tsv"

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -292,15 +292,15 @@ workflow MainVcfQc {
   }
 
   # Merge duplicates
-  # call MergeDuplicates {
-  #   input:
-  #     prefix=prefix,
-  #     tsv_records=IdentifyDuplicates.duplicate_records,
-  #     tsv_counts=IdentifyDuplicates.duplicate_counts,
-  #     sv_pipeline_qc_docker=sv_pipeline_qc_docker,
-  #     custom_script=merge_duplicates_custom,
-  #     runtime_attr_override=runtime_override_merge_duplicates
-  # }
+  call MergeDuplicates {
+    input:
+      prefix=prefix,
+      tsv_records=IdentifyDuplicates.duplicate_records,
+      tsv_counts=IdentifyDuplicates.duplicate_counts,
+      sv_pipeline_qc_docker=sv_pipeline_qc_docker,
+      custom_script=merge_duplicates_custom,
+      runtime_attr_override=runtime_override_merge_duplicates
+  }
 
   # Sanitize all outputs
   call SanitizeOutputs {
@@ -323,10 +323,8 @@ workflow MainVcfQc {
   output {
     File sv_vcf_qc_output = SanitizeOutputs.vcf_qc_tarball
     File vcf2bed_output = MergeVcf2Bed.merged_bed_file
-    Array[File] duplicate_records_output = IdentifyDuplicates.duplicate_records
-    Array[File] duplicate_counts_output = IdentifyDuplicates.duplicate_counts
-    # File duplicate_records_output = MergeDuplicates.duplicate_records
-    # File duplicate_counts_output = MergeDuplicates.duplicate_counts
+    File duplicate_records_output = MergeDuplicates.duplicate_records
+    File duplicate_counts_output = MergeDuplicates.duplicate_counts
   }
 }
 

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -291,6 +291,7 @@ workflow MainVcfQc {
     }
   }
 
+
   # Merge duplicates
   call MergeDuplicates {
     input:
@@ -376,7 +377,6 @@ task PlotQcVcfWide {
     File plots_tarball = "~{prefix}.plotQC_vcfwide_output.tar.gz"
   }
 }
-
 
 # Task to merge VID lists across shards
 task TarShardVidLists {
@@ -888,7 +888,7 @@ task SanitizeOutputs {
 }
 
 
-# Identify all duplicates
+# Identify all duplicates in a single file
 task IdentifyDuplicates {
   input {
     String prefix
@@ -898,8 +898,8 @@ task IdentifyDuplicates {
     RuntimeAttr? runtime_attr_override
   }
 
-  File default_script = "/opt/sv-pipeline/scripts/merge_duplicates.py"
-  File active_script = select_first([custom_script, default_script])
+  # File default_script = "/opt/sv-pipeline/scripts/merge_duplicates.py"
+  # File active_script = select_first([custom_script, default_script])
 
   String vcf_basename = basename(vcf, ".vcf.gz")
   String full_prefix = "~{prefix}.~{vcf_basename}"
@@ -929,7 +929,7 @@ task IdentifyDuplicates {
 
     echo "Processing ~{vcf} into ~{full_prefix}..."
 
-    python ~{active_script} \
+    python ~{custom_script} \
       --vcf ~{vcf} \
       --fout ~{full_prefix}
 
@@ -954,8 +954,8 @@ task MergeDuplicates {
     RuntimeAttr? runtime_attr_override
   }
 
-  File default_script = "/opt/sv-pipeline/scripts/merge_duplicates.py"
-  File active_script = select_first([custom_script, default_script])
+  # File default_script = "/opt/sv-pipeline/scripts/merge_duplicates.py"
+  # File active_script = select_first([custom_script, default_script])
 
   RuntimeAttr runtime_default = object {
     mem_gb: 3.75,
@@ -980,7 +980,7 @@ task MergeDuplicates {
   command <<<
     set -euo pipefail
 
-    python ~{active_script} \
+    python ~{custom_script} \
       --records ~{sep=' ' tsv_records} \
       --counts ~{sep=' ' tsv_counts} \
       --fout "~{prefix}.agg"

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -897,8 +897,8 @@ task IdentifyDuplicates {
     RuntimeAttr? runtime_attr_override
   }
 
-  # File default_script = "/opt/sv-pipeline/scripts/merge_duplicates.py"
-  # File active_script = select_first([custom_script, default_script])
+  File default_script = "/opt/sv-pipeline/scripts/merge_duplicates.py"
+  File active_script = select_first([custom_script, default_script])
 
   String vcf_basename = basename(vcf, ".vcf.gz")
   String full_prefix = "~{prefix}.~{vcf_basename}"
@@ -928,7 +928,7 @@ task IdentifyDuplicates {
 
     echo "Processing ~{vcf} into ~{full_prefix}..."
 
-    python ~{custom_script} \
+    python ~{active_script} \
       --vcf ~{vcf} \
       --fout ~{full_prefix}
 
@@ -953,8 +953,8 @@ task MergeDuplicates {
     RuntimeAttr? runtime_attr_override
   }
 
-  # File default_script = "/opt/sv-pipeline/scripts/merge_duplicates.py"
-  # File active_script = select_first([custom_script, default_script])
+  File default_script = "/opt/sv-pipeline/scripts/merge_duplicates.py"
+  File active_script = select_first([custom_script, default_script])
 
   RuntimeAttr runtime_default = object {
     mem_gb: 3.75,
@@ -980,10 +980,8 @@ task MergeDuplicates {
     set -euo pipefail
 
     echo "Merging all TSV files into one..."
-    echo "Records: ~{sep=', ' tsv_records}"
-    echo "Counts: ~{sep=', ' tsv_counts}"
 
-    python ~{custom_script} \
+    python ~{active_script} \
       --records ~{sep=' ' tsv_records} \
       --counts ~{sep=' ' tsv_counts} \
       --fout "~{prefix}.agg"

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -292,15 +292,15 @@ workflow MainVcfQc {
   }
 
   # Merge duplicates
-  call MergeDuplicates {
-    input:
-      prefix=prefix,
-      tsv_records=IdentifyDuplicates.duplicate_records,
-      tsv_counts=IdentifyDuplicates.duplicate_counts,
-      sv_pipeline_qc_docker=sv_pipeline_qc_docker,
-      custom_script=merge_duplicates_custom,
-      runtime_attr_override=runtime_override_merge_duplicates
-  }
+  # call MergeDuplicates {
+  #   input:
+  #     prefix=prefix,
+  #     tsv_records=IdentifyDuplicates.duplicate_records,
+  #     tsv_counts=IdentifyDuplicates.duplicate_counts,
+  #     sv_pipeline_qc_docker=sv_pipeline_qc_docker,
+  #     custom_script=merge_duplicates_custom,
+  #     runtime_attr_override=runtime_override_merge_duplicates
+  # }
 
   # Sanitize all outputs
   call SanitizeOutputs {
@@ -323,8 +323,10 @@ workflow MainVcfQc {
   output {
     File sv_vcf_qc_output = SanitizeOutputs.vcf_qc_tarball
     File vcf2bed_output = MergeVcf2Bed.merged_bed_file
-    File duplicate_records_output = MergeDuplicates.duplicate_records
-    File duplicate_counts_output = MergeDuplicates.duplicate_counts
+    Array[File] duplicate_records_output = IdentifyDuplicates.duplicate_records
+    Array[File] duplicate_counts_output = IdentifyDuplicates.duplicate_counts
+    # File duplicate_records_output = MergeDuplicates.duplicate_records
+    # File duplicate_counts_output = MergeDuplicates.duplicate_counts
   }
 }
 

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -280,7 +280,7 @@ workflow MainVcfQc {
   }
 
   # Identify all duplicates
-  scatter(vcf in select_first([SubsetVcfBySamplesList.vcf_subset, vcfs])) {
+  scatter(vcf in vcfs_for_qc) {
     call IdentifyDuplicates {
       input:
         prefix=prefix,
@@ -975,7 +975,7 @@ task MergeDuplicates {
     docker: sv_pipeline_qc_docker
     bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
   }
-
+  
   command <<<
     set -euo pipefail
 


### PR DESCRIPTION
Resolution for #701 .

- Creates sript `identify_duplicates.py` that takes a VCF files as input, and produces separate TSVs for 1. duplicate counts aggregated by category and 2. duplicate records tagged to a category.
- Creates script `merge_duplicates.py` that aggregates multiple count and record TSVs produced by `identify_duplicates.py` into a single aggregated TSV.
- Invokes both scripts through two separate tasks in `MainVcfQc.wdl`:
  - _IdentifyDuplicates_ is a distributed task that runs in parallel across all VCFs, and is executed once _SubsetVcfBySamplesList_ completes. Currently allows for an optional parameter _identify_duplicates_custom_ to be passed, which is a path to a script that can be run in place of `identify_duplicates.py`.
  - MergeDuplicates is a distributed task that runs in parallel across all VCFs, and is executed once all _IdentifyDuplicates_ tasks complete. Currently allows for an optional parameter _merge_duplicates_custom_ to be passed, which is a path to a script that can be run in place of `merge_duplicates.py`.