### PR TITLE
Modify EvidenceQC to not create/expect additional column in median coverage file

### DIFF
--- a/src/WGD/bin/medianCoverage.R
+++ b/src/WGD/bin/medianCoverage.R
@@ -122,6 +122,6 @@ if(opts$binwise==TRUE){
   write.table(res,args$args[2], sep="\t", col.names=T, row.names=F, quote=F)
 }else{
   res <- covPerSample(cov,mad=opts$mad)
-  names(res)[1] <- "sample_id"
+  names(res)[1] <- "#sample_id"
   write.table(res,args$args[2], sep="\t", col.names=T, row.names=F, quote=F)
 }

--- a/src/sv-pipeline/scripts/make_evidence_qc_table.py
+++ b/src/sv-pipeline/scripts/make_evidence_qc_table.py
@@ -51,7 +51,7 @@ def read_bincov_median(filename: str) -> pd.DataFrame:
     df_median = pd.read_csv(filename, sep="\t").T
     df_median = df_median.rename_axis(ID_COL).reset_index()
     df_median.columns = [ID_COL, "median_coverage"]
-    df_median = df_median.iloc.reset_index(drop=True)
+    df_median = df_median.reset_index(drop=True)
     return df_median
 
 

--- a/src/sv-pipeline/scripts/make_evidence_qc_table.py
+++ b/src/sv-pipeline/scripts/make_evidence_qc_table.py
@@ -51,7 +51,7 @@ def read_bincov_median(filename: str) -> pd.DataFrame:
     df_median = pd.read_csv(filename, sep="\t").T
     df_median = df_median.rename_axis(ID_COL).reset_index()
     df_median.columns = [ID_COL, "median_coverage"]
-    df_median = df_median.iloc[1:].reset_index(drop=True)
+    df_median = df_median.iloc.reset_index(drop=True)
     return df_median
 
 


### PR DESCRIPTION
### Description
`src/WGD/bin/medianCoverage.R` currently creates an additional column in its output that is not expected by later workflows that use this output, causing an error in _14-GenotypeComplexVariants_. This PR intends to remove this column so that it follows its original representation.

### Testing
- This [Terra job](https://app.terra.bio/#workspaces/broad-firecloud-dsde-methods/GATK-Structural-Variants-Joint-Calling/job_history/7af56e0c-81cb-448a-aa75-cc5b40fac520) demonstrates the a run with the previous version of the scripts - note that additional column in the `bincov_median` output.
- This [Terra job](https://app.terra.bio/#workspaces/Talkowski_training/KJ-GATK-Structural-Variants-Joint-Calling/job_history/dcc03b37-8395-4d4f-86d8-402dad5f56c4) demonstrates the a run with the updated version of the scripts - note that the additional column has disappeared, yet the output `qc_table` is identical to the job above.