### PR TITLE
Fix coordinates issues for complex SV refinement

### DIFF
--- a/src/sv-pipeline/scripts/reformat_CPX_bed_and_generate_script.py
+++ b/src/sv-pipeline/scripts/reformat_CPX_bed_and_generate_script.py
@@ -190,7 +190,7 @@ def extract_bp_list_v4(coordinates, segments, small_sv_size_threshold):
     dup_bp = [int(i) for i in dup_seg[1].split('-')]
     structures = []
     breakpoints = []
-    if del_bp[2] < dup_bp[0]:
+    if del_bp[2] <= dup_bp[0]:
         breakpoints = del_bp + dup_bp
         if del_bp[2] - del_bp[1] > small_sv_size_threshold:
             structures = ['abc', 'c^bc']

--- a/wdl/RefineComplexVariants.wdl
+++ b/wdl/RefineComplexVariants.wdl
@@ -497,8 +497,10 @@ task GenerateCpxReviewScript {
 
         cut -f1,3 ~{sample_batch_pe_map} > sample_PE_metrics.tsv
 
+        awk -F'\t' '/^#/{print; next} {$2++; print}' OFS='\t' '~{bed}' > 'shifted.tsv'
+
         python ~{default="/opt/sv-pipeline/scripts/reformat_CPX_bed_and_generate_script.py" script} \
-        -i ~{bed} \
+        -i 'shifted.tsv' \
         -s sample_PE_metrics.tsv \
         -p CPX_CTX_disINS.PASS.PE_evidences \
         -c collect_PE_evidences.CPX_CTX_disINS.PASS.sh \

--- a/wdl/RefineComplexVariants.wdl
+++ b/wdl/RefineComplexVariants.wdl
@@ -499,7 +499,7 @@ task GenerateCpxReviewScript {
 
         bgzip -cd '~{bed}' \
           | awk -F'\t' '/^#/{print; next} {$2++; print}' OFS='\t' - \
-          | bgzip -c - > shifted.bed.gz
+          | bgzip -c > shifted.bed.gz
 
         python ~{default="/opt/sv-pipeline/scripts/reformat_CPX_bed_and_generate_script.py" script} \
         -i shifted.bed.gz \

--- a/wdl/RefineComplexVariants.wdl
+++ b/wdl/RefineComplexVariants.wdl
@@ -497,10 +497,12 @@ task GenerateCpxReviewScript {
 
         cut -f1,3 ~{sample_batch_pe_map} > sample_PE_metrics.tsv
 
-        awk -F'\t' '/^#/{print; next} {$2++; print}' OFS='\t' '~{bed}' > 'shifted.tsv'
+        bgzip -cd '~{bed}' \
+          | awk -F'\t' '/^#/{print; next} {$2++; print}' OFS='\t' - \
+          | bgzip -c - > shifted.bed.gz
 
         python ~{default="/opt/sv-pipeline/scripts/reformat_CPX_bed_and_generate_script.py" script} \
-        -i 'shifted.tsv' \
+        -i shifted.bed.gz \
         -s sample_PE_metrics.tsv \
         -p CPX_CTX_disINS.PASS.PE_evidences \
         -c collect_PE_evidences.CPX_CTX_disINS.PASS.sh \


### PR DESCRIPTION
1. The input BED file to the CPX BED reformatting script has 0-based, half-closed variant coordinates while the SOURCE coordinates are 1-based, fully-closed. However, the reformatting script assumes the coordinate systems are the same. The first fix adds a step to adjust the variant coordinates in the BED file to be 1-based, fully-closed prior to executing the reformatting script.
2. The reformatting script does not handle the case where the origin of the inserted fragment shares a breakpoint with the insertion point. The second fix adds an equality check to the conditional comparing breakpoints.