### PR TITLE
Update EvidenceQC templates 

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/EvidenceQC.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/EvidenceQC.json.tmpl
@@ -8,7 +8,6 @@
   "EvidenceQC.genome_file": "${workspace.genome_file}",
 
   "EvidenceQC.batch": "${this.sample_set_id}",
-  "EvidenceQC.melt_insert_size": "${this.samples.melt_insert_size}",
   "EvidenceQC.counts": "${this.samples.coverage_counts}",
   "EvidenceQC.manta_vcfs": "${this.samples.manta_vcf}",
   "EvidenceQC.melt_vcfs": "${this.samples.melt_vcf}",

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/EvidenceQC.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/EvidenceQC.json.tmpl
@@ -10,7 +10,6 @@
   "EvidenceQC.batch": "${this.sample_set_id}",
   "EvidenceQC.counts": "${this.samples.coverage_counts}",
   "EvidenceQC.manta_vcfs": "${this.samples.manta_vcf}",
-  "EvidenceQC.melt_vcfs": "${this.samples.melt_vcf}",
   "EvidenceQC.wham_vcfs": "${this.samples.wham_vcf}",
   "EvidenceQC.scramble_vcfs": "${this.samples.scramble_vcf}",
   "EvidenceQC.samples": "${this.samples.sample_id}"

--- a/inputs/templates/test/EvidenceQC/EvidenceQC.json.tmpl
+++ b/inputs/templates/test/EvidenceQC/EvidenceQC.json.tmpl
@@ -12,5 +12,6 @@
   "EvidenceQC.manta_vcfs": {{ test_batch.manta_vcfs | tojson }},
   "EvidenceQC.melt_vcfs": {{ test_batch.melt_vcfs | tojson }},
   "EvidenceQC.wham_vcfs": {{ test_batch.wham_vcfs | tojson }},
+  "EvidenceQC.scramble_vcfs": {{ test_batch.scramble_vcf }},
   "EvidenceQC.samples": {{ test_batch.samples | tojson }}
 }

--- a/inputs/templates/test/EvidenceQC/EvidenceQC.json.tmpl
+++ b/inputs/templates/test/EvidenceQC/EvidenceQC.json.tmpl
@@ -10,7 +10,6 @@
   "EvidenceQC.batch": {{ test_batch.name | tojson }},
   "EvidenceQC.counts": {{ test_batch.counts | tojson }},
   "EvidenceQC.manta_vcfs": {{ test_batch.manta_vcfs | tojson }},
-  "EvidenceQC.melt_vcfs": {{ test_batch.melt_vcfs | tojson }},
   "EvidenceQC.wham_vcfs": {{ test_batch.wham_vcfs | tojson }},
   "EvidenceQC.scramble_vcfs": {{ test_batch.scramble_vcf }},
   "EvidenceQC.samples": {{ test_batch.samples | tojson }}


### PR DESCRIPTION
Updates EvidenceQC templates with changes related to retiring MELT and incorporating Scramble. Specifically:

- [x] Drop the remaining melt-related config;
- [x] Add the missing Scramble-related configuration.