### PR TITLE
Add VCF input option to Vapor WDL

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -199,6 +199,15 @@ workflows:
         - /.*/
 
   - subclass: WDL
+    name: Vapor
+    primaryDescriptorPath: /wdl/Vapor.wdl
+    filters:
+      branches:
+        - main
+      tags:
+        - /.*/
+
+  - subclass: WDL
     name: VisualizeCnvs
     primaryDescriptorPath: /wdl/VisualizeCnvs.wdl
     filters:

--- a/inputs/templates/test/Vapor/Vapor.json.tmpl
+++ b/inputs/templates/test/Vapor/Vapor.json.tmpl
@@ -8,7 +8,6 @@
     "Vapor.ref_dict": {{ reference_resources.reference_dict | tojson }},
     "Vapor.save_plots": "false",
 
-    "Vapor.prefix": {{ test_batch.example_pacbio_sample_id | tojson }},
     "Vapor.sample_id": {{ test_batch.example_pacbio_sample_id | tojson }},
     "Vapor.bam_or_cram_file": {{ test_batch.example_pacbio_cram | tojson }},
     "Vapor.bam_or_cram_index": {{ test_batch.example_pacbio_cram_index | tojson }},

--- a/src/sv-pipeline/scripts/preprocess_bed_for_vapor.py
+++ b/src/sv-pipeline/scripts/preprocess_bed_for_vapor.py
@@ -33,13 +33,13 @@ def handle_header(line, columns, fields, default_num_columns, sample_to_extract)
         for i, name in enumerate(fields[default_num_columns:]):
             columns[name] = default_num_columns + i
         if "SVLEN" not in columns:
-            logging.warning("SVLEN column not found. Will not be able to add SVLEN info to INS events")
+            raise ValueError("SVLEN column not found in header")
     else:
-        logging.warning("Header not found. Will not be able to add SVLEN info to INS events")
+        raise ValueError("Header not found. Header must exist and start with #")
         if len(fields) >= default_num_columns:
             columns['samples'] = default_num_columns  # if no header but extra fields, assume samples is next column
     if sample_to_extract is not None and "samples" not in columns:
-        logging.warning("Sample to extract provided but no samples column found")
+        raise ValueError("Sample to extract provided but no samples column found")
 
 
 def reformat(bed_in, bed_out, contig, sample_to_extract):

--- a/wdl/Vapor.wdl
+++ b/wdl/Vapor.wdl
@@ -49,6 +49,7 @@ workflow Vapor {
     call utils.VcfToBed {
       input:
         vcf_file = SubsetVcfToSample.vcf_subset,
+        args = "-i SVLEN",
         variant_interpretation_docker = sv_pipeline_docker,
         runtime_attr_override = runtime_attr_vcf_to_bed
     }

--- a/wdl/VaporBatch.wdl
+++ b/wdl/VaporBatch.wdl
@@ -21,9 +21,9 @@ workflow VaporBatch {
 
     Boolean save_plots
 
+    RuntimeAttr? runtime_attr_subset_sample
+    RuntimeAttr? runtime_attr_vcf_to_bed
     RuntimeAttr? runtime_attr_vapor
-    RuntimeAttr? runtime_attr_bcf2vcf
-    RuntimeAttr? runtime_attr_vcf2bed
     RuntimeAttr? runtime_attr_split_vcf
     RuntimeAttr? runtime_attr_concat_beds
   }
@@ -31,7 +31,6 @@ workflow VaporBatch {
   scatter (i in range(length(bam_or_cram_files))) {
     call vapor_bed.Vapor {
       input:
-        prefix = samples[i],
         bam_or_cram_file = bam_or_cram_files[i],
         bam_or_cram_index = bam_or_cram_indexes[i],
         bed_file = bed_file,
@@ -45,8 +44,8 @@ workflow VaporBatch {
         sv_base_mini_docker = sv_base_mini_docker,
         sv_pipeline_docker = sv_pipeline_docker,
         runtime_attr_vapor = runtime_attr_vapor,
-        runtime_attr_bcf2vcf = runtime_attr_bcf2vcf,
-        runtime_attr_vcf2bed = runtime_attr_vcf2bed,
+        runtime_attr_subset_sample = runtime_attr_subset_sample,
+        runtime_attr_vcf_to_bed = runtime_attr_vcf_to_bed,
         runtime_attr_split_vcf = runtime_attr_split_vcf,
         runtime_attr_concat_beds = runtime_attr_concat_beds
     }


### PR DESCRIPTION
- Enables VCF inputs in addition to BED in the Vapor workflow.
- Adds Vapor.wdl to Dockstore yaml.
- New utility method `SubsetVcfToSample` for subsetting to a single sample from a `String`. This is nearly identical to `SubsetVcfBySamplesList` which takes a samples list file instead.
- Deletes unnecessary `prefix` input since sample names usually suffice for file naming.

Tested successfully in Terra on 8 samples.