### PR TITLE
Use `communicate()` with Python subprocess

### DIFF
--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -672,10 +672,10 @@ def get_command_output(
     Execute shell command. Raise exception if unsuccessful, otherwise return string with output
     """
     sub_p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-    with sub_p.stdout as pipe_in, sub_p.stderr as pipe_err:
-        output = pipe_in.read().decode(encoding)
-        stderr = pipe_err.read().decode(encoding)
-    return_code = sub_p.poll()
+    byte_stdout, byte_stderr = sub_p.communicate()
+    output = byte_stdout.decode(encoding)
+    stderr = byte_stderr.decode(encoding)
+    return_code = sub_p.returncode
     if raise_on_error and return_code != 0:
         raise RuntimeError("Error executing %s:\n%s" % (command, stderr[:-1]))
     return (output, stderr, return_code) if return_error_info else output


### PR DESCRIPTION
Using `poll()` on a Popen object will return `None` if the child process has not terminated and that can cause trouble with the `get_command_output()` function in the Docker building script. The function assumes that `poll()` always returns the exit code of the child process and compares it to 0 to check if the child process executed successfully. If the child process has not terminated by the time `poll()` is called, then the comparison will always be false and the child process will appear to have failed. `communicate()` will wait until the child process terminates if a timeout is not given.

An error from using `poll()` was observed with Python 3.12.3