### PR TITLE
Add the single-sample pipeline to the Dockstore automation.

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -161,3 +161,12 @@ workflows:
         - main
       tags:
         - /.*/
+
+  - subclass: WDL
+    name: SingleSample
+    primaryDescriptorPath: /wdl/GATKSVPipelineSingleSample.wdl
+    filters:
+      branches:
+        - main
+      tags:
+        - /.*/


### PR DESCRIPTION
Addresses https://github.com/broadinstitute/gatk-sv/issues/724

The latest version of the `GATKSVPipelineSingleSample` on Dockstore is v0.28.4; hence, the latest two releases, i.e., v0.28.5 and v0.29.0 are not published to Dockstore. This is because the workflow is not tracked and published by the Dockstore automation, which this PR fixes. Specifically, this PR makes the following changes:

- Add `GATKSVPipelineSingleSample` to Dockstore automation;
- This workflow was previously published under the `gatk-sv/gatk-sv-single-sample` name, which does not match the naming convention of other workflows. Hence, we are renaming it, and the new versions will publish under the `gatk-sv/SingleSample` name that matches the naming convention of other workflows.