### PR TITLE
Fix IdentifyDuplicates to resolve NoneType mismatches

### DIFF
--- a/src/sv-pipeline/scripts/identify_duplicates.py
+++ b/src/sv-pipeline/scripts/identify_duplicates.py
@@ -44,11 +44,11 @@ def process_duplicates(vcf, fout):
                 record.stop,
                 record.info.get('SVTYPE'),
                 record.info.get('SVLEN'),
-                record.info.get('CHR2') or "",
-                record.info.get('END2') or 0,
-                record.info.get('STRANDS') or "",
-                record.info.get('CPX_TYPE') or "",
-                record.info.get('CPX_INTERVALS') or ""
+                record.info.get('CHR2', ""),
+                record.info.get('END2', 0),
+                record.info.get('STRANDS', ""),
+                record.info.get('CPX_TYPE', ""),
+                record.info.get('CPX_INTERVALS', "")
             )
             exact_buffer.append((exact_key, record.id))
 

--- a/src/sv-pipeline/scripts/identify_duplicates.py
+++ b/src/sv-pipeline/scripts/identify_duplicates.py
@@ -69,7 +69,7 @@ def process_duplicates(vcf, fout):
 
 
 def process_buffers(exact_buffer, ins_buffer, counts, f_records):
-    # Process exact matches    
+    # Process exact matches
     sorted_buffer = sorted(exact_buffer, key=lambda x: x[0])
     exact_matches = {
         key: [record for _, record in group] for key, group in groupby(sorted_buffer, key=lambda x: x[0])

--- a/src/sv-pipeline/scripts/identify_duplicates.py
+++ b/src/sv-pipeline/scripts/identify_duplicates.py
@@ -44,11 +44,11 @@ def process_duplicates(vcf, fout):
                 record.stop,
                 record.info.get('SVTYPE'),
                 record.info.get('SVLEN'),
-                record.info.get('CHR2'),
-                record.info.get('END2'),
-                record.info.get('STRANDS'),
-                record.info.get('CPX_TYPE'),
-                record.info.get('CPX_INTERVALS')
+                record.info.get('CHR2') or "",
+                record.info.get('END2') or 0,
+                record.info.get('STRANDS') or "",
+                record.info.get('CPX_TYPE') or "",
+                record.info.get('CPX_INTERVALS') or ""
             )
             exact_buffer.append((exact_key, record.id))
 
@@ -69,7 +69,7 @@ def process_duplicates(vcf, fout):
 
 
 def process_buffers(exact_buffer, ins_buffer, counts, f_records):
-    # Process exact matches
+    # Process exact matches    
     sorted_buffer = sorted(exact_buffer, key=lambda x: x[0])
     exact_matches = {
         key: [record for _, record in group] for key, group in groupby(sorted_buffer, key=lambda x: x[0])


### PR DESCRIPTION
### Description
The `IdentifyDuplicates` task looks for a match across several INFO fields in order to determine exact or insert matches. However, these INFO fields may not exist for certain records, and hence are represented as `None` in the tuple that stores them. At a certain point, we sort these tuples.

​As highlighted in [Python documentation](https://docs.python.org/3/howto/sorting.html), when sorting a list of tuples, if there is a match on the search index within each tuple, the subsequent elements in the tuples are compared to define the sort order. This means that Python starts by comparing the first element of each tuple; if they are equal, it moves to the second element, and so on, until it finds elements that differ or reaches the end of the tuples. ​

Hence, if we reach an element in our sort process for which the INFO field exists in one record but not another, we get the following error: `TypeError: '<' not supported between instances of 'str' and 'NoneType'`. This PR is intended to avoid this by setting defaults for all INFO fields that may not exist in a record.

### Testing
- [This Terra job](https://app.terra.bio/#workspaces/Talkowski_training/kj-issue-701-1kgp/job_history/7133655a-7ce8-4463-9117-0fd4fec666fc) includes a failed run that does not include this change.
- [This Terra job](https://app.terra.bio/#workspaces/Dragen_SV_testing/DRAGEN-SV-Benchmarking-Talkowski/submission_history/e0acafd3-ff90-4db2-b3bc-ace78b4d47dd) includes a successful run that does include this change.