### PR TITLE
AnnotateVcf should take filtered vcf as input

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/AnnotateVcf.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/AnnotateVcf.json.tmpl
@@ -1,5 +1,5 @@
 {
-  "AnnotateVcf.vcf" : "${this.cleaned_vcf}",
+  "AnnotateVcf.vcf" : "${this.filtered_vcf}",
 
   "AnnotateVcf.protein_coding_gtf" : "${workspace.protein_coding_gtf}",
   "AnnotateVcf.noncoding_bed" : "${workspace.noncoding_bed}",

--- a/inputs/templates/test/AnnotateVcf/AnnotateVcf.json.tmpl
+++ b/inputs/templates/test/AnnotateVcf/AnnotateVcf.json.tmpl
@@ -1,5 +1,5 @@
 {
-  "AnnotateVcf.vcf": {{ test_batch.clean_vcf | tojson }},
+  "AnnotateVcf.vcf": {{ test_batch.genotype_filtered_vcf | tojson }},
 
   "AnnotateVcf.protein_coding_gtf" : {{ reference_resources.protein_coding_gtf | tojson }},
   "AnnotateVcf.noncoding_bed" :       {{ reference_resources.noncoding_bed | tojson }},


### PR DESCRIPTION
### Updates
As reported in #808, AnnotateVcf was configured to take in the cleaned VCF rather than the filtered VCF. This PR updates the input templates to perform annotation on the filtered VCF. The GATK-SV featured and internal Terra workspaces have already been updated with this change, so this PR is just to ensure that future updates retain this configuration.

### Testing
* Validated all WDLs and JSONs with womtool and Terra validation script
* Checked generated JSONs for correctness
* Checked inputs for the rest of the post-CleanVcf workflows