### PR TITLE
Kj cpx cutoff modification

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -132,6 +132,7 @@ workflows:
     filters:
       branches:
         - main
+        - kj_cpx_cutoff_modification
       tags:
         - /.*/
 

--- a/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py
@@ -1148,6 +1148,7 @@ def main(argv: Optional[List[Text]] = None):
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: %s' % log_level)
     logging.basicConfig(level=numeric_level, format='%(asctime)s - %(levelname)s: %(message)s')
+    
     MIN_DDUP_THRESH = args.min_ddup_thresh
 
     all_samples, male_samples, female_samples = parse_ped(args.ped)

--- a/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py
@@ -16,7 +16,6 @@ from intervaltree import IntervalTree
 MIN_SIZE = 1000
 MIN_DIFF = 0.4
 MIN_SIZE_IDEL = 150
-MIN_DDUP_THRESH = 1000000
 
 
 def interval_string(chrom, start, end):
@@ -662,8 +661,9 @@ def final_assessment(cleaned_genotype_counts, variants_to_reclassify):
                     reason="INVERTED_DISPERSED_DUPLICATION",
                     new_sv_type="CPX",
                     new_cpx_type="dDUP",
-                    new_cpx_intervals=f"DUP_{interval_string(dup_chrom, dup_start, dup_end)},"
-                                      f"INV_{interval_string(dup_chrom, dup_start, dup_end)}",
+                    new_cpx_intervals=f"INV_{interval_string(dup_chrom, dup_start, dup_end)},"
+                                      f"DUP_{interval_string(dup_chrom, dup_start, dup_end)}",
+
                     new_svlen=dup_size,
                     new_source=f"DUP_{interval_string(dup_chrom, dup_start, dup_end)}",
                     new_start=None,
@@ -1124,6 +1124,7 @@ def _parse_arguments(argv: List[Text]) -> argparse.Namespace:
     parser.add_argument('--ped', type=str, help='PED family file')
     parser.add_argument('--out', type=str, help='Output file')
     parser.add_argument('--reclassification-table', type=str, help='Output reclassification table path', required=False)
+    parser.add_argument('--min-ddup-thresh', type=int, help="Min DUP threshold", default=1000000)
     parser.add_argument('--chrx', type=str, help='Chromosome X contig name', default='chrX')
     parser.add_argument('--chry', type=str, help='Chromosome Y contig name', default='chrY')
     parser.add_argument("-l", "--log-level", required=False, default="INFO",
@@ -1147,6 +1148,8 @@ def main(argv: Optional[List[Text]] = None):
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: %s' % log_level)
     logging.basicConfig(level=numeric_level, format='%(asctime)s - %(levelname)s: %(message)s')
+
+    MIN_DDUP_THRESH = args.min_ddup_thresh
 
     all_samples, male_samples, female_samples = parse_ped(args.ped)
     genotype_dict = parse_genotypes(args.genotypes)

--- a/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py
@@ -1148,7 +1148,6 @@ def main(argv: Optional[List[Text]] = None):
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: %s' % log_level)
     logging.basicConfig(level=numeric_level, format='%(asctime)s - %(levelname)s: %(message)s')
-    
     MIN_DDUP_THRESH = args.min_ddup_thresh
 
     all_samples, male_samples, female_samples = parse_ped(args.ped)

--- a/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py
@@ -16,6 +16,7 @@ from intervaltree import IntervalTree
 MIN_SIZE = 1000
 MIN_DIFF = 0.4
 MIN_SIZE_IDEL = 150
+MIN_DDUP_THRESH = 1000000
 
 
 def interval_string(chrom, start, end):

--- a/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/process_posthoc_cpx_depth_regenotyping.py
@@ -1148,7 +1148,6 @@ def main(argv: Optional[List[Text]] = None):
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: %s' % log_level)
     logging.basicConfig(level=numeric_level, format='%(asctime)s - %(levelname)s: %(message)s')
-
     MIN_DDUP_THRESH = args.min_ddup_thresh
 
     all_samples, male_samples, female_samples = parse_ped(args.ped)

--- a/wdl/GenotypeComplexVariants.wdl
+++ b/wdl/GenotypeComplexVariants.wdl
@@ -13,6 +13,7 @@ workflow GenotypeComplexVariants {
 
     Boolean merge_vcfs = false
     Int? records_per_shard
+    Int? min_ddup_thresh
 
     Array[File] complex_resolve_vcfs
     Array[File] complex_resolve_vcf_indexes
@@ -85,6 +86,7 @@ workflow GenotypeComplexVariants {
         n_per_split_small=2500,
         n_per_split_large=250,
         n_rd_test_bins=100000,
+        min_ddup_thresh=min_ddup_thresh,
         prefix="~{cohort_name}.~{contig}",
         contig=contig,
         ped_files=SubsetPedFile.ped_subset_file,

--- a/wdl/GenotypeCpxCnvs.wdl
+++ b/wdl/GenotypeCpxCnvs.wdl
@@ -101,7 +101,6 @@ workflow GenotypeCpxCnvs {
       contig=contig,
       sv_pipeline_docker=sv_pipeline_docker,
       runtime_attr_override=runtime_override_parse_genotypes
-    }
   }
 
   # Final output
@@ -205,7 +204,7 @@ task ParseGenotypes {
       --vcf ~{vcf} \
       --intervals ~{intervals} \
       --genotypes ~{genotypes} \
-      ~{"--min-ddup-thresh " + min_ddup_thresh} \
+      ~{if defined(min_ddup_thresh) then "--min-ddup-thresh " + min_ddup_thresh else ""} \
       --ped ~{ped_file} \
       --out out.vcf.gz \
       --reclassification-table ~{prefix}.CPXregenotyping_reclassification_table.~{contig}.txt

--- a/wdl/GenotypeCpxCnvs.wdl
+++ b/wdl/GenotypeCpxCnvs.wdl
@@ -205,10 +205,10 @@ task ParseGenotypes {
       --vcf ~{vcf} \
       --intervals ~{intervals} \
       --genotypes ~{genotypes} \
+      ~{"--min-ddup-thresh " + min_ddup_thresh} \
       --ped ~{ped_file} \
       --out out.vcf.gz \
-      --reclassification-table ~{prefix}.CPXregenotyping_reclassification_table.~{contig}.txt \
-      ~{"--min-ddup-thresh " + min_ddup_thresh}
+      --reclassification-table ~{prefix}.CPXregenotyping_reclassification_table.~{contig}.txt
 
     # Compress for storage
     gzip ~{prefix}.CPXregenotyping_reclassification_table.~{contig}.txt

--- a/wdl/GenotypeCpxCnvs.wdl
+++ b/wdl/GenotypeCpxCnvs.wdl
@@ -19,6 +19,7 @@ workflow GenotypeCpxCnvs {
     Int n_per_split_small
     Int n_per_split_large
     Int n_rd_test_bins
+    Int? min_ddup_thresh
     String prefix
     File ped_file
     String contig
@@ -94,11 +95,13 @@ workflow GenotypeCpxCnvs {
       vcf=vcf,
       intervals=GetCpxCnvIntervals.cpx_cnv_bed,
       genotypes=MergeMeltedGts.outfile,
+      min_ddup_thresh=min_ddup_thresh,
       prefix=contig_prefix,
       ped_file=ped_file,
       contig=contig,
       sv_pipeline_docker=sv_pipeline_docker,
       runtime_attr_override=runtime_override_parse_genotypes
+    }
   }
 
   # Final output
@@ -166,6 +169,7 @@ task ParseGenotypes {
     File vcf
     File intervals
     File genotypes
+    Int? min_ddup_thresh
     File ped_file
     String prefix
     String contig
@@ -203,7 +207,8 @@ task ParseGenotypes {
       --genotypes ~{genotypes} \
       --ped ~{ped_file} \
       --out out.vcf.gz \
-      --reclassification-table ~{prefix}.CPXregenotyping_reclassification_table.~{contig}.txt
+      --reclassification-table ~{prefix}.CPXregenotyping_reclassification_table.~{contig}.txt \
+      ~{"--min-ddup-thresh " + min_ddup_thresh}
 
     # Compress for storage
     gzip ~{prefix}.CPXregenotyping_reclassification_table.~{contig}.txt

--- a/wdl/ScatterCpxGenotyping.wdl
+++ b/wdl/ScatterCpxGenotyping.wdl
@@ -20,6 +20,7 @@ workflow ScatterCpxGenotyping {
     Int n_per_split_small
     Int n_per_split_large
     Int n_rd_test_bins
+    Int? min_ddup_thresh
     String prefix
     File ped_file
     String contig
@@ -73,6 +74,7 @@ workflow ScatterCpxGenotyping {
         n_per_split_large=n_per_split_large,
         n_per_split_small=n_per_split_small,
         n_rd_test_bins=n_rd_test_bins,
+        min_ddup_thresh=min_ddup_thresh,
         prefix=prefix,
         ped_file=ped_file,
         contig=contig,


### PR DESCRIPTION
### Description
This PR is intended to enable passing in a custom breakpoint cutoff for dispersed duplication detection for complex events in GATK-SV.

### Testing
- The [following job](https://app.terra.bio/#workspaces/broad-firecloud-dsde-methods/GATK-Structural-Variants-Joint-Calling/submission_history/4461c956-7fe8-4820-841c-c91f835f4e4b) represents a run of the original WDL.
- The [following job](https://app.terra.bio/#workspaces/broad-firecloud-dsde-methods/kj-cpx-parameter-test/submission_history/837a6256-389b-4adb-b0b5-079590bbf329) represents a run of the modified WDL with the default parameter passed - the number of variants in the output VCF is equal.
- The [following job](https://app.terra.bio/#workspaces/broad-firecloud-dsde-methods/kj-cpx-parameter-test/submission_history/e8e0722b-eaa6-4734-8c30-37680ae69edd) represents a run of the modified WDL with a lower threshold (2000) passed - the number of variants is no longer equal.
- Validated all WDLs with `womtool`.

### Pre-Merge Changes Required
Remove automated sync of the `GenotypeComplexVariants` WDL to Dockstore.