### PR TITLE
Refactor manta-vcf arg to input-vcf to match recent refactors

### DIFF
--- a/src/sv_shell/scramble.sh
+++ b/src/sv_shell/scramble.sh
@@ -12,7 +12,7 @@ bam_or_cram_index=${3}
 original_bam_or_cram_file=${4}
 original_bam_or_cram_index=${5}
 counts_file=${6}
-manta_vcf=${7}
+input_vcf=${7}
 reference_fasta=${8}
 reference_index=${9}
 regions_list=${10}
@@ -47,7 +47,7 @@ echo "bam_or_cram_index:          " "${bam_or_cram_index}"
 echo "original_bam_or_cram_file:  " "${original_bam_or_cram_file}"
 echo "original_bam_or_cram_index: " "${original_bam_or_cram_index}"
 echo "counts_file:                " "${counts_file}"
-echo "manta_vcf:                  " "${manta_vcf}"
+echo "input_vcf:                  " "${input_vcf}"
 echo "reference_fasta:            " "${reference_fasta}"
 echo "reference_index:            " "${reference_index}"
 echo "regions_list:               " "${regions_list}"
@@ -160,7 +160,7 @@ cd "${working_dir_make_vcf}"
 
 python "${scramble_vcf_script}" \
   --table "${scramble_table}" \
-  --manta-vcf "${manta_vcf}" \
+  --input-vcf "${input_vcf}" \
   --alignments-file "${original_bam_or_cram_file}" \
   --sample "${sample_name}" \
   --reference "${reference_fasta}" \


### PR DESCRIPTION
A follow-up from #803 where [`--manta-vcf` is refactored to `--input-vcf`](https://github.com/broadinstitute/gatk-sv/pull/803/files#diff-fc02cfac08a1b2a78f152e93723b991d3538861191f4b19bc9ccd0f4ab9c2821L258); this PR updates the sv-shell script to match the same refactor. 