### PR TITLE
Fix for normalize_counts() in GenerateBatchMetrics

### DIFF
--- a/src/svtk/svtk/pesr/pesr_test.py
+++ b/src/svtk/svtk/pesr/pesr_test.py
@@ -77,7 +77,7 @@ class PESRTest:
         counts = pd.merge(counts, self.medians, on='sample', how='left')
         counts['norm_count'] = counts['count'] * \
             target_cov / counts['median_cov']
-        counts['count'] = counts['norm_count'].round()
+        counts['count'] = counts['norm_count'].astype(float).round()
         counts.drop(['norm_count', 'median_cov'], axis=1, inplace=True)
 
         return counts


### PR DESCRIPTION
### Description
In the process of running the PE test within `GenerateBatchMetrics`, the Pandas version used by the Docker seems to trigger the following error:
```
Traceback (most recent call last):
...
File "/opt/svtk/svtk/pesr/pe_test.py", line 75, in test
counts = self.normalize_counts(counts)
File "/opt/svtk/svtk/pesr/pesr_test.py", line 80, in normalize_counts
counts['count'] = counts['norm_count'].round()
File "/opt/conda/envs/gatk-sv/lib/python3.10/site-packages/pandas/core/series.py", line 2442, in round
result = self._values.round(decimals)
TypeError: loop of ufunc does not support argument 0 of type float which has no callable rint method
```
This PR resolves this error, by casting the column in question to float-type prior to rounding.

### Testing
- This [Terra job](https://job-manager.dsde-prod.broadinstitute.org/jobs/a306d079-1184-4e0b-aade-be7d54f86d8e) uses the original Docker, where the `stderr` file highlights how the current version of `pesr-test.py` causes the `GenerateBatchMetrics` workflow to fail.
- This [Terra job](https://app.terra.bio/#workspaces/Talkowski_training/kj-featured-workspace-clone/job_history/a6c428ec-05b3-4ecf-a956-40e34c678cc8) uses a Docker image loaded with the version of `pesr-test.py` introduced in this PR, and demonstrates how it resolves the issue outlined above - the workflow completes successfully.