### PR TITLE
Add documentation for rename_samples in GatherBatchEvidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Trains a [gCNV](https://gatk.broadinstitute.org/hc/en-us/articles/360035531152) 
 ## <a name="gather-batch-evidence">GatherBatchEvidence</a>
 *Formerly Module00c*
 
-Runs CNV callers ([cn.MOPS](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3351174/), [GATK-gCNV](https://gatk.broadinstitute.org/hc/en-us/articles/360035531152)) and combines single-sample raw evidence into a batch. See [above](#cohort-mode) for more information on batching.
+Runs CNV callers ([cn.MOPS](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3351174/), [GATK-gCNV](https://gatk.broadinstitute.org/hc/en-us/articles/360035531152)) and combines single-sample raw evidence into a batch. See [above](#cohort-mode) for more information on batching. `rename_samples` can be set to True in order to rename samples with PE, SR and BAF evidence to their IDs in the _samples_ array - this is always done for RD evidence.
 
 #### Prerequisites:
 * [GatherSampleEvidence](#gather-sample-evidence)

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Trains a [gCNV](https://gatk.broadinstitute.org/hc/en-us/articles/360035531152) 
 ## <a name="gather-batch-evidence">GatherBatchEvidence</a>
 *Formerly Module00c*
 
-Runs CNV callers ([cn.MOPS](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3351174/), [GATK-gCNV](https://gatk.broadinstitute.org/hc/en-us/articles/360035531152)) and combines single-sample raw evidence into a batch. `rename_samples` can be set to True in order to rename samples with PE, SR and BAF evidence to their IDs in the _samples_ array - this is always done for RD evidence. See [above](#cohort-mode) for more information on batching.
+Runs CNV callers ([cn.MOPS](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3351174/), [GATK-gCNV](https://gatk.broadinstitute.org/hc/en-us/articles/360035531152)) and combines single-sample raw evidence into a batch. See [above](#cohort-mode) for more information on batching.
 
 #### Prerequisites:
 * [GatherSampleEvidence](#gather-sample-evidence)

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Trains a [gCNV](https://gatk.broadinstitute.org/hc/en-us/articles/360035531152) 
 ## <a name="gather-batch-evidence">GatherBatchEvidence</a>
 *Formerly Module00c*
 
-Runs CNV callers ([cn.MOPS](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3351174/), [GATK-gCNV](https://gatk.broadinstitute.org/hc/en-us/articles/360035531152)) and combines single-sample raw evidence into a batch. See [above](#cohort-mode) for more information on batching. `rename_samples` can be set to True in order to rename samples with PE, SR and BAF evidence to their IDs in the _samples_ array - this is always done for RD evidence.
+Runs CNV callers ([cn.MOPS](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3351174/), [GATK-gCNV](https://gatk.broadinstitute.org/hc/en-us/articles/360035531152)) and combines single-sample raw evidence into a batch. `rename_samples` can be set to True in order to rename samples with PE, SR and BAF evidence to their IDs in the _samples_ array - this is always done for RD evidence. See [above](#cohort-mode) for more information on batching.
 
 #### Prerequisites:
 * [GatherSampleEvidence](#gather-sample-evidence)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Sample IDs should not:
 
 The same requirements apply to family IDs in the PED file, as well as batch IDs and the cohort ID provided as workflow inputs.
 
-Sample IDs are provided to [GatherSampleEvidence](#gather-sample-evidence) directly and need not match sample names from the BAM/CRAM headers. `GetSampleID.wdl` can be used to fetch BAM sample IDs and also generates a set of alternate IDs that are considered safe for this pipeline; alternatively, [this script](https://github.com/talkowski-lab/gnomad_sv_v3/blob/master/sample_id/convert_sample_ids.py) transforms a list of sample IDs to fit these requirements. Currently, sample IDs can be replaced again in [GatherBatchEvidence](#gather-batch-evidence). 
+Sample IDs are provided to [GatherSampleEvidence](#gather-sample-evidence) directly and need not match sample names from the BAM/CRAM headers.  `GetSampleID.wdl` can be used to fetch BAM sample IDs and also generates a set of alternate IDs that are considered safe for this pipeline; alternatively, [this script](https://github.com/talkowski-lab/gnomad_sv_v3/blob/master/sample_id/convert_sample_ids.py) transforms a list of sample IDs to fit these requirements. Currently, sample IDs can be replaced again in [GatherBatchEvidence](#gather-batch-evidence) - to do so, set the parameter `rename_samples = True` and provide updated sample IDs via the `samples` parameter.
 
 The following inputs will need to be updated with the transformed sample IDs:
 * Sample ID list for [GatherSampleEvidence](#gather-sample-evidence) or [GatherBatchEvidence](#gather-batch-evidence)

--- a/inputs/templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
@@ -173,7 +173,6 @@ Read the full TrainGCNV documentation [here](https://github.com/broadinstitute/g
 Read the full GatherBatchEvidence documentation [here](https://github.com/broadinstitute/gatk-sv#gather-batch-evidence).
 * Use the same `sample_set` definitions you used for `03-TrainGCNV`.
 * Before running this workflow, ensure that you have updated the `cohort_ped_file` attribute in Workspace Data with your cohort's PED file, with sex assignments updated based on ploidy detection from `02-EvidenceQC`.
-* `rename_samples` can be set to True in order to rename samples with PE, SR and BAF evidence to their IDs in the _samples_ array, which is always done for RD evidence.
 
 #### 05-ClusterBatch and 06-GenerateBatchMetrics
 

--- a/inputs/templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/cohort_mode_workspace_dashboard.md.tmpl
@@ -173,6 +173,7 @@ Read the full TrainGCNV documentation [here](https://github.com/broadinstitute/g
 Read the full GatherBatchEvidence documentation [here](https://github.com/broadinstitute/gatk-sv#gather-batch-evidence).
 * Use the same `sample_set` definitions you used for `03-TrainGCNV`.
 * Before running this workflow, ensure that you have updated the `cohort_ped_file` attribute in Workspace Data with your cohort's PED file, with sex assignments updated based on ploidy detection from `02-EvidenceQC`.
+* `rename_samples` can be set to True in order to rename samples with PE, SR and BAF evidence to their IDs in the _samples_ array, which is always done for RD evidence.
 
 #### 05-ClusterBatch and 06-GenerateBatchMetrics
 


### PR DESCRIPTION
This PR addresses Issue https://github.com/broadinstitute/gatk-sv/issues/698.

### Description
Includes a line of documentation regarding the outcome of setting _rename_samples_ to True in `GatherBatchEvidence`.

### Testing
N/A - solely documentation change.