### PR TITLE
Reorder PED file columns in SampleQC notebook

### DIFF
--- a/scripts/notebooks/SampleQC.ipynb
+++ b/scripts/notebooks/SampleQC.ipynb
@@ -1402,9 +1402,9 @@
     "        reference_ped[\"Phenotype\"] = \"0\"\n",
     "    \n",
     "    # Assign sexes based on sex assignment dictionary\n",
-    "    computed_ped = reference_ped[['Sample_ID', 'Family_ID', 'Paternal_ID', 'Maternal_ID', 'Phenotype']]\n",
+    "    computed_ped = reference_ped[['Family_ID', 'Sample_ID', 'Paternal_ID', 'Maternal_ID', 'Phenotype']]\n",
     "    computed_ped['Sex'] = computed_ped['Sample_ID'].map(sex_assignments).map(SEX_CODES)\n",
-    "    computed_ped = computed_ped[['Sample_ID', 'Family_ID', 'Paternal_ID', 'Maternal_ID', 'Sex', 'Phenotype']]\n",
+    "    computed_ped = computed_ped[['Family_ID', 'Sample_ID', 'Paternal_ID', 'Maternal_ID', 'Sex', 'Phenotype']]\n",
     "    computed_ped = computed_ped[computed_ped['Sample_ID'].isin(sex_assignments.keys())]\n",
     "    \n",
     "    # Save dataframe\n",
@@ -2715,7 +2715,7 @@
     "file_path = generate_file_path(TLD_PATH, 'sex_analysis', 'sample_qc.ped')\n",
     "create_ped(updated_sex, reference_ped, file_path)\n",
     "\n",
-    "created_ped = pd.read_table(file_path, names=['Sample_ID', 'Family_ID', 'Paternal_ID', \n",
+    "created_ped = pd.read_table(file_path, names=['Family_ID', 'Sample_ID', 'Paternal_ID',\n",
     "                                               'Maternal_ID', 'Sex', 'Phenotype'])\n",
     "created_ped"
    ]


### PR DESCRIPTION
Bug fix to align PED file specifications per [the guidelines](https://gatk.broadinstitute.org/hc/en-us/articles/360035531972-PED-Pedigree-format).