### PR TITLE
Fix file naming in GenotypeBatch.SplitVariants

### DIFF
--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -66,7 +66,7 @@ def main():
     parser.add_argument("--n", help="number of variants per output file", required=True, type=int)
     parser.add_argument("--bca", default=False, help="Flag to set to True if the VCF contains BCAs",
                         action='store_true')
-    parser.add_argument("--digits", "-d", default=9, help="Number of digits in filename suffix")
+    parser.add_argument("--digits", "-d", default=9, type=int, help="Number of digits in filename suffix")
     parser.add_argument("--log-level", required=False, default="INFO", help="Specify level of logging information")
     args = parser.parse_args()
 

--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -54,7 +54,7 @@ def process_bed_file(input_bed, n_per_split, bca=True, digits=9):
 
 
 def get_file_name(prefix, suffix, digits):
-    if suffix >= 10 ** digits:
+    if len(str(suffix)) > digits:
         raise ValueError('No more files can be generated with the current naming scheme. '
                          'Increase the digits parameter or the n parameter to proceed.')
     return f"{prefix}.{str(suffix).zfill(digits)}.bed"

--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -44,7 +44,7 @@ def process_bed_file(input_bed, n_per_split, bca=True, digits=9):
                         # Update the tracking information
                         current_lines[prefix] = []
                         current_counts[prefix] = 0
-                        current_suffixes[prefix] = increment_suffix(current_suffixes[prefix], digits)
+                        current_suffixes[prefix] = current_suffixes[prefix] + 1
     # Handle the samples after files with the given number of lines per file have been written
     for prefix, lines in current_lines.items():
         if lines:
@@ -54,15 +54,10 @@ def process_bed_file(input_bed, n_per_split, bca=True, digits=9):
             logging.info(f"File '{output_file}' written.")
 
 
-# Increment file suffix number and error if maximum number of file names is reached
-def increment_suffix(suffix, digits):
-    if suffix + 1 >= 10 ** digits:
-        raise ValueError('All possible files generated.')
-    else:
-        return suffix + 1
-
-
 def get_file_name(prefix, suffix, digits):
+    if suffix >= 10 ** digits:
+        raise ValueError('No more files can be generated with the current naming scheme.'
+                         'Increase the digits parameter or the n parameter to proceed.')
     return f"{prefix}.{str(suffix).zfill(digits)}.bed"
 
 

--- a/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/split_variants.py
@@ -55,7 +55,7 @@ def process_bed_file(input_bed, n_per_split, bca=True, digits=9):
 
 def get_file_name(prefix, suffix, digits):
     if suffix >= 10 ** digits:
-        raise ValueError('No more files can be generated with the current naming scheme.'
+        raise ValueError('No more files can be generated with the current naming scheme. '
                          'Increase the digits parameter or the n parameter to proceed.')
     return f"{prefix}.{str(suffix).zfill(digits)}.bed"
 


### PR DESCRIPTION
### Updates

The SplitVariants task in GenotypeBatch was not successfully incrementing file name suffixes; after reaching `aaaaaz` it looped back to `aaaaaa`. This resulted in variants being dropped from sufficiently large VCFs in the output.

This PR updates SplitVariants to use numeric file naming for simplicity, with a default of 9 characters in the suffix for a maximum of 1,000,000,000 files (to ensure that there can be at least as many files as alphabetical naming with 6 characters in the suffix, which allows for 308,915,776 files). 

### Testing

* Tested manually on data that was large enough to trigger the issue with the previous SplitVariants version and verified that 52 files were produced instead of the previous and erroneous 26 files.
* Tested manually on the same data with `-d 1` and verified that the error message was produced after 10 files were written.
* Validated all WDLs and JSONs with womtool and Terra validation script
* Tested with an updated docker image to verify a successful run on the reference panel. The depth VCF was identical to the one produced by v0.28.5-beta (this test set is too small to observe the issue of overwriting files), although there were small differences in the PESR VCF, likely due to the updates to the way MEIs are treated (the number of records was identical)