### PR TITLE
CPU configuration workaround for RealignSoftClippedReads

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -6,7 +6,6 @@ workflows:
     filters:
       branches:
         - main
-        - kj_darwin_svexpression
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -6,6 +6,7 @@ workflows:
     filters:
       branches:
         - main
+        - kj_darwin_svexpression
       tags:
         - /.*/
 

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -550,6 +550,7 @@ task RealignSoftClippedReads {
                                max_retries: 1
                              }
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+  
   String disk_type = if use_ssd then "SSD" else "HDD"
 
   output {

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -541,7 +541,7 @@ task RealignSoftClippedReads {
     RuntimeAttr? runtime_attr_override
   }
 
-  RuntimeAttr default_attr = object {
+  RuntimeAttr runtime_default = object {
                                cpu_cores: 4,
                                mem_gb: 20,
                                disk_gb: ceil(10 + size(reads_path, "GB") * 2 + size([reference_bwa_bwt, reference_bwa_pac, reference_bwa_sa], "GB")),
@@ -549,9 +549,18 @@ task RealignSoftClippedReads {
                                preemptible_tries: 3,
                                max_retries: 1
                              }
-  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
-  
+  RuntimeAttr runtime_override = select_first([runtime_attr_override, runtime_default])
   String disk_type = if use_ssd then "SSD" else "HDD"
+
+  runtime {
+    memory: "~{select_first([runtime_override.mem_gb, default_attr.mem_gb])} GiB"
+    disks: "local-disk ~{select_first([runtime_override.disk_gb, default_attr.disk_gb])} ~{disk_type}"
+    cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
+    preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
+    maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
+    docker: sv_base_mini_docker
+    bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
+  }
 
   output {
     File out = "~{sample_id}.realign_soft_clipped_reads.bam"
@@ -586,13 +595,4 @@ task RealignSoftClippedReads {
       | samtools view -1 -h -O BAM -o ~{sample_id}.realign_soft_clipped_reads.bam
     samtools index -@${N_CORES} ~{sample_id}.realign_soft_clipped_reads.bam
   >>>
-  runtime {
-    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
-    memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
-    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " " + disk_type
-    bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
-    docker: sv_base_mini_docker
-    preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
-    maxRetries: select_first([runtime_attr.max_retries, default_attr.max_retries])
-  }
 }

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -550,7 +550,6 @@ task RealignSoftClippedReads {
                                max_retries: 1
                              }
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
-  Int n_cpu = select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
   String disk_type = if use_ssd then "SSD" else "HDD"
 
   output {
@@ -587,7 +586,7 @@ task RealignSoftClippedReads {
     samtools index -@${N_CORES} ~{sample_id}.realign_soft_clipped_reads.bam
   >>>
   runtime {
-    cpu: n_cpu
+    cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
     disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " " + disk_type
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])

--- a/wdl/GatherSampleEvidence.wdl
+++ b/wdl/GatherSampleEvidence.wdl
@@ -553,8 +553,8 @@ task RealignSoftClippedReads {
   String disk_type = if use_ssd then "SSD" else "HDD"
 
   runtime {
-    memory: "~{select_first([runtime_override.mem_gb, default_attr.mem_gb])} GiB"
-    disks: "local-disk ~{select_first([runtime_override.disk_gb, default_attr.disk_gb])} ~{disk_type}"
+    memory: "~{select_first([runtime_override.mem_gb, runtime_default.mem_gb])} GiB"
+    disks: "local-disk ~{select_first([runtime_override.disk_gb, runtime_default.disk_gb])} ~{disk_type}"
     cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
     preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
     maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])


### PR DESCRIPTION
### Description
The _GatherSampleEvidence_ task appears to fail in the _RealignSoftClippedReads_ task, which is run on CRAMs that were aligned with DRAGEN v3.7.8. It triggers the following error message:
> `Failed to evaluate input 'n_cpu' (reason 1 of 2): No value found for member access lookup. Report this bug: Insufficient input values supplied by engine. Needed 'runtime_attr' or 'runtime_attr.cpu_cores' but only received: 'reads_path, reference_bwa_sa, runtime_attr_override, disk_type, reference_bwa_alt, scramble_table, sv_base_mini_docker, reference_bwa_ann, is_bam, reference_bwa_pac, reference_index, reference_bwa_bwt, sample_id, reference_fasta, reference_bwa_amb, use_ssd, reads_index'`


While the error appears to be caused by Terra, this PR represents a change that seems to circumvent the error.

### Testing
- [This Terra job](https://app.terra.bio/#workspaces/cpg-terra/tenk10k-sv/submission_history/817bf85a-c574-46cf-809f-33560d37a1af) highlights a failed run that uses the original _GatherSampleEvidence_ WDL.
- [This Terra job](https://app.terra.bio/#workspaces/cpg-terra/tenk10k-sv/submission_history/9b234ccd-d7c6-49c0-b751-329867b61d30) includes a successful run that uses the modified _GatherSampleEvidence_ WDL.