### PR TITLE
Fix code path in EvidenceQc when run_ploidy is false

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -15,7 +15,6 @@ workflows:
     filters:
       branches:
         - main
-        - mw_run_ploidy
       tags:
         - /.*/
 


### PR DESCRIPTION
Fixes a WDL error in the single sample pipeline when `run_ploidy` is false:

```
Failed to evaluate 'EvidenceQC.ploidy_plots' (reason 1 of 1): Evaluating select_first([CreateVariantCountPlots.ploidy_plots, Ploidy.ploidy_plots]) failed: select_first was called with 2 empty values. We needed at least one to be filled.
```

This is caused by the `select_first()` call to assign the optional `ploidy_plots` output.

Tested the EvidenceQc module in Terra with `run_ploidy` set to true and to false.