### PR TITLE
Add back MELT inputs to EvidenceQC Terra json

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/EvidenceQC.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/EvidenceQC.json.tmpl
@@ -9,8 +9,10 @@
 
   "EvidenceQC.batch": "${this.sample_set_id}",
   "EvidenceQC.counts": "${this.samples.coverage_counts}",
+  "EvidenceQC.melt_insert_size": "${this.samples.melt_insert_size}",
   "EvidenceQC.manta_vcfs": "${this.samples.manta_vcf}",
   "EvidenceQC.wham_vcfs": "${this.samples.wham_vcf}",
   "EvidenceQC.scramble_vcfs": "${this.samples.scramble_vcf}",
+  "EvidenceQC.melt_vcfs": "${this.samples.melt_vcf}",
   "EvidenceQC.samples": "${this.samples.sample_id}"
 }


### PR DESCRIPTION
Updates:
This PR reverts a change from #763. The Terra JSONs are meant to be configured such that switching out raw callers requires editing inputs for GatherSampleEvidence only. All other workflows should look for any caller-specific inputs that are present, and if an input is empty, the workflows are designed to ignore it. This PR adds back MELT-specific inputs to the Terra EvidenceQC JSON template so that if users do configure MELT, those inputs will not be ignored during EvidenceQC.

Testing:
* Validated EvidenceQC Terra JSON with Terra validation script
* Tested EvidenceQC with updated input parameters in a workspace with no MELT files and it ran and produced output as expected