### PR TITLE
Add the de novo pipeline to Dockstore 

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -224,3 +224,12 @@ workflows:
         - main
       tags:
         - /.*/
+
+  - subclass: WDL
+    name: CallDeNovoSV
+    primaryDescriptorPath: /wdl/RunDeNovoSVs.wdl
+    filters:
+      branches:
+        - main
+      tags:
+        - /.*/


### PR DESCRIPTION
The PR updates Dockstore integration so the _de novo_ pipeline's workflows are auto-synched. 