### PR TITLE
Zip regeno coverage medians file

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -96,6 +96,7 @@ workflows:
     filters:
       branches:
         - main
+        - eph_zip_regeno_cov_med
       tags:
         - /.*/
 
@@ -105,6 +106,7 @@ workflows:
     filters:
       branches:
         - main
+        - eph_zip_regeno_cov_med
       tags:
         - /.*/
 

--- a/wdl/GenotypeDepthPart2.wdl
+++ b/wdl/GenotypeDepthPart2.wdl
@@ -228,7 +228,7 @@ task MergeRegenoCoverageMedians {
     File regeno_coverage_medians = "~{batch}.regeno.coverage_medians_merged.bed"
   }
   command <<<
-    cat ~{sep=' ' regeno_coverage_medians_array} | fgrep -v $'chr\tstart\tend\tcnvID' > ~{batch}.regeno.coverage_medians_merged.bed
+    cat ~{sep=' ' regeno_coverage_medians_array} | fgrep -v $'chr\tstart\tend\tcnvID' | bgzip -c > ~{batch}.regeno.coverage_medians_merged.bed.gz
   >>>
 
   runtime {

--- a/wdl/GenotypeDepthPart2.wdl
+++ b/wdl/GenotypeDepthPart2.wdl
@@ -225,7 +225,7 @@ task MergeRegenoCoverageMedians {
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 
   output {
-    File regeno_coverage_medians = "~{batch}.regeno.coverage_medians_merged.bed"
+    File regeno_coverage_medians = "~{batch}.regeno.coverage_medians_merged.bed.gz"
   }
   command <<<
     cat ~{sep=' ' regeno_coverage_medians_array} | fgrep -v $'chr\tstart\tend\tcnvID' | bgzip -c > ~{batch}.regeno.coverage_medians_merged.bed.gz

--- a/wdl/RegenotypeCNVs.wdl
+++ b/wdl/RegenotypeCNVs.wdl
@@ -620,7 +620,19 @@ task GetMedianSubset {
     python3 <<CODE
 
     from statistics import median
-    with open("~{medians}", 'r') as inp, open("~{batch}_to_regeno.bed", 'w') as outp:
+
+
+    # Flexibly open .gz or uncompressed file to read
+    # Expect bgzipped BED file but should be able to handle legacy uncompressed files
+    # Output file is smaller and deleted as a workflow intermediate so can be uncompressed
+    def _open(filename):
+      if filename.endswith(".gz"):
+        return gzip.open(filename, 'rt')
+      else:
+        return open(filename, 'r')
+
+
+    with _open("~{medians}", 'r') as inp, open("~{batch}_to_regeno.bed", 'w') as outp:
       for line in inp:
         fields = line.strip().split('\t')
         # first 4 fields are variant info (chr, start, end, varID)

--- a/wdl/RegenotypeCNVs.wdl
+++ b/wdl/RegenotypeCNVs.wdl
@@ -620,7 +620,7 @@ task GetMedianSubset {
     python3 <<CODE
 
     from statistics import median
-
+    import gzip
 
     # Flexibly open .gz or uncompressed file to read
     # Expect bgzipped BED file but should be able to handle legacy uncompressed files

--- a/wdl/RegenotypeCNVs.wdl
+++ b/wdl/RegenotypeCNVs.wdl
@@ -632,7 +632,7 @@ task GetMedianSubset {
         return open(filename, 'r')
 
 
-    with _open("~{medians}", 'r') as inp, open("~{batch}_to_regeno.bed", 'w') as outp:
+    with _open("~{medians}") as inp, open("~{batch}_to_regeno.bed", 'w') as outp:
       for line in inp:
         fields = line.strip().split('\t')
         # first 4 fields are variant info (chr, start, end, varID)


### PR DESCRIPTION
### Updates

Compress the regeno_coverage_medians file. This file is an output of GenotypeBatch, so it is retained as a workflow output. It can get quite large (~3 GB per batch for AoU) so it makes sense to compress it to reduce storage. Compatibility with uncompressed files was maintained for RegenotypeCNVs in case of legacy inputs.

### Testing

* Ran GenotypeBatch and RegenotypeCNVs successfully
* Validated all WDLs and JSONs

Before merging, I will need to revert changes to the dockstore.yml.