### PR TITLE
Plot SV counts for all VCFs in FilterBatchSites

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -78,6 +78,7 @@ workflows:
     filters:
       branches:
         - main
+        - eph_plotsvcounts_6vcfs
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -60,7 +60,6 @@ workflows:
     filters:
       branches:
         - main
-        - eph_plotsvcounts_6vcfs
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -60,6 +60,7 @@ workflows:
     filters:
       branches:
         - main
+        - eph_plotsvcounts_6vcfs
       tags:
         - /.*/
 
@@ -78,7 +79,6 @@ workflows:
     filters:
       branches:
         - main
-        - eph_plotsvcounts_6vcfs
       tags:
         - /.*/
 

--- a/wdl/FilterBatchSites.wdl
+++ b/wdl/FilterBatchSites.wdl
@@ -78,7 +78,7 @@ workflow FilterBatchSites {
   call sv_counts.PlotSVCountsPerSample {
     input:
       prefix = batch,
-      vcfs=[FilterAnnotateVcf.annotated_vcf[0], FilterAnnotateVcf.annotated_vcf[1], FilterAnnotateVcf.annotated_vcf[2], FilterAnnotateVcf.annotated_vcf[3], FilterAnnotateVcf.annotated_vcf[4]],
+      vcfs=[FilterAnnotateVcf.annotated_vcf[0], FilterAnnotateVcf.annotated_vcf[1], FilterAnnotateVcf.annotated_vcf[2], FilterAnnotateVcf.annotated_vcf[3], FilterAnnotateVcf.annotated_vcf[4], FilterAnnotateVcf.annotated_vcf[5]],
       N_IQR_cutoff = N_IQR_cutoff_plotting,
       sv_pipeline_docker = sv_pipeline_docker,
       runtime_attr_count_svs = runtime_attr_count_svs,


### PR DESCRIPTION
### Updates
After adding the DRAGEN VCF, the array of VCFs passed to PlotSVCountsPerSample in FilterBatchSites was not updated so the Wham SV counts were not getting plotted. This PR updates FilterBatchSites to pass all 6 possible VCFs to PlotSVCountsPerSample.

### Testing
* Validated all WDLs and JSONs
* Ran FilterBatchSites and confirmed that all expected plots were generated

### Notes
* This PR needs to be merged before the next release
* The changes to the dockstore.yml need to be reverted before merging