### PR TITLE
Patch streaming crams error on Google Batch

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -6,7 +6,6 @@ workflows:
     filters:
       branches:
         - main
-        - patch-streaming
       tags:
         - /.*/
 


### PR DESCRIPTION
Google Batch sets an env variable that interferes with `gcloud` resolving a path to python installed gatk-sv docker images. This results in the following error in `Whamg`: 

```
[batch_task_logs] ... Failed to open file "gs://HG00096.final.cram" : Operation not permitted
[batch_task_logs] ... samtools view: failed to open "gs://HG00096.final.cram" for reading: Operation not permitted
```

This error was reported previously at https://github.com/broadinstitute/gatk-sv/issues/798. 

The patch this PR implements is suggested by the cromwell team and we [successfully tested](https://app.terra.bio/#workspaces/gnomad-v3-sv/GATK-Structural-Variants-Joint-Calling-vj-test-streaming/submission_history/d07d8626-ae58-4d7a-9720-616bc7df11c3) the patched task on Terra.
