### PR TITLE
Remove sorting from SVConcordance to align with the updated GATK tool

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -168,6 +168,7 @@ workflows:
     filters:
       branches:
         - main
+        - kj_svconcordance_update_v2
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -168,7 +168,6 @@ workflows:
     filters:
       branches:
         - main
-        - kj_svconcordance_update_v2
       tags:
         - /.*/
 

--- a/wdl/SVConcordance.wdl
+++ b/wdl/SVConcordance.wdl
@@ -120,7 +120,6 @@ task SVConcordanceTask {
       --eval ~{eval_vcf} \
       --truth ~{truth_vcf} \
       -O ~{output_prefix}.vcf.gz \
-      --do-not-sort \
       ~{additional_args}
   >>>
   runtime {

--- a/wdl/SVConcordance.wdl
+++ b/wdl/SVConcordance.wdl
@@ -27,7 +27,7 @@ workflow SVConcordance {
       input:
         eval_vcf=eval_vcf,
         truth_vcf=truth_vcf,
-        output_prefix="~{output_prefix}.concordance.~{contig}.unsorted",
+        output_prefix="~{output_prefix}.concordance.~{contig}",
         contig=contig,
         reference_dict=reference_dict,
         java_mem_fraction=java_mem_fraction,

--- a/wdl/SVConcordance.wdl
+++ b/wdl/SVConcordance.wdl
@@ -19,7 +19,6 @@ workflow SVConcordance {
     Float? java_mem_fraction
 
     RuntimeAttr? runtime_attr_sv_concordance
-    RuntimeAttr? runtime_attr_sort_vcf
     RuntimeAttr? runtime_override_concat_shards
   }
 
@@ -35,20 +34,12 @@ workflow SVConcordance {
         gatk_docker=gatk_docker,
         runtime_attr_override=runtime_attr_sv_concordance
     }
-
-    call tasks_cohort.SortVcf {
-      input:
-        vcf=SVConcordanceTask.out_unsorted,
-        outfile_prefix="~{output_prefix}.concordance.~{contig}.sorted",
-        sv_base_mini_docker=sv_base_mini_docker,
-        runtime_attr_override=runtime_attr_sort_vcf
-    }
   }
 
   call tasks_cohort.ConcatVcfs {
     input:
-      vcfs=SortVcf.out,
-      vcfs_idx=SortVcf.out_index,
+      vcfs=SVConcordanceTask.out,
+      vcfs_idx=SVConcordanceTask.out_index,
       naive=true,
       outfile_prefix="~{output_prefix}.concordance",
       sv_base_mini_docker=sv_base_mini_docker,
@@ -95,7 +86,8 @@ task SVConcordanceTask {
   RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 
   output {
-    File out_unsorted = "~{output_prefix}.vcf.gz"
+    File out = "~{output_prefix}.vcf.gz"
+    File out_index = "~{output_prefix}.vcf.gz.tbi"
   }
   command <<<
     set -euo pipefail

--- a/wdl/SVConcordance.wdl
+++ b/wdl/SVConcordance.wdl
@@ -113,7 +113,6 @@ task SVConcordanceTask {
     JVM_MAX_MEM=$(getJavaMem MemTotal)
     echo "JVM memory: $JVM_MAX_MEM"
 
-    # As of 12/15/2023, the gatk docker contains an outdated version of bcftools so we sort in a subsequent task
     gatk --java-options "-Xmx${JVM_MAX_MEM}" SVConcordance \
       ~{"-L " + contig} \
       --sequence-dictionary ~{reference_dict} \

--- a/wdl/SVConcordancePacBioSample.wdl
+++ b/wdl/SVConcordancePacBioSample.wdl
@@ -64,7 +64,7 @@ workflow SVConcordancePacBioSample {
     }
     call tasks_cohort.SortVcf {
       input:
-        vcf=SVConcordanceTask.out_unsorted,
+        vcf=SVConcordanceTask.out,
         outfile_prefix="~{prefix}.concordance.~{tool_names[i]}.~{sample_id}.sorted",
         sv_base_mini_docker=sv_base_mini_docker,
         runtime_attr_override=runtime_attr_sort_vcf


### PR DESCRIPTION
### Description
This PR is intended to update the `SVConcordance` workflow to better align with the version of the tool pointed to by the updated GATK docker in the featured workspace by removing the sorting option, which is now reprecated (as well as a related comment).

This is a critical fix as using the updated GATK docker in the featured workspace without this change leads to the following error:
`A USER ERROR has occurred: do-not-sort is not a recognized option.`

### Testing
- The [following job](https://app.terra.bio/#workspaces/prenatal-wgs/FGC_Wapner_Talkowski_FirstSeq_WGS/workflows/prenatal-wgs/18-SVConcordance) highlights a run of the WDL prior to this change that results in a failure.
- The [following job](https://app.terra.bio/#workspaces/broad-firecloud-dsde-methods/kj-svconcordance-update/submission_history/6a5e416d-4689-43eb-8d56-e8a8672f751e) highlights a run of the WDL following this change that succeeds.
- Validated all WDLs with `womtool`.

### Pre-Merge Changes Required
Remove automated sync of the `SVConcordance` WDL to Dockstore.