### PR TITLE
Ignore sites with null GTs during de novo rate calculation

### DIFF
--- a/wdl/CollectQcPerSample.wdl
+++ b/wdl/CollectQcPerSample.wdl
@@ -102,14 +102,14 @@ task CollectVidsPerSample {
       | bcftools view -i 'SVTYPE=="CNV" || AC>0' \
       | bcftools query -f '[%SAMPLE\t%ID\t%ALT\t%GT\t%GQ\t%CN\t%CNQ\n]' \
       | awk '{OFS="\t"; gt = $4; gq = $5; if ($3 == "<CNV>") { gq = $7; if ($6 == 2) { gt = "0/0" } else if ($6 == 1 || $6 == 3) { gt = "0/1" } else { gt = "1/1"} }; print $1, $2, gt, gq}' \
-      | awk -v outprefix="~{outdirprefix}" '$3 != "0/0" && $3 != "./." {OFS="\t"; print $2, $3, $4 >> outprefix"/"$1".VIDs_genotypes.txt" }'
+      | awk -v outprefix="~{outdirprefix}" '$3 != "0/0" {OFS="\t"; print $2, $3, $4 >> outprefix"/"$1".VIDs_genotypes.txt" }'
     else
       bcftools view -S ~{samples_list} ~{vcf} \
       | bcftools +fill-tags -- -t AC \
       | bcftools view -i 'SVTYPE=="CNV" || AC>0' \
       | bcftools query -f '[%SAMPLE\t%ID\t%ALT\t%GT\t%GQ\n]' \
       | awk '{OFS="\t"; gt = $4; gq = $5; if ($3 ~ /CN0/) { if ($4 == "0/2") { gt = "0/0" } else if ($4 == "0/1" || $4 == "0/3") { gt = "0/1" } else { gt = "1/1"} }; print $1, $2, gt, gq}' \
-      | awk -v outprefix="~{outdirprefix}" '$3 != "0/0" && $3 != "./." {OFS="\t"; print $2, $3, $4 >> outprefix"/"$1".VIDs_genotypes.txt" }'
+      | awk -v outprefix="~{outdirprefix}" '$3 != "0/0" {OFS="\t"; print $2, $3, $4 >> outprefix"/"$1".VIDs_genotypes.txt" }'
     fi
 
     # Gzip all output lists

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -518,7 +518,7 @@ task PlotQcPerSample {
       --directory tmp_untar/
     find tmp_untar/ -name "*.VIDs_genotypes.txt.gz" | while read FILE; do
       bname=$(basename $FILE)
-      zcat $FILE | awk '$3 != "./."' | gzip -f > ~{prefix}_perSample/$bname
+      zcat $FILE | awk '$2 != "./."' | gzip -f > ~{prefix}_perSample/$bname
       rm $FILE
     done
 

--- a/wdl/MainVcfQc.wdl
+++ b/wdl/MainVcfQc.wdl
@@ -512,12 +512,14 @@ task PlotQcPerSample {
     # Make per-sample directory
     mkdir ~{prefix}_perSample/
 
-    # Untar per-sample VID lists
+    # Untar per-sample VID lists and exclude null genotypes
     mkdir tmp_untar/
     tar -xvzf ~{per_sample_tarball} \
       --directory tmp_untar/
     find tmp_untar/ -name "*.VIDs_genotypes.txt.gz" | while read FILE; do
-      mv $FILE ~{prefix}_perSample/
+      bname=$(basename $FILE)
+      zcat $FILE | awk '$3 != "./."' | gzip -f > ~{prefix}_perSample/$bname
+      rm $FILE
     done
 
     # Plot per-sample distributions


### PR DESCRIPTION
### Updates

The intention of analyze_fams.R is to exclude sites for which any member of the trio has a null genotype ([line 120](https://github.com/broadinstitute/gatk-sv/blob/ab512d42d08af365194987fcc9b3d953a1dd8e93/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R#L120)). However, CollectVidsPerSample excludes null genotypes from each sample's carrier VID list ([line 105](https://github.com/broadinstitute/gatk-sv/blob/dc968ef03a98a894913ecdc5500faeb814dc9604/wdl/CollectQcPerSample.wdl#L105)). Those genotypes therefore appear as NA for that sample in analyze_fams.R when merged with another trio member who is a carrier, and they are treated thereafter as hom ref ([line 133](https://github.com/broadinstitute/gatk-sv/blob/ab512d42d08af365194987fcc9b3d953a1dd8e93/src/sv-pipeline/scripts/vcf_qc/analyze_fams.R#L133)). This is not the intention of the script, and creates ambiguity in the de novo rate, as there is no claim made about the genotype when it is null. 

This PR retains the VIDs with null genotypes for each sample so those sites can be discarded for the entire trio as intended during the de novo rate calculation. The null genotypes are removed prior to per-sample QC to maintain the previous behavior. The impact of null genotypes on the de novo rate should be examined further and reported as described in #807.


### Testing
* Validated all WDLs and JSONs with womtool and Terra validation script
* Successfully ran MainVcfQc.wdl on the hgdp data (which contains trios)
  * Verified that ./. genotypes were retained in VID lists and locally tested their removal during per-sample QC
  * The de novo rate decreases slightly compared to the version on main (13.8% from 15.8%) owing to the dropped sites. 
  * The SVs per genome were identical when examining the same subset of samples.
  * The cost and runtime were comparable despite the increase in intermediate data
 