### PR TITLE
Update the OS version of the Action runners

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build_args_job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Determine Build Args
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -109,7 +109,7 @@ jobs:
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   build_job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Test Images Build
     if: github.event_name == 'pull_request'
     needs: build_args_job
@@ -143,7 +143,7 @@ jobs:
     # credentials. Finally, it rebuilds the docker images (targets are
     # determined by the `build_args_job`) and pushes them to GCR.
     name: Publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: Deploy
     if: github.event_name == 'push'
     needs: build_args_job

--- a/.github/workflows/testwdls.yaml
+++ b/.github/workflows/testwdls.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   syntax_test_job:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Check WDL Syntax
     strategy:
       matrix:


### PR DESCRIPTION
We're currently using `ubuntu-20.04` in some of the actions (the rest are set to always use the latest version), which is set for deprecation in April 2025. 

This PR updates the pinned version to the current latest, 24.04. 