### PR TITLE
Update Docker build CI/CD action 

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -224,3 +224,12 @@ workflows:
         - main
       tags:
         - /.*/
+
+  - subclass: WDL
+    name: CallDeNovoSV
+    primaryDescriptorPath: /wdl/RunDeNovoSVs.wdl
+    filters:
+      branches:
+        - main
+      tags:
+        - /.*/

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -30,7 +30,7 @@ jobs:
       image_tag: ${{ steps.image_tag.outputs.IMAGE_TAG }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # By default, this checks out only the current commit;
           # however, since a diff between the current commit and
@@ -118,13 +118,13 @@ jobs:
         python-version: ['3.8']
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # See the comment on build_args_job.
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -155,7 +155,7 @@ jobs:
       DOCKERS_GCP: "./inputs/values/dockers.json"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # See the comment on build_args_job.
           fetch-depth: 0
@@ -163,22 +163,26 @@ jobs:
           token: ${{ secrets.BOT_PAT }}
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Azure login
-        uses: azure/docker-login@v1
+        uses: azure/docker-login@v2
         with:
           login-server: ${{ secrets.AZ_CR }}
           username: ${{ secrets.AZ_USERNAME }}
           password: ${{ secrets.AZ_PASSWORD }}
 
+      - name: GCP login
+        uses: google-github-actions/auth@v2.0.0
+        with:
+          credentials_json: '${{ secrets.GCP_SA_CREDENTIALS }}'
+
       - name: Setup gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.3.0
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_GCR_SA_KEY }}
           # xref: https://github.com/google-github-actions/setup-gcloud#inputs
           # If you need to set `export_default_credentials: true`
           # make sure to pass the `--disable-git-protect` flag to


### PR DESCRIPTION
This PR is a follow-up from https://github.com/broadinstitute/gatk-sv/pull/781 and https://github.com/broadinstitute/gatk-sv/pull/785 where the OS version of the runners was updated to the current latest version of Ubuntu, and it updates the actions to their current latest version to account for their interface update. 

 Specifically: 
- [x] Update actions to their current version since the old versions did not work properly on the latest Ubuntu;
- [x] GCP login is updated to match the current method. Note that we're using the long-lived tokens method instead of the implicit flow (the recommended approach) for two reasons: (1) The tokens generated in the recommended approach are valid for 15min only, and since the GATK-SV's Docker build can take longer than 15min, the tokens are expired when pushing images; and (2) The recommended flow's GCP/IAM configuration has conflicts with the current setting of the GCP project GATK-SV uses. 
- [x] All the credentials are updated to match the requirements of the set versions of the actions. 