### PR TITLE
Make functional annotation optional if no GTF/BED provided

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -195,7 +195,6 @@ workflows:
     filters:
       branches:
         - main
-        - eph_disable_func_anno
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -195,6 +195,7 @@ workflows:
     filters:
       branches:
         - main
+        - eph_disable_func_anno
       tags:
         - /.*/
 

--- a/wdl/AnnotateFunctionalConsequences.wdl
+++ b/wdl/AnnotateFunctionalConsequences.wdl
@@ -8,7 +8,7 @@ workflow AnnotateFunctionalConsequences {
     File? vcf_index
     String prefix
 
-    File protein_coding_gtf
+    File? protein_coding_gtf
     File? noncoding_bed
     Int? promoter_window
     Int? max_breakend_as_cnv_length
@@ -44,7 +44,7 @@ task SVAnnotate {
     File? vcf_index
     String prefix
 
-    File protein_coding_gtf
+    File? protein_coding_gtf
     File? noncoding_bed
     Int? promoter_window
     Int? max_breakend_as_cnv_length
@@ -85,7 +85,7 @@ task SVAnnotate {
     gatk --java-options "-Xmx~{java_mem_mb}m" SVAnnotate \
       -V ~{vcf} \
       -O ~{outfile} \
-      --protein-coding-gtf ~{protein_coding_gtf} \
+      ~{"--protein-coding-gtf " + protein_coding_gtf} \
       ~{"--non-coding-bed " + noncoding_bed} \
       ~{"--promoter-window-length " + promoter_window} \
       ~{"--max-breakend-as-cnv-length " + max_breakend_as_cnv_length} \

--- a/wdl/AnnotateVcf.wdl
+++ b/wdl/AnnotateVcf.wdl
@@ -12,7 +12,7 @@ workflow AnnotateVcf {
     File contig_list  # Ordered list of contigs to annotate that are present in the input VCF
     String prefix
 
-    File? protein_coding_gtf
+    File? protein_coding_gtf  # Provide at least one of protein_coding_gtf or noncoding_bed to perform functional annotation
     File? noncoding_bed
     Int? promoter_window
     Int? max_breakend_as_cnv_length

--- a/wdl/AnnotateVcf.wdl
+++ b/wdl/AnnotateVcf.wdl
@@ -12,7 +12,7 @@ workflow AnnotateVcf {
     File contig_list  # Ordered list of contigs to annotate that are present in the input VCF
     String prefix
 
-    File protein_coding_gtf
+    File? protein_coding_gtf
     File? noncoding_bed
     Int? promoter_window
     Int? max_breakend_as_cnv_length


### PR DESCRIPTION
### Updates
Toggle functional annotation in AnnotateVcf by not providing a GTF or noncoding BED file. I wanted this for some processing I was doing, and I think Harrison requested this ability as well. 

### Testing
* Validated all WDLs & JSONs with womtool and Terra validation script
* Tested AnnotateVcf with and without GTF and ran as expected

Changes to the dockstore.yml were for testing only and will be reverted before merging