### PR TITLE
Fix bug in ClusterBatch when SR2POS not present

### DIFF
--- a/src/sv-pipeline/scripts/format_gatk_vcf_for_svtk.py
+++ b/src/sv-pipeline/scripts/format_gatk_vcf_for_svtk.py
@@ -153,7 +153,7 @@ def convert(record: pysam.VariantRecord,
         new_record.info['STRANDS'] = '+-'
         # END information is lost when setting POS=END, so we need to set it to SR2POS if it's available
         # Note that the END position is only important following SR breakpoint refinement in FilterBatch
-        if record.info.get('SR2POS') is not None:
+        if record.info.get('SR2POS', None) is not None:
             new_record.stop = record.info['SR2POS']
     elif svtype == 'BND' or svtype == 'CTX':
         new_record.stop = record.info['END2']

--- a/src/sv-pipeline/scripts/format_gatk_vcf_for_svtk.py
+++ b/src/sv-pipeline/scripts/format_gatk_vcf_for_svtk.py
@@ -153,7 +153,7 @@ def convert(record: pysam.VariantRecord,
         new_record.info['STRANDS'] = '+-'
         # END information is lost when setting POS=END, so we need to set it to SR2POS if it's available
         # Note that the END position is only important following SR breakpoint refinement in FilterBatch
-        if record.info.get('SR2POS', None) is not None:
+        if 'SR2POS' in record.info:
             new_record.stop = record.info['SR2POS']
     elif svtype == 'BND' or svtype == 'CTX':
         new_record.stop = record.info['END2']

--- a/src/sv-pipeline/scripts/format_gatk_vcf_for_svtk.py
+++ b/src/sv-pipeline/scripts/format_gatk_vcf_for_svtk.py
@@ -153,7 +153,7 @@ def convert(record: pysam.VariantRecord,
         new_record.info['STRANDS'] = '+-'
         # END information is lost when setting POS=END, so we need to set it to SR2POS if it's available
         # Note that the END position is only important following SR breakpoint refinement in FilterBatch
-        if 'SR2POS' in record.info:
+        if 'SR2POS' in record.info and record.info['SR2POS'] is not None:
             new_record.stop = record.info['SR2POS']
     elif svtype == 'BND' or svtype == 'CTX':
         new_record.stop = record.info['END2']


### PR DESCRIPTION
With the latest version, ClusterBatch failed during GatkToSvtkVcf due to SR2POS being missing. This PR updates the check to one that does not fail if SR2POS is not in the header. Tested on a clone of the joint-calling workspace with an updated docker and the same inputs that failed before.