### PR TITLE
Patch for INS with sink inside inverted SOURCE in RefineComplexVariants

### DIFF
--- a/src/sv-pipeline/scripts/reformat_CPX_bed_and_generate_script.py
+++ b/src/sv-pipeline/scripts/reformat_CPX_bed_and_generate_script.py
@@ -202,6 +202,8 @@ def extract_bp_list_v4(coordinates, segments, small_sv_size_threshold):
             structures = ['abc', 'aba^']
         else:
             structures = ['ab', 'aba^']
+    else:
+        return 'unresolved'
     return [breakpoints, structures]
 
 
@@ -274,6 +276,9 @@ def cpx_sv_readin(input_bed, header_pos, unresolved):
                 else:
                     segments = pin[header_pos['SOURCE']].split(',')
                     cpx_info = extract_bp_list_v4(pin[:3], segments, small_sv_size_threshold)
+                    if cpx_info == 'unresolved':
+                        unresolved_svids.append(pin[header_pos['name']])
+                        continue
                     ref_alt = cpx_info[1]
                     breakpoints = cpx_info[0]
                 out.append([breakpoints, ref_alt, pin[3]])


### PR DESCRIPTION
### Updates
This PR addresses an error that occurred for an insertion variant for which the sink coordinates were inside the SOURCE, which was inverted. Insertions with inverted SOURCE are handled by RefineComplexVariants, and the script did not account for the case that the sink was located inside the source. dDUP SVs where the sink is inside the source are currently marked as UNRESOLVED, so this update will match that behavior for insertions with inverted source. These SVs were observed to be low-quality in AoU which is why they were marked UNRESOLVED. Going forward we should update the script to collect and evaluate PE evidence for both cases, but this patch allows the workflow to complete successfully and with consistent behavior in the meantime.

### Testing
Tested locally on one shard containing one of the variants in question, and the output was as expected. Tested in Terra on the same cohort with the rebuilt docker and the workflow succeeded (where it had previously failed). 