### PR TITLE
fix no EVIDENCE bug in stitch_fragmented_CNVs.sh

### DIFF
--- a/src/sv-pipeline/04_variant_resolution/scripts/stitch_fragmented_CNVs.sh
+++ b/src/sv-pipeline/04_variant_resolution/scripts/stitch_fragmented_CNVs.sh
@@ -96,10 +96,8 @@ zcat ${INVCF} \
   | grep -e 'SVTYPE=DEL\|SVTYPE=DUP' \
   | fgrep -v "MULTIALLELIC" \
   | awk -v OFS="\t" '{ print $3, $8 }' \
-  | sed 's/EVIDENCE=/\t/g' \
-  | cut -f1,3 \
   | sed 's/\;/\t/g' \
-  | awk -v check=${CHECK_EVIDENCE} '{ if (check=="true" && ($2~"RD" || $2~"BAF") && $2!~"PE" && $2!~"SR") print $1 }' \
+  | cut -f1 \
   | fgrep -wf - <( zcat ${INVCF} ) \
   | cat <( zcat ${INVCF} | fgrep "#" ) - \
   | vcf-sort \


### PR DESCRIPTION
The input VCF lacks the "EVIDENCE" field in the INFO column. As a result, during the step "Subset VCF to biallelic CNVs without PE or SR support", the script will produce an empty biallelic_depth_CNVs.vcf.gz file containing no variants. This step does not raise an error or halt execution, so the pipeline continues; however, no stitched VCF is generated. Therefore, the script's output will be identical to the input.