### PR TITLE
Fix BND header description

### DIFF
--- a/src/svtk/svtk/data/GRCh37_template.vcf
+++ b/src/svtk/svtk/data/GRCh37_template.vcf
@@ -2,7 +2,7 @@
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DUP,Description="Duplication">
 ##ALT=<ID=INV,Description="Inversion">
-##ALT=<ID=BND,Description="Translocation">
+##ALT=<ID=BND,Description="Breakend">
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome for END coordinate">

--- a/src/svtk/svtk/data/no_contigs_template.vcf
+++ b/src/svtk/svtk/data/no_contigs_template.vcf
@@ -2,7 +2,7 @@
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DUP,Description="Duplication">
 ##ALT=<ID=INV,Description="Inversion">
-##ALT=<ID=BND,Description="Translocation">
+##ALT=<ID=BND,Description="Breakend">
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome for END coordinate">

--- a/src/svtk/svtk/data/vcfcluster_template.vcf
+++ b/src/svtk/svtk/data/vcfcluster_template.vcf
@@ -2,7 +2,7 @@
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DUP,Description="Duplication">
 ##ALT=<ID=INV,Description="Inversion">
-##ALT=<ID=BND,Description="Translocation">
+##ALT=<ID=BND,Description="Breakend">
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome for END coordinate">


### PR DESCRIPTION
### Updates
Modified the VCF header templates to define BND alleles as breakends rather than translocations. Note that SanitizeHeader currently performs this edit posthoc in FilterGenotypes, but this PR fixes it at the source. For now, I've left the substitution in SanitizeHeader as well in case of processing legacy VCFs, but in the future we should be able to remove that step.

### Testing
* Validated all WDLs and JSONs with womtool and Terra validation script.
* Tested GatherBatchEvidence with an updated docker image and verified that the header was fixed in one of the standardized manta VCFs. This change is aesthetic and should not have any downstream impacts.