### PR TITLE
Keep unresolved Manta calls

### DIFF
--- a/wdl/GatherBatchEvidence.wdl
+++ b/wdl/GatherBatchEvidence.wdl
@@ -506,6 +506,7 @@ workflow GatherBatchEvidence {
     File? Matrix_QC_plot = MatrixQC.QC_plot
     
     Array[File]? manta_tloc = TinyResolve.tloc_manta_vcf
+    Array[File]? manta_unresolved = TinyResolve.unresolved_manta_vcf
 
     File? metrics_file_batchevidence = GatherBatchEvidenceMetrics.metrics_file
   }

--- a/wdl/GatherBatchEvidence.wdl
+++ b/wdl/GatherBatchEvidence.wdl
@@ -505,8 +505,8 @@ workflow GatherBatchEvidence {
     File? BAF_stats = MatrixQC.BAF_stats
     File? Matrix_QC_plot = MatrixQC.QC_plot
     
-    File? manta_tloc_tar = TinyResolve.tloc_manta_tar
-    File? manta_unresolved_tar = TinyResolve.unresolved_manta_tar
+    File? manta_tloc_tar = TinyResolve.manta_tloc_tar
+    File? manta_unresolved_tar = TinyResolve.manta_unresolved_tar
 
     File? metrics_file_batchevidence = GatherBatchEvidenceMetrics.metrics_file
   }

--- a/wdl/GatherBatchEvidence.wdl
+++ b/wdl/GatherBatchEvidence.wdl
@@ -505,8 +505,8 @@ workflow GatherBatchEvidence {
     File? BAF_stats = MatrixQC.BAF_stats
     File? Matrix_QC_plot = MatrixQC.QC_plot
     
-    Array[File]? manta_tloc = TinyResolve.tloc_manta_vcf
-    Array[File]? manta_unresolved = TinyResolve.unresolved_manta_vcf
+    File? manta_tloc_tar = TinyResolve.tloc_manta_tar
+    File? manta_unresolved_tar = TinyResolve.unresolved_manta_tar
 
     File? metrics_file_batchevidence = GatherBatchEvidenceMetrics.metrics_file
   }

--- a/wdl/TinyResolve.wdl
+++ b/wdl/TinyResolve.wdl
@@ -142,6 +142,8 @@ task ResolveManta {
       pe=${discfiles[$i]}
       sample_no=`printf %03d $i`
       bash /opt/sv-pipeline/00_preprocessing/scripts/mantatloccheck.sh $vcf $pe ${sample_id} ~{mei_bed} ~{cytoband}
+      bcftools sort --output manta.unresolved.vcf.tmp --output-type v manta.unresolved.vcf
+      mv manta.unresolved.vcf.tmp manta.unresolved.vcf
       if [[ ~{true='true' false='false' rm_cpx_type} = 'true' ]]; then
         bcftools annotate --include 'INFO/SVTYPE != "CPX"' --keep-sites \
           --remove 'INFO/CPX_TYPE' \

--- a/wdl/TinyResolve.wdl
+++ b/wdl/TinyResolve.wdl
@@ -192,14 +192,22 @@ task ConcatTars {
     while read -r tl; do
       tar --extract --file "${tl}" --directory manta_tloc
     done < '~{write_lines(manta_tloc_tars)}'
-    tar --create --gzip --file manta_tloc.tar.gz manta_tloc
+    pushd manta_tloc
+    find . -type f -name '*.vcf.gz' > manifest.list
+    popd
+    tar --create --gzip --file manta_tloc.tar.gz --directory manta_tloc \
+      --files-from manta_tloc/manifest.list
     rm -rf manta_tloc
 
     mkdir manta_unresolved
     while read -r ur; do
       tar --extract --file "${ur}" --directory manta_unresolved
     done < '~{write_lines(manta_unresolved_tars)}'
-    tar --create --gzip --file manta_unresolved.tar.gz manta_unresolved
+    pushd manta_unresolved
+    find . -type f -name '*.vcf.gz' > manifest.list
+    popd
+    tar --create --gzip --file manta_unresolved.tar.gz \
+      --directory manta_unresolved --files-from manta_unresolved/manifest.list
   >>>
 
   runtime {

--- a/wdl/TinyResolve.wdl
+++ b/wdl/TinyResolve.wdl
@@ -176,7 +176,7 @@ task ConcatTars {
   RuntimeAttr default_attr = object {
     cpu_cores: 1,
     mem_gb: 1.0,
-    disk_gb: ceil(3 * (size(manta_tloc_tars, "GB") + size(manta_unresolved_tars, "GB"))),
+    disk_gb: ceil(10 + 3 * (size(manta_tloc_tars, "GB") + size(manta_unresolved_tars, "GB"))),
     boot_disk_gb: 10,
     preemptible_tries: 3,
     max_retries: 1

--- a/wdl/TinyResolve.wdl
+++ b/wdl/TinyResolve.wdl
@@ -85,6 +85,7 @@ workflow TinyResolve {
 
   output {
     Array[File] tloc_manta_vcf = flatten(ResolveManta.tloc_vcf)
+    Array[File] unresolved_manta_vcf = flatten(ResolveManta.unresolved_vcf)
   }
 }
 
@@ -128,11 +129,14 @@ task ResolveManta {
       sample_no=`printf %03d $i`
       bash /opt/sv-pipeline/00_preprocessing/scripts/mantatloccheck.sh $vcf $pe ${sample_id} ~{mei_bed} ~{cytoband}
       mv ${sample_id}.manta.complex.vcf.gz tloc_${sample_no}.${sample_id}.manta.complex.vcf.gz
+      bgzip manta.unresolved.vcf
+      mv manta.unresolved.vcf.gz ${sample_no}.${sample_id}.manta.unresolved.vcf.gz
     done
   >>>
 
   output {
-    Array[File] tloc_vcf = glob("tloc_*.vcf.gz")
+    Array[File] tloc_vcf = glob("tloc_*complex.vcf.gz")
+    Array[File] unresolved_vcf = glob("*unresolved.vcf.gz")
   }
   
   runtime {


### PR DESCRIPTION
Keep unresolved Manta calls in TinyResolve to assist with resolving ultra complex events.