### PR TITLE
Update website regarding GATK forum

### DIFF
--- a/website/docs/troubleshooting/support.md
+++ b/website/docs/troubleshooting/support.md
@@ -6,5 +6,5 @@ sidebar_position: 1
 
 For guidance troubleshooting error messages, please review our [FAQ](./faq). 
 
-If you still cannot resolve your issue, reach out to our support team on the 
+If you still cannot resolve your issue, we recommend consulting the 
 [GATK forums](https://gatk.broadinstitute.org/hc/en-us/community/topics).


### PR DESCRIPTION
Given the switch to a community-driven/moderated GATK forum, this PR updates our website to remove the reference to "our support team" but continue to direct users to the forum for community support.