### PR TITLE
Enable non-existent INFO/EVIDENCE fields in input VCF for breakpoint overlap filtering in ResolveComplexVariants

### DIFF
--- a/src/sv-pipeline/04_variant_resolution/scripts/overlap_breakpoint_filter.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/overlap_breakpoint_filter.py
@@ -86,7 +86,7 @@ bnds_to_ids = defaultdict(list)
 for record in vcf:
     # Filter depth-only CNVs
     # Note that in some cases CNVs are incorrectly missing an SR evidence annotation but usually have PE at least
-    if ('SR' not in record.info['EVIDENCE'] and 'PE' not in record.info['EVIDENCE']) \
+    if ('SR' not in record.info.get('EVIDENCE', '') and 'PE' not in record.info.get('EVIDENCE', '')) \
             and (record.info['SVTYPE'] == 'DEL' or record.info['SVTYPE'] == 'DUP') \
             and record.info['SVLEN'] >= 5000:
         continue


### PR DESCRIPTION
### Description
The _13-ResolveComplexVariants_ task appears to fail in the _ BreakpointOverlap_ task if the _INFO/EVIDENCE_ is not populated, which is a possible scenario for certain VCFs and cohorts. In such an event, it triggers the following error message:
> `Failed to evaluate input 'n_cpu' (reason 1 of 2): No value found for member access lookup. Report this bug: Insufficient input values supplied by engine. Needed 'runtime_attr' or 'runtime_attr.cpu_cores' but only received: 'reads_path, reference_bwa_sa, runtime_attr_override, disk_type, reference_bwa_alt, scramble_table, sv_base_mini_docker, reference_bwa_ann, is_bam, reference_bwa_pac, reference_index, reference_bwa_bwt, sample_id, reference_fasta, reference_bwa_amb, use_ssd, reads_index'`

### Testing
- [This Terra job](https://app.terra.bio/#workspaces/SBD_WGS/CrossDev-WGS-SV-filtering/submission_history/4c5b5798-2c7b-4beb-84b5-c15149bfc22d) highlights a failing run that uses the original _ResolveComplexVariants_ on a VCF that lacks an _INFO/EVIDENCE_ field in line 210.
- [This Terra job](TODO) highlights a successful run that uses the updated docker for _ResolveComplexVariants_ on a VCF that lacks an _INFO/EVIDENCE_ field for each of its first 10 variants.