### PR TITLE
Template bug fix

### DIFF
--- a/inputs/templates/test/EvidenceQC/EvidenceQC.json.tmpl
+++ b/inputs/templates/test/EvidenceQC/EvidenceQC.json.tmpl
@@ -11,6 +11,6 @@
   "EvidenceQC.counts": {{ test_batch.counts | tojson }},
   "EvidenceQC.manta_vcfs": {{ test_batch.manta_vcfs | tojson }},
   "EvidenceQC.wham_vcfs": {{ test_batch.wham_vcfs | tojson }},
-  "EvidenceQC.scramble_vcfs": {{ test_batch.scramble_vcf }},
+  "EvidenceQC.scramble_vcfs": {{ test_batch.scramble_vcf | tojson }},
   "EvidenceQC.samples": {{ test_batch.samples | tojson }}
 }


### PR DESCRIPTION
This PR fixes the jinja2 compatibility of the JSON template broken in https://github.com/broadinstitute/gatk-sv/pull/763. 

