### PR TITLE
[Do Not Merge] Updates all BND-agnostic references of Pysam's .stop across GATK-SV

### DIFF
--- a/src/WGD/bin/convert_gcnv.py
+++ b/src/WGD/bin/convert_gcnv.py
@@ -15,8 +15,9 @@ DEFAULT_CUTOFF = 30
 
 
 def write_bed_entry(file, record, score, type, sample):
+    end = record.info.get('END2') if record.info.get('SVTYPE') == 'BND' else record.stop
     bed_entries = (record.chrom, str(record.start), str(
-        record.stop), str(score), sample, type, 'gcnv')
+        end), str(score), sample, type, 'gcnv')
     file.write('\t'.join(bed_entries) + '\n')
 
 # Writes record in bed format if it is a del or dup of sufficient quality

--- a/src/sv-pipeline/03_variant_filtering/scripts/rewrite_SR_coords.py
+++ b/src/sv-pipeline/03_variant_filtering/scripts/rewrite_SR_coords.py
@@ -29,6 +29,10 @@ def rewrite_SR_coords(record, metrics, pval_cutoff, bg_cutoff):
                 record.info['STRANDS'] = '+-'
         elif record.info['SVTYPE'] == 'INV':
             record.pos, record.stop = sorted([posA, posB])
+        elif record.info['SVTYPE'] == 'BND':
+            record.pos = posA
+            record.info['END2'] = posB
+            record.stop = posA
         else:
             record.pos = posA
             record.stop = posB

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b_filter.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b_filter.py
@@ -45,7 +45,8 @@ def modify_variants(dict_file_gz, vcf, multi_cnvs):
                         o.update({"GT": (0, 1)})
                         o.update({"GQ": o.get("RD_GQ")})
 
-                if variant.stop - variant.start >= 1000:
+                end = variant.info.get('END2') if variant.info.get('SVTYPE') == 'BND' else variant.stop
+                if end - variant.start >= 1000:
                     if variant.info[SVTYPE] in [SVType.DEL, SVType.DUP]:
                         is_del = variant.info[SVTYPE] == SVType.DEL
                         for k, v in variant.samples.items():

--- a/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part5_update_records.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part5_update_records.py
@@ -91,20 +91,23 @@ def main():
                     print("processed {} records".format(idx), file=sys.stderr)
                 if record.id in revised_lines_by_id:
                     record = revised_lines_by_id[record.id]
+                
+                end = record.info.get('END2') if record.info.get('SVTYPE') == 'BND' else record.stop
+                
                 if record.info.get('SVTYPE', None) == 'DEL':
-                    if abs(record.stop - record.pos) >= 1000:
+                    if abs(end - record.pos) >= 1000:
                         sample_cn_map = {s: record.samples[s].get('RD_CN') for s in non_outlier_samples}
                         if len([s for s in sample_cn_map if (sample_cn_map[s] is not None and sample_cn_map[s] > 3)]) > vf_1:
                             multi_del = True
                     gts = [record.samples[s].get('GT') for s in non_outlier_samples]
                     if any(gt not in biallelic_gts for gt in gts):
                         gt5kb_del = True
-                    if abs(record.stop - record.pos) >= 5000 or '<CN0>' in record.alts:
+                    if abs(end - record.pos) >= 5000 or '<CN0>' in record.alts:
                         if not multi_del:
                             gt5kb_del = True
 
                 if record.info.get('SVTYPE', None) == 'DUP':
-                    if abs(record.stop - record.pos) >= 1000:
+                    if abs(end - record.pos) >= 1000:
                         sample_cn_map = {s: record.samples[s].get('RD_CN') for s in non_outlier_samples}
                         if sum(1 for s in sample_cn_map if sample_cn_map[s] is not None and sample_cn_map[s] > 4) > vf_1:
                             multi_dup = True
@@ -116,7 +119,7 @@ def main():
                     gts = [record.samples[s].get('GT') for s in non_outlier_samples]
                     if any(gt not in biallelic_gts for gt in gts):
                         gt5kb_dup = True
-                    if abs(record.stop - record.pos) >= 5000 or '<CN0>' in record.alts:
+                    if abs(end - record.pos) >= 5000 or '<CN0>' in record.alts:
                         if not multi_dup:
                             gt5kb_dup = True
 

--- a/src/sv-pipeline/04_variant_resolution/scripts/merge_linked_depth_calls.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/merge_linked_depth_calls.py
@@ -106,12 +106,20 @@ def merge_linked_depth_calls(vcf, ID_links):
 
         # Take maximal region
         start = np.min([record.pos for record in cluster])
-        end = np.max([record.stop for record in cluster])
+        end = np.max([record.info.get('END2') if record.info.get('SVTYPE') == 'BND' else record.stop for record in cluster])
 
         merged_record = cluster[0].copy()
         merged_record.pos = start
-        merged_record.stop = end
-        merged_record.info['SVLEN'] = merged_record.stop - merged_record.pos
+        if merged_record.info['SVTYPE'] == 'BND':
+            merged_record.info['END2'] = end
+            merged_record.stop = merged_record.pos + 1
+        else:
+            merged_record.stop = end
+
+        if merged_record.chrom == merged_record.info.get('CHR2', merged_record.chrom):
+            merged_record.info['SVLEN'] = end - start
+        else:
+            merged_record.info['SVLEN'] = -1
 
         svu.update_best_genotypes(merged_record, cluster,
                                   preserve_multiallelic=True)

--- a/src/sv-pipeline/04_variant_resolution/scripts/merge_pesr_depth.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/merge_pesr_depth.py
@@ -68,7 +68,9 @@ def merge_pesr_depth(vcf, fout, prefix, frac, sample_overlap, min_depth_only_siz
         return len(alg) == 1 and alg[0] == 'depth'
 
     def _reciprocal_overlap(record_a, record_b):
-        return svu.recip(record_a.pos, record_a.stop, record_b.pos, record_b.stop, frac=frac)
+        end_a = record_a.info.get('END2') if record_a.info.get('SVTYPE') == 'BND' else record_a.stop
+        end_b = record_b.info.get('END2') if record_b.info.get('SVTYPE') == 'BND' else record_b.stop
+        return svu.recip(record_a.pos, end_a, record_b.pos, end_b, frac=frac)
 
     def _cache_sample_overlap(record, force=False):
         if force or record.id not in sample_overlap_cache:

--- a/src/sv-pipeline/04_variant_resolution/scripts/merge_vcfs.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/merge_vcfs.py
@@ -17,9 +17,11 @@ def records_match(record, other):
     Test if two records are same SV: check chromosome, position, stop, SVTYPE, SVLEN (for insertions),
     STRANDS (for BNDS and INVs), and (if they exist) CHR2/END2 for multi-chromosomal events
     """
+    end1 = record.info.get('END2') if record.info.get('SVTYPE') == 'BND' else record.stop
+    end2 = other.info.get('END2') if other.info.get('SVTYPE') == 'BND' else other.stop
     return (record.chrom == other.chrom and
             record.pos == other.pos and
-            record.stop == other.stop and
+            end1 == end2 and
             record.info['SVTYPE'] == other.info['SVTYPE'] and
             record.info['SVLEN'] == other.info['SVLEN'] and
             record.info['STRANDS'] == other.info['STRANDS'] and
@@ -33,8 +35,8 @@ def merge_key(record):
     so that all identical records according to records_match will be adjacent
     """
     chr2 = record.info['CHR2'] if 'CHR2' in record.info else None
-    end2 = record.info['END2'] if 'END2' in record.info else None
-    return (record.pos, record.stop, record.info['SVTYPE'], record.info['SVLEN'], chr2, end2, record.info['STRANDS'], record.id)
+    end = record.info.get('END2') if record.info.get('SVTYPE') == 'BND' else record.stop
+    return (record.pos, end, record.info['SVTYPE'], record.info['SVLEN'], chr2, record.info.get('END2'), record.info['STRANDS'], record.id)
 
 
 def dedup_records(records):

--- a/src/sv-pipeline/04_variant_resolution/scripts/overlap_breakpoint_filter.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/overlap_breakpoint_filter.py
@@ -92,7 +92,8 @@ for record in vcf:
         continue
     strands = record.info['STRANDS']
     bnd1 = "{}_{}_{}".format(record.chrom, record.pos, strands[0])
-    bnd2 = "{}_{}_{}".format(record.info['CHR2'], record.stop, strands[1])
+    end = record.info.get('END2') if record.info.get('SVTYPE') == 'BND' else record.stop
+    bnd2 = "{}_{}_{}".format(record.info['CHR2'], end, strands[1])
     bnds_to_ids[bnd1].append(record.id)
     bnds_to_ids[bnd2].append(record.id)
 

--- a/src/sv-pipeline/04_variant_resolution/scripts/postCPX_cleanup.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/postCPX_cleanup.py
@@ -93,7 +93,7 @@ def cleanup(vcf, fout):
 
             # Correct alt syntax
             record.alts = ('<BND>', )
-            record.stop = record.start + 1
+            record.stop = record.pos + 1
 
             # All BNDs are unresolved by definition
             record.info['UNRESOLVED'] = True

--- a/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py
@@ -117,7 +117,8 @@ class VcfRecord:
         # TODO despite implementing the same strategy as svtk vcf2bed, small differences in some CPX intervals
         #  may occur because pysam forces stop to be max(pos, end)
         self.sink_chrom = variant_record.chrom
-        start, end = sorted([variant_record.pos, end_dict.get(self.vid, variant_record.stop)])
+        end = variant_record.info.get('END2') if variant_record.info.get('SVTYPE') == 'BND' else variant_record.stop
+        start, end = sorted([variant_record.pos, end_dict.get(self.vid, end)])
         self.sink_start = max(0, start - 1)
         if variant_record.info.get("UNRESOLVED_TYPE", "").startswith("INVERSION_SINGLE_ENDER"):
             self.sink_end = variant_record.info.get("END2", variant_record.stop)

--- a/src/sv-pipeline/05_annotation/scripts/compute_AFs.py
+++ b/src/sv-pipeline/05_annotation/scripts/compute_AFs.py
@@ -34,7 +34,8 @@ def in_par(record, parbt):
     """
 
     # Sort start & end to handle edge cases and ensure end > start for pbt functionality
-    sstart, send = [str(x) for x in sorted([record.start, record.stop])]
+    end = record.info.get('END2') if record.info.get('SVTYPE') == 'BND' else record.stop
+    sstart, send = [str(x) for x in sorted([record.start, end])]
     svbt_str = '\t'.join([record.chrom, sstart, send]) + '\n'
     svbt = pbt.BedTool(svbt_str, from_string=True)
     if len(svbt.intersect(parbt)) > 0:

--- a/src/sv-pipeline/scripts/format_gatk_vcf_for_svtk.py
+++ b/src/sv-pipeline/scripts/format_gatk_vcf_for_svtk.py
@@ -148,6 +148,7 @@ def convert(record: pysam.VariantRecord,
     if chr2 is None:
         new_record.info['CHR2'] = contig
     # fix END, SVLEN, STRANDS
+    end = record.info.get('END2') if svtype == 'BND' else record.stop
     if svtype == 'INS':
         new_record.info['SVLEN'] = record.info.get('SVLEN', -1)
         new_record.info['STRANDS'] = '+-'
@@ -156,7 +157,8 @@ def convert(record: pysam.VariantRecord,
         if 'SR2POS' in record.info and record.info['SR2POS'] is not None:
             new_record.stop = record.info['SR2POS']
     elif svtype == 'BND' or svtype == 'CTX':
-        new_record.stop = record.info['END2']
+        new_record.info['END2'] = record.info['END2']
+        new_record.stop = new_record.pos + 1
         new_record.info['SVLEN'] = -1
     elif svtype == 'CPX':
         new_record.info['SVLEN'] = record.info.get('SVLEN', -1)

--- a/src/sv-pipeline/scripts/format_pb_for_gatk.py
+++ b/src/sv-pipeline/scripts/format_pb_for_gatk.py
@@ -135,8 +135,8 @@ def convert(record: pysam.VariantRecord,
         else:
             end = record.start + svlen
     else:
-        svlen = record.stop - record.pos
         end = record.stop
+        svlen = end - record.pos
     if svlen < min_size:
         return list()
     if end <= record.start:

--- a/src/sv-pipeline/scripts/identify_duplicates.py
+++ b/src/sv-pipeline/scripts/identify_duplicates.py
@@ -38,10 +38,11 @@ def process_duplicates(vcf, fout):
                 current_pos = record.pos
 
             # Update buffers with new record
+            end = record.info.get('END2') if record.info.get('SVTYPE') == 'BND' else record.stop
             exact_key = (
                 record.chrom,
                 record.pos,
-                record.stop,
+                end,
                 record.info.get('SVTYPE'),
                 record.info.get('SVLEN'),
                 record.info.get('CHR2', ""),

--- a/src/sv-pipeline/scripts/preprocess_gatk_for_pacbio_eval.py
+++ b/src/sv-pipeline/scripts/preprocess_gatk_for_pacbio_eval.py
@@ -30,13 +30,14 @@ def process(vcf: pysam.VariantFile) -> None:
         svtype = record.info['SVTYPE']
         if svtype not in allowed_svtypes:
             continue
-        svlen = record.info.get('SVLEN', record.stop - record.pos)
+        end = record.info.get('END2') if svtype == 'BND' else record.stop
+        svlen = record.info.get('SVLEN', end - record.pos)
         if svlen > 5000:
             continue
         if svtype != 'DUP':
             sys.stdout.write(str(record))
         else:
-            record.info['SVLEN'] = record.stop - record.pos
+            record.info['SVLEN'] = end - record.pos
             record.info['SVTYPE'] = 'INS'
             record.stop = record.pos + 1
             sys.stdout.write(str(record).replace("<DUP>", "<INS>"))

--- a/src/sv-pipeline/scripts/refine_training_set.py
+++ b/src/sv-pipeline/scripts/refine_training_set.py
@@ -46,7 +46,8 @@ def get_vids_and_bypass(vcf: pysam.VariantFile,
     for record in vcf:
         vids.add(record.id)
         svtype = record.info['SVTYPE']
-        svlen = record.info['SVLEN'] if 'SVLEN' in record.info else record.stop - record.pos
+        end = record.info.get('END2') if svtype == 'BND' else record.stop
+        svlen = record.info['SVLEN'] if 'SVLEN' in record.info else end - record.pos
         if svtype in cnv_types and svlen >= cnv_size_cutoff:
             large_cnv_vids.add(record.id)
         if svtype in ['INS', 'INV'] and svlen >= non_cnv_size_cutoff:

--- a/src/sv-pipeline/scripts/single_sample/update_variant_representations.py
+++ b/src/sv-pipeline/scripts/single_sample/update_variant_representations.py
@@ -80,7 +80,7 @@ def make_reciprocal_translocation_bnds(record, ref_fasta):
     if 'END2' in record.info.keys():
         chr2_pos1 = int(record.info['END2'])
     else:
-        chr2_pos1 = record.stop
+        chr2_pos1 = record.info.get('END2') if record.info.get('SVTYPE') == 'BND' else record.stop
     chr2_pos1_ref = get_ref_base(chr2, chr2_pos1, ref_fasta)
     chr2_pos2 = chr2_pos1 + 1
     chr2_pos2_ref = get_ref_base(chr2, chr2_pos2, ref_fasta)
@@ -137,7 +137,7 @@ def make_reciprocal_translocation_bnds(record, ref_fasta):
     m1.id = m1_id
     m1.contig = chr1
     m1.pos = m1_pos1
-    m1.stop = m1_pos1 + 1
+    m1.stop = m1.pos + 1
     m1.ref = m1_ref
     m1.alts = (svu.make_bnd_alt(chr2, m1_pos2, strands_m1, ref_base=m1.ref), )
     m1.info['MATEID'] = m2_id
@@ -146,7 +146,7 @@ def make_reciprocal_translocation_bnds(record, ref_fasta):
     m2.id = m2_id
     m2.contig = chr2
     m2.pos = m2_pos1
-    m2.stop = m2_pos1 + 1
+    m2.stop = m2.pos + 1
     m2.ref = m2_ref
     m2.alts = (svu.make_bnd_alt(chr1, m2_pos2, strands_m2, ref_base=m2.ref), )
     m2.info['MATEID'] = m2_id
@@ -155,7 +155,7 @@ def make_reciprocal_translocation_bnds(record, ref_fasta):
     m3.id = m3_id
     m3.contig = chr1
     m3.pos = m3_pos1
-    m3.stop = m3_pos1 + 1
+    m3.stop = m3.pos + 1
     m3.ref = m3_ref
     m3.alts = (svu.make_bnd_alt(chr2, m3_pos2, strands_m3, ref_base=m3.ref), )
     m3.info['MATEID'] = m4_id
@@ -164,7 +164,7 @@ def make_reciprocal_translocation_bnds(record, ref_fasta):
     m4.id = m4_id
     m4.contig = chr2
     m4.pos = m4_pos1
-    m4.stop = m4_pos1 + 1
+    m4.stop = m4.pos + 1
     m4.ref = m4_ref
     m4.alts = (svu.make_bnd_alt(chr1, m4_pos2, strands_m4, ref_base=m4.ref), )
     m4.info['MATEID'] = m3_id

--- a/src/svtk/svtk/cli/resolve.py
+++ b/src/svtk/svtk/cli/resolve.py
@@ -106,13 +106,14 @@ def _cluster_INV_list(independent_INV):
     out = []
     rec = float('-inf')  # be sure to add first element
     for i in independent_INV:
+        end = i.info.get('END2') if i.info.get('SVTYPE') == 'BND' else i.stop
         if i.pos > rec:
             out.append([i])
-            rec = i.stop
+            rec = end
         else:
             out[-1].append(i)
-            if i.stop > rec:
-                rec = i.stop
+            if end > rec:
+                rec = end
     return out
 
 
@@ -278,7 +279,11 @@ def cluster_cleanup(clusters_v2):
     for i in range(len(clusters_v2)):
         info = clusters_v2[i]
         info_pos = '_'.join(sorted(
-            [','.join([str(k) for k in [j.pos, j.stop, j.info['SVTYPE']]]) for j in info]))
+            [','.join([str(k) for k in [
+                j.pos, 
+                j.info.get('END2') if j.info.get('SVTYPE') == 'BND' else j.stop, 
+                j.info['SVTYPE']
+            ]]) for j in info]))
         if info_pos not in cluster_info:
             cluster_info.append(info_pos)
             cluster_pos.append(i)

--- a/src/svtk/svtk/cxsv/complex_sv.py
+++ b/src/svtk/svtk/cxsv/complex_sv.py
@@ -217,16 +217,18 @@ class ComplexSV:
 
         # If event is >1kb and both breakpoints are SR-only,
         # leave variant as unresolved
+        ff_end = FF.info.get('END2') if FF.info.get('SVTYPE') == 'BND' else FF.stop
+        rr_end = RR.info.get('END2') if RR.info.get('SVTYPE') == 'BND' else RR.stop
         if 'EVIDENCE' in FF.info.keys() and 'EVIDENCE' in RR.info.keys():
             if FF.info['EVIDENCE'] == ('SR',) and RR.info['EVIDENCE'] == ('SR',):
-                if max(FF.stop, RR.stop) - min(FF.pos, RR.pos) > SR_only_cutoff:
+                if max(ff_end, rr_end) - min(FF.pos, RR.pos) > SR_only_cutoff:
                     self.cpx_type = 'UNK'
                     self.svtype = 'UNR'
 
         # Overall variant start/end
         if self.svtype in ['INV', 'CPX', 'UNR']:
             self.vcf_record.pos = min(FF.pos, RR.pos)
-            self.vcf_record.stop = max(FF.stop, RR.stop)
+            self.vcf_record.stop = max(ff_end, rr_end)
 
             self.vcf_record.info['SVLEN'] = abs(self.vcf_record.stop -
                                                 self.vcf_record.pos)
@@ -241,12 +243,12 @@ class ComplexSV:
             # -->|<----|-->
             if self.cpx_type == 'DUP5/INS3':
                 source_start, source_end = RR.pos, FF.pos
-                sink_start, sink_end = FF.stop, RR.stop
+                sink_start, sink_end = ff_end, rr_end
 
             #   A D   C B
             # -->|<----|-->
             elif self.cpx_type == 'DUP3/INS5':
-                source_start, source_end = RR.stop, FF.stop
+                source_start, source_end = rr_end, ff_end
                 sink_start, sink_end = FF.pos, RR.pos
 
             # first check for overlap with MEI

--- a/src/svtk/svtk/cxsv/cpx_link.py
+++ b/src/svtk/svtk/cxsv/cpx_link.py
@@ -157,11 +157,12 @@ def link_cpx_V2(linked_INV, cpx_dist=2000):
     cluster = []
     for inv in overlapping_inv:
         if len(inv) > 1:
-            if abs(inv[1].pos - inv[0].pos) > cpx_dist and abs(inv[1].stop - inv[0].stop) > cpx_dist:
+            end1 = inv[0].info.get('END2') if inv[0].info.get('SVTYPE') == 'BND' else inv[0].stop
+            end2 = inv[1].info.get('END2') if inv[1].info.get('SVTYPE') == 'BND' else inv[1].stop
+            if abs(inv[1].pos - inv[0].pos) > cpx_dist and abs(end2 - end1) > cpx_dist:
                 if 'STRANDS' in inv[0].info.keys() and 'STRANDS' in inv[1].info.keys():
                     if inv[0].info['STRANDS'] != inv[1].info['STRANDS']:
-                        if inv[0].pos < inv[1].pos < inv[0].stop < inv[1].stop \
-                                or inv[1].pos < inv[0].pos < inv[1].stop < inv[0].stop:
+                        if inv[0].pos < inv[1].pos < end1 < end2 or inv[1].pos < inv[0].pos < end2 < end1:
                             cluster.append(inv)
         else:
             cluster.append(inv)
@@ -170,9 +171,13 @@ def link_cpx_V2(linked_INV, cpx_dist=2000):
 
 def close_enough(r1, r2, cpx_dist=2000):
     distA = np.abs(r1.pos - r2.pos)
-    distB = np.abs(r1.stop - r2.stop)
+    end1 = r1.info.get('END2') if r1.info.get('SVTYPE') == 'BND' else r1.stop
+    end2 = r2.info.get('END2') if r2.info.get('SVTYPE') == 'BND' else r2.stop
+    distB = np.abs(end1 - end2)
     return distA < cpx_dist or distB < cpx_dist
 
 
 def records_overlap(r1, r2):
-    return r1.chrom == r2.chrom and not (r1.pos > r2.stop or r1.stop < r2.pos)
+    end1 = r1.info.get('END2') if r1.info.get('SVTYPE') == 'BND' else r1.stop
+    end2 = r2.info.get('END2') if r2.info.get('SVTYPE') == 'BND' else r2.stop
+    return r1.chrom == r2.chrom and not (r1.pos > end2 or end1 < r2.pos)

--- a/src/svtk/svtk/cxsv/cpx_tloc.py
+++ b/src/svtk/svtk/cxsv/cpx_tloc.py
@@ -10,8 +10,8 @@ Classification of reciprocal translocations.
 def classify_insertion(plus, minus, mh_buffer=50):
     plus_A = plus.pos
     minus_A = minus.pos
-    plus_B = plus.stop
-    minus_B = minus.stop
+    plus_B = plus.info.get('END2') if plus.info.get('SVTYPE') == 'BND' else plus.stop
+    minus_B = minus.info.get('END2') if minus.info.get('SVTYPE') == 'BND' else minus.stop
 
     # Buffer comparisons
     def _greater(p1, p2):
@@ -57,8 +57,8 @@ def classify_simple_translocation(plus, minus, mh_buffer=10):
     # get positions
     plus_A = plus.pos
     minus_A = minus.pos
-    plus_B = plus.stop
-    minus_B = minus.stop
+    plus_B = plus.info.get('END2') if plus.info.get('SVTYPE') == 'BND' else plus.stop
+    minus_B = minus.info.get('END2') if minus.info.get('SVTYPE') == 'BND' else minus.stop
 
     plus_strands = plus.info['STRANDS']
 

--- a/src/svtk/svtk/cxsv/rescan_single_enders.py
+++ b/src/svtk/svtk/cxsv/rescan_single_enders.py
@@ -51,7 +51,8 @@ def match_cluster(record, cluster, dist=300):
     -------
     match : bool
     """
-    r_start, r_end = record.pos, record.stop
+    r_start = record.pos
+    r_end = record.info.get('END2') if record.info.get('SVTYPE') == 'BND' else record.stop
 
     if record.info['STRANDS'] == '++':
         # Choose max start/end of ++ pairs
@@ -230,14 +231,20 @@ def make_new_record(pairs, old_record, retain_algs=False):
     # Take first quartile of - read positions for -/- breakpoints
     if pairs[0].strandA == '+':
         record.pos = round(np.percentile([p.posA for p in pairs], 90), 0)
-        record.stop = round(np.percentile([p.posB for p in pairs], 90), 0)
+        end = round(np.percentile([p.posB for p in pairs], 90), 0)
         record.info['STRANDS'] = '++'
     else:
         record.pos = round(np.percentile([p.posA for p in pairs], 10), 0)
-        record.stop = round(np.percentile([p.posB for p in pairs], 10), 0)
+        end = round(np.percentile([p.posB for p in pairs], 10), 0)
         record.info['STRANDS'] = '--'
 
-    record.info['SVLEN'] = record.stop - record.pos
+    if record.info.get('SVTYPE') == 'BND':
+        record.info['END2'] = end
+        record.stop = record.pos + 1
+    else:
+        record.stop = end
+
+    record.info['SVLEN'] = end - record.pos
     if retain_algs:
         old_algs = list(record.info['ALGORITHMS'])
         old_algs.append('rescan')

--- a/src/svtk/svtk/pesr/breakpoint.py
+++ b/src/svtk/svtk/pesr/breakpoint.py
@@ -49,7 +49,7 @@ class Breakpoint:
         chrA = record.chrom
         posA = record.pos
         chrB = record.info['CHR2']
-        posB = record.stop
+        posB = record.info.get('END2') if record.info['SVTYPE'] == 'BND' else record.stop
 
         name = record.id
         strands = record.info['STRANDS']

--- a/src/svtk/svtk/pesr/pe_test.py
+++ b/src/svtk/svtk/pesr/pe_test.py
@@ -87,7 +87,9 @@ class PETest(PESRTest):
 
         strandA, strandB = record.info['STRANDS']
         startA, endA = _get_coords(record.pos, strandA)
-        startB, endB = _get_coords(record.stop, strandB)
+        
+        end_pos = record.info.get('END2') if record.info['SVTYPE'] == 'BND' else record.stop
+        startB, endB = _get_coords(end_pos, strandB)
 
         # Add 1 because evidence is stored/indexed with 0-based coordinates
         region = '{0}:{1}-{2}'.format(record.chrom, startA + 1, endA + 1)

--- a/src/svtk/svtk/pesr/sr_test.py
+++ b/src/svtk/svtk/pesr/sr_test.py
@@ -28,9 +28,10 @@ class SRTest(PESRTest):
             record.pos, record.info['STRANDS'][0], record.chrom,
             called, background, record.pos - self.window, record.pos + self.window)
 
+        end = record.info.get('END2') if record.info['SVTYPE'] == 'BND' else record.stop
         resultB = self._test_coord(
-            record.stop, record.info['STRANDS'][1], record.info['CHR2'],
-            called, background, record.stop - self.window, record.stop + self.window)
+            end, record.info['STRANDS'][1], record.info['CHR2'],
+            called, background, end - self.window, end + self.window)
 
         posA = int(resultA.pos)
         posB = int(resultB.pos)
@@ -56,15 +57,15 @@ class SRTest(PESRTest):
                 # Note that the case posA > posB is allowed and corrected for in the SR coordinate rewriting step later
                 if posA == posB and self.window > 0:
                     resultB = self._test_coord(
-                        record.stop, record.info['STRANDS'][1], record.info['CHR2'],
-                        called, background, record.stop - self.window, record.stop + self.window,
+                        end, record.info['STRANDS'][1], record.info['CHR2'],
+                        called, background, end - self.window, end + self.window,
                         invalid_pos_list=[posA])
             elif posA >= posB:
                 # Invalid coordinates, need to re-optimize around the better coordinate
                 if log_pval_A >= log_pval_B:
                     # posA is better, so use posA as anchor and check for best posB in valid window
                     resultB = self._test_coord(
-                        record.stop, record.info['STRANDS'][1], record.info['CHR2'],
+                        end, record.info['STRANDS'][1], record.info['CHR2'],
                         called, background, posA, posA + self.window)
                 else:
                     # vice versa

--- a/src/svtk/svtk/standardize/std_lumpy.py
+++ b/src/svtk/svtk/standardize/std_lumpy.py
@@ -54,21 +54,27 @@ class LumpyStandardizer(VCFStandardizer):
         # Parse CHR2 and END
         if std_rec.info['SVTYPE'] == 'BND':
             chr2, end = parse_bnd_pos(std_rec.alts[0])
+            chrom, pos = std_rec.chrom, std_rec.pos
 
             # swap chr2/chrom, pos/end, and reverse strandedness
-            if not is_smaller_chrom(std_rec.chrom, chr2):
-                std_rec.pos, end = end, std_rec.pos
-                std_rec.chrom, chr2 = chr2, std_rec.chrom
+            if not is_smaller_chrom(chrom, chr2):
+                pos, end = end, pos
+                chrom, chr2 = chr2, chrom
                 std_rec.info['STRANDS'] = std_rec.info['STRANDS'][::-1]
+            
+            std_rec.chrom = chrom
+            std_rec.pos = pos
+            std_rec.info['CHR2'] = chr2
+            std_rec.info['END2'] = end
+            std_rec.stop = pos
         else:
-            chr2, end = raw_rec.chrom, raw_rec.stop
-
-        std_rec.info['CHR2'] = chr2
-        std_rec.stop = end
+            std_rec.info['CHR2'] = raw_rec.chrom
+            std_rec.stop = raw_rec.stop
 
         # Add SVLEN
         if std_rec.chrom == std_rec.info['CHR2']:
-            std_rec.info['SVLEN'] = end - std_rec.pos
+            sv_end = std_rec.info.get('END2') if std_rec.info['SVTYPE'] == 'BND' else std_rec.stop
+            std_rec.info['SVLEN'] = sv_end - std_rec.pos
         else:
             std_rec.info['SVLEN'] = -1
 

--- a/src/svtk/svtk/standardize/std_manta.py
+++ b/src/svtk/svtk/standardize/std_manta.py
@@ -62,15 +62,15 @@ class MantaStandardizer(VCFStandardizer):
                 chrom, chr2 = chr2, chrom
                 std_rec.pos = pos
                 std_rec.chrom = chrom
+            std_rec.info['CHR2'] = chr2
+            std_rec.info['END2'] = end
+            std_rec.stop = std_rec.pos
         elif svtype == 'INS':
-            chr2 = raw_rec.chrom
-            end = raw_rec.pos + 1
+            std_rec.info['CHR2'] = raw_rec.chrom
+            std_rec.stop = raw_rec.pos + 1
         else:
-            chr2 = raw_rec.chrom
-            end = raw_rec.stop
-
-        std_rec.info['CHR2'] = chr2
-        std_rec.stop = end
+            std_rec.info['CHR2'] = raw_rec.chrom
+            std_rec.stop = raw_rec.stop
 
         # Strand parsing
         if svtype == 'INV':
@@ -96,7 +96,8 @@ class MantaStandardizer(VCFStandardizer):
         elif svtype == 'INS':
             std_rec.info['SVLEN'] = raw_rec.info.get('SVLEN', -1)
         else:
-            std_rec.info['SVLEN'] = std_rec.stop - std_rec.pos
+            end = std_rec.info.get('END2') if svtype == 'BND' else std_rec.stop
+            std_rec.info['SVLEN'] = end - std_rec.pos
 
         std_rec.info['ALGORITHMS'] = ['manta']
 

--- a/src/svtk/svtk/standardize/std_smoove.py
+++ b/src/svtk/svtk/standardize/std_smoove.py
@@ -54,21 +54,27 @@ class SmooveStandardizer(VCFStandardizer):
         # Parse CHR2 and END
         if std_rec.info['SVTYPE'] == 'BND':
             chr2, end = parse_bnd_pos(std_rec.alts[0])
+            chrom, pos = std_rec.chrom, std_rec.pos
 
             # swap chr2/chrom, pos/end, and reverse strandedness
-            if not is_smaller_chrom(std_rec.chrom, chr2):
-                std_rec.pos, end = end, std_rec.pos
-                std_rec.chrom, chr2 = chr2, std_rec.chrom
+            if not is_smaller_chrom(chrom, chr2):
+                pos, end = end, pos
+                chrom, chr2 = chr2, chrom
                 std_rec.info['STRANDS'] = std_rec.info['STRANDS'][::-1]
-        else:
-            chr2, end = raw_rec.chrom, raw_rec.stop
 
-        std_rec.info['CHR2'] = chr2
-        std_rec.stop = end
+            std_rec.chrom = chrom
+            std_rec.pos = pos
+            std_rec.info['CHR2'] = chr2
+            std_rec.info['END2'] = end
+            std_rec.stop = std_rec.pos + 1
+        else:
+            std_rec.info['CHR2'] = raw_rec.chrom
+            std_rec.stop = raw_rec.stop
 
         # Add SVLEN
         if std_rec.chrom == std_rec.info['CHR2']:
-            std_rec.info['SVLEN'] = end - std_rec.pos
+            sv_end = std_rec.info.get('END2') if std_rec.info['SVTYPE'] == 'BND' else std_rec.stop
+            std_rec.info['SVLEN'] = sv_end - std_rec.pos
         else:
             std_rec.info['SVLEN'] = -1
 

--- a/src/svtk/svtk/standardize/std_wham.py
+++ b/src/svtk/svtk/standardize/std_wham.py
@@ -32,7 +32,11 @@ class WhamStandardizer(VCFStandardizer):
 
         # No CTX events
         std_rec.info['CHR2'] = std_rec.chrom
-        std_rec.stop = raw_rec.stop
+        if std_rec.info['SVTYPE'] == 'BND':
+            std_rec.info['END2'] = raw_rec.info['END2']
+            std_rec.stop = std_rec.pos + 1
+        else:
+            std_rec.stop = raw_rec.stop
 
         # Strand not provided for inv/tloc
         if std_rec.info['SVTYPE'] == 'DEL':

--- a/src/svtk/svtk/utils/utils.py
+++ b/src/svtk/svtk/utils/utils.py
@@ -209,14 +209,15 @@ def vcf2bedtool(vcf, split_bnd=True, include_samples=False,
 
             chrom = record.chrom
             name = record.id
+            end = record.info.get('END2') if record.info['SVTYPE'] == 'BND' else record.stop
 
             # Set start & end coordinates to appropriate sorted order
             # for all records (to not break bedtools)
             if no_sort_coords:
                 start = int(record.pos)
-                end = int(record.stop)
+                end = int(end)
             else:
-                start, end = sorted([int(record.pos), int(record.stop)])
+                start, end = sorted([int(record.pos), int(end)])
 
             # Subtract 1bp from pos to convert to 0-based BED vs 1-based VCF
             start = max([0, int(start) - 1])
@@ -239,7 +240,7 @@ def vcf2bedtool(vcf, split_bnd=True, include_samples=False,
                 for key in include_infos:
                     # Can't access END through info
                     if key == 'END':
-                        infos.append(record.stop)
+                        infos.append(end)
                     else:
                         infos.append(record.info.get(key))
 


### PR DESCRIPTION
This PR outlines code part of an initial test refactoring of GATK-SV to align it to Pysam's upgraded versions, which do not allow `END` positions that are less than the start position. 

This is comprehensive across GATK-SV, though we only wish to update references that are potentially problematic - this branch will hence act as a reference branch for ____.

Changes included:
1. `src/svtk/svtk/cli/standardize_vcf.py`: Includes the `END2` header line in the output VCF, which is necessary in order to set these for Manta VCFs.
2. `src/svtk/svtk/standardize/std_manta.py`: Sets the `END2` tag correctly for BNDs.
3. `src/svtk/svtk/cli/resolve.py`: Called by `TinyResolve` from `GatherBatchEvidence`, and operates on BNDs. Requires updating as the Manta VCFs will now contain an `END2` tag.

Changes to be determined:
1. `src/WGD/bin/convert_gcnv.py`: Called in _GatherBatchEvidence_.
2. `src/sv-pipeline/scripts/format_gatk_vcf_for_svtk.py`: Called in _ClusterBatch_ and _CombineBatches_.
3. `src/svtk/svtk/pesr/pe_test.py`: Called in _GenerateBatchMetrics_.
4. `src/svtk/svtk/pesr/sr_test.py`: Called in _GenerateBatchMetrics_.
5. `src/svtk/svtk/pesr/breakpoint.py`: Called in _GenerateBatchMetrics_.
6. `src/sv-pipeline/03_variant_filtering/scripts/rewrite_SR_coords.py`: Called in _FilterBatchSites_.
7. `src/sv-pipeline/04_variant_resolution/scripts/merge_vcfs.py`: Called in _MergeBatchSites_.
8. `src/sv-pipeline/04_variant_resolution/scripts/overlap_breakpoint_filter.py`: Called in _ResolveComplexVariants_.
9. `src/sv-pipeline/04_variant_resolution/scripts/postCPX_cleanup.py`: Called in _ResolveComplexVariants_.
10. `src/svtk/svtk/cxsv/complex_sv.py`: Called in _ResolveComplexVariants_.
11. `src/svtk/svtk/cxsv/cpx_inv.py`: Called in _ResolveComplexVariants_.
12. `src/svtk/svtk/cxsv/cpx_link.py`: Called in _ResolveComplexVariants_.
13. `src/svtk/svtk/cxsv/cpx_tloc.py`: Called in _ResolveComplexVariants_.
14. `src/svtk/svtk/cxsv/rescan_single_enders.py`: Called in _ResolveComplexVariants_.
15. `src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part1b_filter.py`: Called in _CleanVcf_.
16. `src/sv-pipeline/04_variant_resolution/scripts/clean_vcf_part5_update_records.py`: Called in _CleanVcf_.
17. `src/sv-pipeline/05_annotation/scripts/compute_AFs.py`: Called in _AnnotateVcf_.
18. `src/sv-pipeline/scripts/identify_duplicates.py`: Called in _MainVcfQc_.

Changes of lower priority: 
1. `src/sv-pipeline/scripts/single_sample/update_variant_representations.py`: Called in `GATKSVPipelineSingleSample`. 
2. src/sv-pipeline/scripts/format_pb_for_gatk.py: Called in `MakeGqRecalibratorTrainingSetFromPacBio`
3. `src/sv-pipeline/scripts/preprocess_gatk_for_pacbio_eval.py`: Called in `MakeGqRecalibratorTrainingSetFromPacBio`.
4. `src/sv-pipeline/scripts/refine_training_set.py`: Called in `MakeGqRecalibratorTrainingSetFromPacBio`.

Changes omitted:
1. `src/svtk/svtk/utils/utils.py`: BNDs should continue to be represented as a single position in the `vcf2bed`, we should not pull their `END` position from the `END2` tag. 
2. `src/svtk/svtk/standardize/std_wham.py`: Does not call sites with `SVTYPE=BND`.
3.  `src/svtk/svtk/standardize/std_delly.py`: GATK-SV no longer supports this caller ==> archive?
4. `src/svtk/svtk/standardize/std_lumpy.py`: GATK-SV no longer supports this caller ==> archive?
5. `src/svtk/svtk/standardize/std_smoove.py`: GATK-SV no longer supports this caller ==> archive?
6. `src/sv-pipeline/04_variant_resolution/scripts/overlap_pass.py`: GATK-SV no longer uses this script ==> archive?
7.  `src/sv-pipeline/04_variant_resolution/scripts/eliminate_redundancies.py`: GATK-SV no longer uses this script ==> archive?
9. `src/sv-pipeline/04_variant_resolution/scripts/merge_linked_depth_calls.py`: GATK-SV no longer uses this script ==> archive?
10.`src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py`: GATK-SV no longer uses this script ==> archive?
11. `src/sv-pipeline/04_variant_resolution/scripts/merge_pesr_depth.py`: GATK-SV no longer uses this script ==> archive?
12. `src/sv_utils/src/sv_utils/fix_vcf.py`: GATK-SV no longer uses this script ==> archive?
13. `src/sv_utils/src/sv_utils/fix_vcf.py`: GATK-SV no longer uses this script ==> archive?
14. `src/svtk/svtk/svfile.py`: GATK-SV no longer uses this script ==> archive?