### PR TITLE
Fix multiallelic genotypes for biallelic CNVs

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -141,6 +141,7 @@ workflows:
     filters:
       branches:
         - main
+        - kj_fix_retained_multiallelic_genos
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -141,7 +141,6 @@ workflows:
     filters:
       branches:
         - main
-        - kj_fix_retained_multiallelic_genos
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -141,6 +141,7 @@ workflows:
     filters:
       branches:
         - main
+        - kj_fix_retained_multiallelic_genos
       tags:
         - /.*/
 
@@ -213,15 +214,5 @@ workflows:
     filters:
       branches:
         - main
-      tags:
-        - /.*/
-
-  - subclass: WDL
-    name: CleanVcf5
-    primaryDescriptorPath: /wdl/CleanVcf5.wdl
-    filters:
-      branches:
-        - main
-        - kj_fix_retained_multiallelic_genos
       tags:
         - /.*/

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -141,7 +141,6 @@ workflows:
     filters:
       branches:
         - main
-        - kj_fix_retained_multiallelic_genos
       tags:
         - /.*/
 
@@ -214,5 +213,15 @@ workflows:
     filters:
       branches:
         - main
+      tags:
+        - /.*/
+
+  - subclass: WDL
+    name: CleanVcf5
+    primaryDescriptorPath: /wdl/CleanVcf5.wdl
+    filters:
+      branches:
+        - main
+        - kj_fix_retained_multiallelic_genos
       tags:
         - /.*/

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part5_update_records.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part5_update_records.py
@@ -136,7 +136,7 @@ def main():
 
                 if gt5kb_dup:
                     for sample_obj in record.samples.itervalues():
-                        # Leave no-calls
+                        # Leave no-calls - also causes bug that skips multiallelic genotypes for a biallelic variant
                         if sample_obj['GT'] == (None, None):
                             continue
                         if not sample_obj['GQ'] is None and \

--- a/wdl/CleanVcf5.wdl
+++ b/wdl/CleanVcf5.wdl
@@ -247,8 +247,15 @@ task Polish {
                 --exclude 'ID=@ids_to_remove.list' \
                 --output-type z -o polished.need_reheader.vcf.gz --threads ~{threads}
 
+        # replace multiallelic genotypes for CNVs with a homref call
+        bcftools +setGT polished.need_reheader.vcf.gz \
+            -- -t . \
+            -n '1/1' \
+            -i '(ALT="<DUP>" || ALT="<DEL>" || ALT="<CNV>") && (GT[0]>1 || GT[1]>1) && FMT/RD_CN>3' \
+            -Oz -o polished.need_reheader.modified.vcf.gz --threads ~{threads}
+
         # do the last bit of header cleanup
-        bcftools view -h polished.need_reheader.vcf.gz > original_header.vcf
+        bcftools view -h polished.need_reheader.modified.vcf.gz > original_header.vcf
         cat original_header.vcf | fgrep '##fileformat' > new_header.vcf
         cat original_header.vcf \
             | egrep -v "CIPOS|CIEND|RMSSTD|EVENT|INFO=<ID=UNRESOLVED,|source|varGQ|bcftools|ALT=<ID=UNR|INFO=<ID=MULTIALLELIC|GATKCommandLine|#CHROM|##contig|##fileformat" \
@@ -256,7 +263,7 @@ task Polish {
         # Don't sort contigs lexicographically, which would result in incorrect chr1, chr10, chr11, ... ordering
         cat original_header.vcf | fgrep '##contig' >> new_header.vcf
         cat original_header.vcf | fgrep '#CHROM' >> new_header.vcf
-        bcftools reheader polished.need_reheader.vcf.gz -h new_header.vcf -o ~{prefix}.vcf.gz
+        bcftools reheader polished.need_reheader.modified.vcf.gz -h new_header.vcf -o ~{prefix}.vcf.gz
     >>>
 
     output {

--- a/wdl/CleanVcf5.wdl
+++ b/wdl/CleanVcf5.wdl
@@ -249,9 +249,9 @@ task Polish {
 
         # replace multiallelic genotypes for CNVs with homref
         bcftools +setGT polished.need_reheader.vcf.gz -- \
-            --target-gt q \
-            --new-gt c:'1/1' \
-            --include '(INFO/SVTYPE="DEL" || INFO/SVTYPE="DUP") && (GT~"[2-9]" || GT~"[1-9][0-9]+") && FMT/RD_CN>3' > polished.need_reheader.regenotyped.vcf
+            -t q \
+            -n c:'1/1' \
+            -i '(INFO/SVTYPE="DEL" | INFO/SVTYPE="DUP") & (FMT/GT~"[2-9]" | FMT/GT~"[1-9][0-9]+") & FMT/RD_CN>3' > polished.need_reheader.regenotyped.vcf
         
         bgzip polished.need_reheader.regenotyped.vcf
         

--- a/wdl/CleanVcf5.wdl
+++ b/wdl/CleanVcf5.wdl
@@ -247,7 +247,7 @@ task Polish {
                 --exclude 'ID=@ids_to_remove.list' \
                 --output-type z -o polished.need_reheader.vcf.gz --threads ~{threads}
 
-        # replace multiallelic genotypes for CNVs with a homref call
+        # replace multiallelic genotypes for CNVs with homref
         bcftools +setGT polished.need_reheader.vcf.gz \
             -- -t . \
             -n '1/1' \


### PR DESCRIPTION
### Description
Due to an issue in _pysam_ where it parses multiallelic genotypes for biallelic CNVs as (`None`, `None`), `clean_vcf_part5_update_records.py` of _CleanVcf5_ currently retains such genotypes, causing an error in _18-SVConcordance_ as GATK is unable to parse such a VCF record. This PR intends to eliminate such genotypes from the VCF output by this module.

### Testing
- This [Terra job](https://app.terra.bio/#workspaces/broad-firecloud-dsde-methods/GATK-Structural-Variants-Joint-Calling/job_history/65cceb6c-0936-438b-a09f-a026ef08aa18) demonstrates the a run with the previous version of _CleanVcf5_ - note that the `cleaned_vcf` output contains some multiallelic genotypes for CNVs.
- This [Terra job](https://app.terra.bio/#workspaces/Talkowski_training/KJ-GATK-Structural-Variants-Joint-Calling/job_history/744093ce-4330-4f04-82cd-98ce2ea65356) demonstrates a run with the updated version of _CleanVcf5_ - note that the `cleaned_vcf` output does not contain any multiallelic genotypes for CNVs.