### PR TITLE
Scale down GQ in CombineBatches

### DIFF
--- a/wdl/CleanVcfChromosome.wdl
+++ b/wdl/CleanVcfChromosome.wdl
@@ -323,7 +323,6 @@ workflow CleanVcfChromosome {
     input:
       vcf=FinalCleanup.final_cleaned_shard,
       ploidy_table=ploidy_table,
-      args="--scale-down-gq",
       output_prefix="~{prefix}.final_format",
       script=svtk_to_gatk_script,
       sv_pipeline_docker=sv_pipeline_docker,

--- a/wdl/CombineBatches.wdl
+++ b/wdl/CombineBatches.wdl
@@ -112,7 +112,7 @@ workflow CombineBatches {
       input:
         vcf=reformatted_vcf,
         ploidy_table=CreatePloidyTableFromPed.out,
-        args="--fix-end --add-sr-pos",
+        args="--fix-end --add-sr-pos --scale-down-gq",
         output_prefix=basename(vcf, ".vcf.gz") + ".reformat_gatk",
         bothside_pass_list=CombineSRBothsidePass.out,
         background_fail_list=CombineBackgroundFail.outfile,

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -26,7 +26,7 @@ workflow MainVcfQc {
     Array[Array[String]]? sample_level_comparison_datasets  # Array of two-element arrays, one per dataset, each of format [prefix, gs:// path to per-sample tarballs]
     File primary_contigs_fai
     Int? random_seed
-    Int? max_gq  # Max GQ for plotting. Default = 99, ie. GQ is on a scale of [0,99]. Prior to CleanVcf, use 999
+    Int? max_gq  # Max GQ for plotting. Default = 99, ie. GQ is on a scale of [0,99]. Prior to CombineBatches, use 999
     Int? downsample_qc_per_sample  # Number of samples to use for per-sample QC. Default: 1000
 
     String sv_base_mini_docker

--- a/wdl/MakeCohortVcf.wdl
+++ b/wdl/MakeCohortVcf.wdl
@@ -71,7 +71,7 @@ workflow MakeCohortVcf {
 
     File? outlier_samples_list
     Int? random_seed
-    Int? max_gq  # Max GQ for plotting. Default = 99, ie. GQ is on a scale of [0,99]. Prior to CleanVcf, use 999
+    Int? max_gq  # Max GQ for plotting. Default = 99, ie. GQ is on a scale of [0,99]. Prior to CombineBatches, use 999
 
     Array[Array[String]]? site_level_comparison_datasets    # Array of two-element arrays, one per dataset, each of format [prefix, gs:// path to directory with one BED per population]
     Array[Array[String]]? sample_level_comparison_datasets  # Array of two-element arrays, one per dataset, each of format [prefix, gs:// path to per-sample tarballs]

--- a/website/docs/modules/main_vcf_qc.md
+++ b/website/docs/modules/main_vcf_qc.md
@@ -214,7 +214,7 @@ section for available benchmarking call sets.
 Default: `0`. Random seed for sample subsetting in external call set comparisons.
 
 #### <HighlightOptionalArg>Optional</HighlightOptionalArg> `max_gq`
-Default: `99`. Max value to define range for `GQ` plotting. For modules prior to `CleanVcf`, use `999`.
+Default: `99`. Max value to define range for `GQ` plotting. For modules prior to `CombineBatches`, use `999`.
 
 #### <HighlightOptionalArg>Optional</HighlightOptionalArg> `downsample_qc_per_sample`
 Default: `1000`. Number of samples to subset to for per-sample QC.


### PR DESCRIPTION
Addresses a bug introduced in #732 where all genotype qualities (GQ) were clipped at 99 in `CombineBatches` (and subsequently to 9 in `CleanVcf`). Note that GQ is recalibrated during `FilterGenotypes`, so final GQs had appeared normal. However, in a test run we found that the clipping had modest effect on recalibration scores for most variant types (see attached figures).

To resolve the clipping, this PR moves GQ rescaling from `CleanVcf` to a formatting step preceding `gatk SVCluster` in `CombineBatches`.

![Screenshot 2025-04-10 at 10 49 45 AM](https://github.com/user-attachments/assets/137e9f29-47b5-4f6d-9397-72f5972342b2)
