### PR TITLE
Remove mention of variant filtering from GenerateBatchMetrics documentation

### DIFF
--- a/website/docs/execution/joint.md
+++ b/website/docs/execution/joint.md
@@ -66,7 +66,7 @@ algorithms (Manta, MELT, and Wham), read depth (RD), split read positions (SR), 
 6. `04-GatherBatchEvidence`: Per-batch copy number variant calling using cn.MOPS and GATK gCNV; B-allele frequency (BAF) 
 generation; call and evidence aggregation
 7. `05-ClusterBatch`: Per-batch variant clustering
-8. `06-GenerateBatchMetrics`: Per-batch variant filtering, metric generation
+8. `06-GenerateBatchMetrics`: Per-batch metric generation
 9. `07-FilterBatchSites`: Per-batch variant filtering and plot SV counts per sample per SV type to enable choice of IQR 
 cutoff for outlier filtration in `08-FilterBatchSamples`
 10. `08-FilterBatchSamples`: Per-batch outlier sample filtration

--- a/website/docs/modules/merge_batch_sites.md
+++ b/website/docs/modules/merge_batch_sites.md
@@ -59,7 +59,7 @@ section apply here.
 Array of filtered depth VCFs across batches generated in [FilterBatch](./fb#filtered_depth_vcf).
 
 #### `pesr_vcfs`
-Array of filtered depth VCFs across batches generated in [FilterBatch](./fb#filtered_pesr_vcf).
+Array of filtered PE/SR VCFs across batches generated in [FilterBatch](./fb#filtered_pesr_vcf).
 
 ### Outputs
 


### PR DESCRIPTION
Minor documentation update, as described by title.