### PR TITLE
Patch incomplete logic in complex reformatting script

### DIFF
--- a/src/sv-pipeline/scripts/reformat_CPX_bed_and_generate_script.py
+++ b/src/sv-pipeline/scripts/reformat_CPX_bed_and_generate_script.py
@@ -196,7 +196,7 @@ def extract_bp_list_v4(coordinates, segments, small_sv_size_threshold):
             structures = ['abc', 'c^bc']
         else:
             structures = ['ab', 'b^ab']
-    elif del_bp[1] > dup_bp[1]:
+    elif del_bp[1] >= dup_bp[1]:
         breakpoints = [del_bp[0]] + dup_bp + del_bp[1:]
         if del_bp[2] - del_bp[1] > small_sv_size_threshold:
             structures = ['abc', 'aba^']


### PR DESCRIPTION
There is a logical statement in `extract_bp_list_v4()` within `reformat_CPX_bed_and_generate_script.py` that does not completely cover all possible cases.

I encountered this bug during processing of a ~60k WGS callset with GATK-SV v1.0.1. This error occurred exactly once across all 24 chromosomes, so I surmise it is a pretty rare edge case.

Relevant variant information as follows:
Candidate complex insertion SV
BED coordinates: `chr5:94362620-94362621`
SOURCE field: `INV_chr5:94362525-94362620`

To me, this appears to be either a small (91bp) inversion represented/resolved oddly by GATK-SV, or is some kind of small inverted insertion that happens to be inserted at the same position as the right breakpoint of the inverted source segment.

Either way, this exposes a gap in the logic on lines 193-199 of `reformat_CPX_bed_and_generate_script.py`, which compares coordinates of the source and sink by looking for strictly greater than or less than inequalities, which does not cover this case where the position of the right breakpoint of the SOURCE interval is equal to the left breakpoint of the sink.

I have patched this logic by converting the final logical `elif` statement within `extract_bp_list_v4()` to use a greater than or equal to inequality, which covers this case.