### PR TITLE
Resolve incorrect mCNV genotype counts for hom-alt

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -150,7 +150,7 @@ workflows:
     filters:
       branches: 
         - main
-        - kj/690_incorrect_mCNV_counts
+        - kj/690_incorrect_mCNV_counts 
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -150,7 +150,6 @@ workflows:
     filters:
       branches: 
         - main
-        - kj/690_incorrect_mCNV_counts
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -150,7 +150,7 @@ workflows:
     filters:
       branches: 
         - main
-        - kj/690_incorrect_mCNV_counts 
+        - kj/690_incorrect_mCNV_counts
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -150,6 +150,7 @@ workflows:
     filters:
       branches: 
         - main
+        - kj/690_incorrect_mCNV_counts
       tags:
         - /.*/
 

--- a/src/sv-pipeline/scripts/vcf_qc/collectQC.vcf_wide.sh
+++ b/src/sv-pipeline/scripts/vcf_qc/collectQC.vcf_wide.sh
@@ -185,7 +185,7 @@ awk -v FS="\t" -v OFS="\t" -v nsamp=${nsamp} '{
  for(i=10;i<=NF;i++) {
   split($i,a,":");
     if (a[CN]==2) {homref++}
-    else if (a[CN]==0) {homalt++}
+    else if (a[CN]==0 || a[CN]>=4) {homalt++}
     else {het++} };
   AC=(2*homalt)+het; AN=2*(nsamp-(unknown+other)); AF=AC/AN;
   print $3, nsamp-unknown, homref, het, homalt, other, unknown, AC, AN, AF }' >> \


### PR DESCRIPTION
This PR addresses Issue https://github.com/broadinstitute/gatk-sv/issues/690.

### Description
Includes the case where CN >= 4 in the condition for counting hom-alt instances.

### Testing
- [This Terra job](https://app.terra.bio/#workspaces/Talkowski_training/kj-issue-701-gatk-sv-pipeline-1kgp/job_history/1bf3d5c9-8abb-45a9-b465-b877b6978755) shows an example run of the pipeline for the 1KGP cohort prior to this change.
- [This Terra job](https://app.terra.bio/#workspaces/Talkowski_training/kj-issue-701-gatk-sv-pipeline-1kgp/job_history/8fca24b5-da4f-42a2-a0a9-bcbb8a5abef5) shows an example run of the pipeline for the 1KGP cohort with this change.
- We can inspect some of the intermediate outputs for the modified task, which are stored at: _MainVcfQc/be0d8bbc-966f-47c0-a147-cc4301f7bbeb/call-CollectQcVcfWide/shard-0/CollectQcVcfWide/ded4fc77-8917-446f-adf2-d56af0148c17/call-CollectShardedVcfStats/shard-0/1kgp_2batch_test_cohort.chr1.collect_qc_vcf_wide.collect_stats.shard_0.collectQC_vcfwide_output.tar.gz_
- The stats files show that the `hom_gts` total increases in certain rows, while the `het_gts` total decreases in such rows - the sum of `hom_gts` & `het_gts` stays the same though.
- Lines 5 and 6 in the two images below provide an example of this, with the first image corresponding to the statistics files from before the change and the second image corresponding to the same file but after the change:
<img width="703" alt="prev" src="https://github.com/user-attachments/assets/f3155e07-df42-448a-8c11-b7aba9193a48">
<img width="703" alt="new" src="https://github.com/user-attachments/assets/6a3ed499-83f1-4460-8b38-c757d4888a78">

### Pre-Merge Changes Required
Remove automated Dockstore image sync for `MainVcfQc.wdl` in development branch.