### PR TITLE
Create the Docker daemon config file if missing 

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -224,3 +224,12 @@ workflows:
         - main
       tags:
         - /.*/
+
+  - subclass: WDL
+    name: CallDeNovoSV
+    primaryDescriptorPath: /wdl/RunDeNovoSVs.wdl
+    filters:
+      branches:
+        - main
+      tags:
+        - /.*/

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -194,11 +194,17 @@ jobs:
         #
         # The build_docker.py uses the `--squash` flag when building the
         # images to be pushed to GCR. This flag is only available when
-        # experimental features are enabled, hence the features are enabled
-        # in this flag.
+        # experimental features are enabled, hence are enabled in this section.
+        #
+        # The /etc/docker/daemon.json is not created by default during 
+        # Docker installation; however, upstream configurations may 
+        # create and use this file for their configuration depending 
+        # on their versions. Hence, we create the file if it does not 
+        # exist in order to preserve compatibility.
         run: |
           gcloud auth configure-docker
           tmp=$(mktemp)
+          sudo touch /etc/docker/daemon.json
           sudo jq '.+{experimental:true}' /etc/docker/daemon.json > "$tmp"
           sudo mv "$tmp" /etc/docker/daemon.json
           sudo systemctl restart docker.service


### PR DESCRIPTION
The `/etc/docker/daemon.json` is not created/populated before enabling experimental features, which is charged after updating the base image of the runners to the current latest Ubuntu version in https://github.com/broadinstitute/gatk-sv/pull/781. This PR fixes the issue by creating the file if it does not already exist. 