### PR TITLE
Update reference genome in depth plots

### DIFF
--- a/src/RdTest/RdTest.R
+++ b/src/RdTest/RdTest.R
@@ -804,7 +804,7 @@ plotJPG <- function(genotype_matrix,cnv_matrix,chr,start,end,cnvID,sampleIDs,out
   ##Limits number of sample Ids due to size limiations for readablity
   if(nchar(as.character(sampleIDs))>44){sampleIDsToDisplay<-paste(substr(sampleIDs,1,44),"...",sep="")}else{sampleIDsToDisplay<-sampleIDs}
   ##Title line 1##
-  main1=paste(chr,":",prettyNum(start,big.mark=","),"-",prettyNum(end,big.mark=",")," (hg19)",sep="")
+  main1=paste(chr,":",prettyNum(start,big.mark=","),"-",prettyNum(end,big.mark=",")," (hg38)",sep="")
   
   ###Add proper size abbr. for larger events
   size=end-start
@@ -839,7 +839,7 @@ plotJPG <- function(genotype_matrix,cnv_matrix,chr,start,end,cnvID,sampleIDs,out
   ##Blue if Dup; Red if Del
   if ( plotK == TRUE ) {
     #keep plot_colormatrix
-    main1=paste(chr,":",prettyNum(start,big.mark=","),"-",prettyNum(end,big.mark=",")," (hg19)",sep="")
+    main1=paste(chr,":",prettyNum(start,big.mark=","),"-",prettyNum(end,big.mark=",")," (hg38)",sep="")
     mainText = paste(main1, "\n", "Copy Estimate"," ", mysize, sep = "")  
     plot_linematrix[,5:ncol(plot_linematrix)]<-"0.5"
   } else if (toupper(cnvtype) == "DEL") {

--- a/src/RdTest/RdTestV2.R
+++ b/src/RdTest/RdTestV2.R
@@ -922,7 +922,7 @@ plotJPG <- function(genotype_matrix,cnv_matrix,chr,start,end,cnvID,sampleIDs,out
   ##Limits number of sample Ids due to size limiations for readablity
   if(nchar(as.character(sampleIDs))>44){sampleIDsToDisplay<-paste(substr(sampleIDs,1,44),"...",sep="")}else{sampleIDsToDisplay<-sampleIDs}
   ##Title line 1##
-  main1=paste(chr,":",prettyNum(start,big.mark=","),"-",prettyNum(end,big.mark=",")," (hg19)",sep="")
+  main1=paste(chr,":",prettyNum(start,big.mark=","),"-",prettyNum(end,big.mark=",")," (hg38)",sep="")
   
   ###Add proper size abbr. for larger events
   size=end-start
@@ -957,7 +957,7 @@ plotJPG <- function(genotype_matrix,cnv_matrix,chr,start,end,cnvID,sampleIDs,out
   ##Blue if Dup; Red if Del
   if ( plotK == TRUE ) {
     #keep plot_colormatrix
-    main1=paste(chr,":",prettyNum(start,big.mark=","),"-",prettyNum(end,big.mark=",")," (hg19)",sep="")
+    main1=paste(chr,":",prettyNum(start,big.mark=","),"-",prettyNum(end,big.mark=",")," (hg38)",sep="")
     mainText = paste(main1, "\n", "Copy Estimate"," ", mysize, sep = "")  
     plot_linematrix[,5:ncol(plot_linematrix)]<-"0.5"
   } else if (toupper(cnvtype) == "DEL") {


### PR DESCRIPTION
### Description
This PR is intended to update the labelled reference genome in depth plots from `hg19` to `hg38`.

### Testing
- The [following job](https://app.terra.bio/#workspaces/broad-firecloud-dsde-methods/GATK-Structural-Variants-Joint-Calling/submission_history/8e26ce4c-8864-4f0d-8816-df6ddcb28292) represents a run of the original script.
- The [following job](https://app.terra.bio/#workspaces/cpg-terra/tenk10k-sv/submission_history/9a41c05a-a202-4c13-9dfd-0c63e6175471) represents a run with a docker that uses the modified script - the plots are now tagged with `hg38`. 

### Alternative Implementations
- Remove the reference genome from the plot annotations and labels altogether.
- Extract the reference genome version from the reference itself, and annotate this - would require adding a `ref_fasta` input to the workflow just to extract the version from, which feels overkill given the fact that numerous workflows that call this script (e.g. `VisualizeCnvs`) don't currently require this as an input.