### PR TITLE
Replace relative paths with abs paths to JS components

### DIFF
--- a/website/docs/modules/annotate_vcf.md
+++ b/website/docs/modules/annotate_vcf.md
@@ -5,7 +5,7 @@ sidebar_position: 20
 slug: av
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 Adds annotations, such as the inferred function and allele frequencies of variants, to a VCF.
 

--- a/website/docs/modules/annotate_vcf.md
+++ b/website/docs/modules/annotate_vcf.md
@@ -5,7 +5,7 @@ sidebar_position: 20
 slug: av
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 Adds annotations, such as the inferred function and allele frequencies of variants, to a VCF.
 

--- a/website/docs/modules/clean_vcf.md
+++ b/website/docs/modules/clean_vcf.md
@@ -5,7 +5,7 @@ sidebar_position: 14
 slug: cvcf
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/CleanVcf.wdl)
 

--- a/website/docs/modules/clean_vcf.md
+++ b/website/docs/modules/clean_vcf.md
@@ -5,7 +5,7 @@ sidebar_position: 14
 slug: cvcf
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/CleanVcf.wdl)
 

--- a/website/docs/modules/cluster_batch.md
+++ b/website/docs/modules/cluster_batch.md
@@ -5,7 +5,7 @@ sidebar_position: 5
 slug: cb
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/ClusterBatch.wdl)
 

--- a/website/docs/modules/cluster_batch.md
+++ b/website/docs/modules/cluster_batch.md
@@ -5,7 +5,7 @@ sidebar_position: 5
 slug: cb
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/ClusterBatch.wdl)
 

--- a/website/docs/modules/combine_batches.md
+++ b/website/docs/modules/combine_batches.md
@@ -5,7 +5,7 @@ sidebar_position: 11
 slug: cmb
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/CombineBatches.wdl)
 

--- a/website/docs/modules/combine_batches.md
+++ b/website/docs/modules/combine_batches.md
@@ -5,7 +5,7 @@ sidebar_position: 11
 slug: cmb
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/CombineBatches.wdl)
 

--- a/website/docs/modules/evidence_qc.md
+++ b/website/docs/modules/evidence_qc.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 slug: eqc
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/EvidenceQC.wdl)
 

--- a/website/docs/modules/evidence_qc.md
+++ b/website/docs/modules/evidence_qc.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 slug: eqc
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/EvidenceQC.wdl)
 

--- a/website/docs/modules/filter_batch.md
+++ b/website/docs/modules/filter_batch.md
@@ -5,7 +5,7 @@ sidebar_position: 7
 slug: fb
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/FilterBatch.wdl)
 

--- a/website/docs/modules/filter_batch.md
+++ b/website/docs/modules/filter_batch.md
@@ -5,7 +5,7 @@ sidebar_position: 7
 slug: fb
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/FilterBatch.wdl)
 

--- a/website/docs/modules/filter_genotypes.md
+++ b/website/docs/modules/filter_genotypes.md
@@ -5,7 +5,7 @@ sidebar_position: 19
 slug: fg
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/FilterGenotypes.wdl)
 

--- a/website/docs/modules/filter_genotypes.md
+++ b/website/docs/modules/filter_genotypes.md
@@ -5,7 +5,7 @@ sidebar_position: 19
 slug: fg
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/FilterGenotypes.wdl)
 

--- a/website/docs/modules/gather_batch_evidence.md
+++ b/website/docs/modules/gather_batch_evidence.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 slug: gbe
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/GatherBatchEvidence.wdl)
 

--- a/website/docs/modules/gather_batch_evidence.md
+++ b/website/docs/modules/gather_batch_evidence.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 slug: gbe
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/GatherBatchEvidence.wdl)
 

--- a/website/docs/modules/gather_sample_evidence.md
+++ b/website/docs/modules/gather_sample_evidence.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 slug: gse
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/GatherSampleEvidence.wdl)
 

--- a/website/docs/modules/gather_sample_evidence.md
+++ b/website/docs/modules/gather_sample_evidence.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 slug: gse
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/GatherSampleEvidence.wdl)
 

--- a/website/docs/modules/genotype_complex.md
+++ b/website/docs/modules/genotype_complex.md
@@ -5,7 +5,7 @@ sidebar_position: 13
 slug: gcv
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/GenotypeComplexVariants.wdl)
 

--- a/website/docs/modules/genotype_complex.md
+++ b/website/docs/modules/genotype_complex.md
@@ -5,7 +5,7 @@ sidebar_position: 13
 slug: gcv
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/GenotypeComplexVariants.wdl)
 

--- a/website/docs/modules/main_vcf_qc.md
+++ b/website/docs/modules/main_vcf_qc.md
@@ -5,7 +5,7 @@ sidebar_position: 21
 slug: mvqc
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/MainVcfQC.wdl)
 

--- a/website/docs/modules/main_vcf_qc.md
+++ b/website/docs/modules/main_vcf_qc.md
@@ -5,7 +5,7 @@ sidebar_position: 21
 slug: mvqc
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/MainVcfQC.wdl)
 

--- a/website/docs/modules/refine_cpx.md
+++ b/website/docs/modules/refine_cpx.md
@@ -5,7 +5,7 @@ sidebar_position: 15
 slug: refcv
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/RefineComplexVariants.wdl)
 

--- a/website/docs/modules/refine_cpx.md
+++ b/website/docs/modules/refine_cpx.md
@@ -5,7 +5,7 @@ sidebar_position: 15
 slug: refcv
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/RefineComplexVariants.wdl)
 

--- a/website/docs/modules/resolve_complex.md
+++ b/website/docs/modules/resolve_complex.md
@@ -5,7 +5,7 @@ sidebar_position: 12
 slug: rcv
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/ResolveComplexVariants.wdl)
 

--- a/website/docs/modules/resolve_complex.md
+++ b/website/docs/modules/resolve_complex.md
@@ -5,7 +5,7 @@ sidebar_position: 12
 slug: rcv
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/ResolveComplexVariants.wdl)
 

--- a/website/docs/modules/train_gcnv.md
+++ b/website/docs/modules/train_gcnv.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 slug: gcnv
 ---
 
-import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "@site/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/TrainGCNV.wdl)
 

--- a/website/docs/modules/train_gcnv.md
+++ b/website/docs/modules/train_gcnv.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 slug: gcnv
 ---
 
-import { Highlight, HighlightOptionalArg } from "../../src/components/highlight.js"
+import { Highlight, HighlightOptionalArg } from "/src/components/highlight.js"
 
 [WDL source code](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/TrainGCNV.wdl)
 


### PR DESCRIPTION
Relative paths used for referencing components break version docs, so I am replacing them with ABS paths for portability. 