### PR TITLE
Update type-checking in RdTestV2 to be class-based

### DIFF
--- a/src/RdTest/RdTest.R
+++ b/src/RdTest/RdTest.R
@@ -1359,7 +1359,7 @@ intervals[, c(2:3)] <-
   })
 intervals <- data.frame(lapply(intervals, as.character), stringsAsFactors=FALSE)
 results<-alply(intervals,1,runRdTest)
-if(is.list(results)) {
+if(class(results)=="list") {
   results<-do.call(rbind,results)
 } else {
   results <- t(results)

--- a/src/RdTest/RdTest.R
+++ b/src/RdTest/RdTest.R
@@ -1359,7 +1359,7 @@ intervals[, c(2:3)] <-
   })
 intervals <- data.frame(lapply(intervals, as.character), stringsAsFactors=FALSE)
 results<-alply(intervals,1,runRdTest)
-if(class(results)=="list") {
+if(is.list(results)) {
   results<-do.call(rbind,results)
 } else {
   results <- t(results)

--- a/src/RdTest/RdTestV2.R
+++ b/src/RdTest/RdTestV2.R
@@ -1450,7 +1450,7 @@ intervals[, c(2:3)] <-
   })
 intervals <- data.frame(lapply(intervals, as.character), stringsAsFactors=FALSE)
 results<-apply(intervals,1,runRdTest)
-if(class(results)=="list") {
+if(is.list(results)) {
   results<-do.call(rbind,results)
 } else {
   results <- t(results)


### PR DESCRIPTION
### Description
- In the process of generating the output metrics file, `RdTestV2.R` throws the following error in more up-to-date versions of R:
`Error in if (class(results) == "list") { : the condition has length > 1
Execution halted`
- The current version being used in the `VisualizeCnvs` workflow throws a warning, though the warning message highlights how `results` is being evaluated in an incorrect manner, as it now checks the class of a single element rather than the entire data structure:
`Warning message: In if (class(results) == "list") { :
  the condition has length > 1 and only the first element will be used`
- This PR resolves this by updating the check to be based on the class of `results`. 

### Testing
- This [Terra job](https://app.terra.bio/#workspaces/Talkowski_training/kj-issue-44-brainvar/job_history/c6dc384b-6fbb-4dd5-8fca-acce500ac7b1) uses the original Docker, where the `stderr` file highlights how the current version of `RdTestV2.R` causes the `VisualizeCnvs` workflow to trigger a warning.
- This [Terra job](https://app.terra.bio/#workspaces/Talkowski_training/kj-issue-44-brainvar-2/job_history/d2042c1a-acd5-4868-b4ba-1cd8e8f00e18) uses a Docker image loaded with the version of `RdTestV2.R` introduced in this PR, and demonstrates how it resolves the issue outlined above - there is no such warning in the `stderr` file.