### PR TITLE
Rename high & low overall outliers columns generated via EvidenceQC

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -15,6 +15,7 @@ workflows:
     filters:
       branches: 
         - main
+        - kj/rename_overall_outliers
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -15,7 +15,6 @@ workflows:
     filters:
       branches: 
         - main
-        - kj/rename_overall_outliers
       tags:
         - /.*/
 

--- a/src/sv-pipeline/scripts/make_evidence_qc_table.py
+++ b/src/sv-pipeline/scripts/make_evidence_qc_table.py
@@ -147,10 +147,10 @@ def read_all_outlier(outlier_manta_df: pd.DataFrame, outlier_melt_df: pd.DataFra
         merged_dicts.update(counted)
     all_outliers = dict(merged_dicts)
     if len(all_outliers) == 0:
-        all_outliers_df = pd.DataFrame(columns=[ID_COL, outlier_type + "_overall_outliers"])
+        all_outliers_df = pd.DataFrame(columns=[ID_COL, "overall_" + outlier_type + "_outlier"])
     else:
         all_outliers_df = pd.DataFrame.from_dict(all_outliers, orient="index").reset_index()
-        all_outliers_df.columns = [ID_COL, outlier_type + "_overall_outliers"]
+        all_outliers_df.columns = [ID_COL, "overall_" + outlier_type + "_outlier"]
     return all_outliers_df
 
 


### PR DESCRIPTION
### Description
Renames the columns high_overall_outliers and low_overall_outliers to `overall_high_outlier` and `overall_low_outlier` respectively. This is done in order to standardize with the column names for the other callers generated via EvidenceQC.

### Testing
The outputs from [this Terra job](https://app.terra.bio/#workspaces/Talkowski_training/kj-issue-701-gatk-sv-pipeline-1kgp/job_history/b3f9c49c-1d60-4ed4-b7c5-c9a439ea0c3f) shows an example run of the pipeline for the 1KGP cohort following this change. As you can see in the image below, which has been extracted from the output TSV files created in this job, the new column names for overall outliers now align with the caller-specific outlier column names.
 
<img width="594" alt="Screenshot 2024-08-20 at 4 47 38 PM" src="https://github.com/user-attachments/assets/903c610a-32ff-4204-b4a1-89441e8a4b21">
