### PR TITLE
Update shell flags for consistency.

### DIFF
--- a/wdl/MakeBincovMatrix.wdl
+++ b/wdl/MakeBincovMatrix.wdl
@@ -96,21 +96,12 @@ task SetBins {
   command <<<
     set -Eeuo pipefail
 
-    # make the CollectReadCounts output consistent with the old bincov code
-    # determine what format this is
-    firstchar=$(head -c 1 <(gunzip -c "${count_file}"))
-    if [ $firstchar == '@' ]; then
-      shift=1  # GATK CollectReadCounts (to convert from 1-based closed intervals)
-    else
-      shift=0  # bincov sample or matrix
-    fi
-
     # kill the dictionary | kill the header | adjust to bed format: 0-based half-open intervals
     zcat ~{count_file} \
       | sed '/^@/d' \
       | sed '/^CONTIG	START	END	COUNT$/d' \
       | sed '/^#/d' \
-      | awk -v x="${shift}" 'BEGIN{OFS="\t"}{$2=$2-x; print $1,$2,$3}' > tmp_locs
+      | awk -v x="1" 'BEGIN{OFS="\t"}{$2=$2-x; print $1,$2,$3}' > tmp_locs
 
     # determine bin size, and drop all bins not exactly equal to this size
     if ~{defined(binsize)}; then
@@ -180,14 +171,7 @@ task MakeBincovMatrixColumns {
   }
 
   command <<<
-    set -Eeu
-    firstchar=$(gunzip -c "~{count_file}" | head -c 1)
-    set -o pipefail
-    if [ $firstchar == '@' ]; then
-      shift=1
-    else
-      shift=0
-    fi
+    set -Eeuo pipefail
 
     TMP_BED="$(basename "~{count_file}").tmp.bed"
     printf "#Chr\tStart\tEnd\t%s\n" "~{sample}" > $TMP_BED
@@ -195,7 +179,7 @@ task MakeBincovMatrixColumns {
       | sed '/^@/d' \
       | sed '/^CONTIG	START	END	COUNT$/d' \
       | sed '/^#/d' \
-      | awk -v x=$shift -v b=~{binsize} \
+      | awk -v x=1 -v b=~{binsize} \
         'BEGIN{OFS="\t"}{$2=$2-x; if ($3-$2==b) print $0}' \
       >> "$TMP_BED"
 

--- a/wdl/MakeBincovMatrix.wdl
+++ b/wdl/MakeBincovMatrix.wdl
@@ -94,12 +94,11 @@ task SetBins {
   }
 
   command <<<
-    set -Eeu
+    set -Eeuo pipefail
 
     # make the CollectReadCounts output consistent with the old bincov code
     # determine what format this is
-    firstchar=$(gunzip -c ~{count_file} | head -c 1)
-    set -o pipefail
+    firstchar=$(head -c 1 <(gunzip -c "${count_file}"))
     if [ $firstchar == '@' ]; then
       shift=1  # GATK CollectReadCounts (to convert from 1-based closed intervals)
     else


### PR DESCRIPTION
```
firstchar=$(gunzip -c ~{count_file} | head -c 1)
```

Running above results in exiting the shell if `set -Eeuo pipefail` is set (see [this](https://unix.stackexchange.com/a/452015) for details); hence, we have split the configuration of shell flags in the current implementation. While the current implementation works, it is inconsistent with other scripts and a source of confusion (as we experienced rewriting these scripts for "sv-box").  

Since we currently only use the GATK-style count files, this PR simplifies these tasks by removing the check of the count files' syntax by reading the first character, and hardcodes the GATK-style requirement. 

Successfully tested on [EvidenceQc](https://app.terra.bio/#workspaces/gnomad-v3-sv/GATK-Structural-Variants-Joint-Calling-test-bincov/submission_history/ca39ef21-c4a8-4b7a-8a5c-99ae33791958), the workflow ran successfully, and the generated file for `bincov_matrix` is identical to the file in the featured workspace: 

```bash
% sha256 new_all_samples.RD.txt 
SHA256 (new_all_samples.RD.txt) = 98edf991c0b9f07da8c77989c19ab51303d5385352fb0ccee1b1f81efc89d3ad

% sha256 old_all_samples.RD.txt 
SHA256 (old_all_samples.RD.txt) = 98edf991c0b9f07da8c77989c19ab51303d5385352fb0ccee1b1f81efc89d3ad
```