### PR TITLE
Fix multiallelic GTs with low copy number

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -141,7 +141,6 @@ workflows:
     filters:
       branches:
         - main
-        - kj_fix_multiallelic_low_cn_gt
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -141,6 +141,7 @@ workflows:
     filters:
       branches:
         - main
+        - kj_fix_multiallelic_low_cn_gt
       tags:
         - /.*/
 

--- a/wdl/CleanVcf5.wdl
+++ b/wdl/CleanVcf5.wdl
@@ -251,7 +251,7 @@ task Polish {
         bcftools +setGT polished.need_reheader.vcf.gz -- \
             -t q \
             -n c:'1/1' \
-            -i '(INFO/SVTYPE="DEL" | INFO/SVTYPE="DUP") & (FMT/GT~"[2-9]" | FMT/GT~"[1-9][0-9]+") & FMT/RD_CN>3' > polished.need_reheader.regenotyped.vcf
+            -i '(INFO/SVTYPE="DEL" | INFO/SVTYPE="DUP") & (FMT/GT~"[2-9]" | FMT/GT~"[1-9][0-9]+")' > polished.need_reheader.regenotyped.vcf
         
         bgzip polished.need_reheader.regenotyped.vcf
         


### PR DESCRIPTION
### Description
Due to an issue in _pysam_ where it parses multiallelic genotypes for biallelic CNVs as (`None`, `None`), `clean_vcf_part5_update_records.py` of _CleanVcf5_ currently retains such genotypes, causing an error in _18-SVConcordance_ as GATK is unable to parse such a VCF record. A previous PR https://github.com/broadinstitute/gatk-sv/pull/748 modified these to be 2/2, but only did so for genotypes where `RD_CN >= 4`. This PR intends to do it for all genotypes, regardless of `RD_CN`, as the original process did.

### Testing
- This [Terra job](https://app.terra.bio/#workspaces/cmg-acct/gatk-sv-cmg-phase5-dragen/job_history/739811c9-f971-4ad3-b67c-ca5005740076) demonstrates the a run with the previous version of _CleanVcf5_ - note that the `cleaned_vcf` output still contains a handful of multiallelic genotypes for CNVs.
- This [Terra job](https://app.terra.bio/#workspaces/cmg-acct/gatk-sv-cmg-phase5-dragen/job_history/041366fa-001a-4f77-9086-973cafbc725d) demonstrates a run with the updated version of _CleanVcf5_ - note that the `cleaned_vcf` output does not contain any multiallelic genotypes for CNVs.