### PR TITLE
Bug fix missing sample ID in median coverage

### DIFF
--- a/src/WGD/bin/medianCoverage.R
+++ b/src/WGD/bin/medianCoverage.R
@@ -67,7 +67,7 @@ covPerSample <- function(cov,downsample=1000000,mad=F){
   }
   # Replace sample IDs if input matrix has header
   if(opts$header==T){
-    res$ID <- names(cov[,-c(1:3)])
+    res$ID <- names(cov[, -c(1:3), drop = FALSE])
   }
   # Return output df
   return(res)


### PR DESCRIPTION
This PR fixes the `medianCoverage.R` script, which fails to report the sample ID in the output. 

```bash
 > printf "Chr\tStart\tEnd\tNA12878\nchr1\t10000\t10100\t1014\nchr1\t10100\t10200\t378\nchr1\t10200\t10300\t218\n" > test_input.bed
```

Current output: 

```bash
> Rscript src/WGD/bin/medianCoverage.R test_input.bed -H test_output.bed
> cat test_output.bed

#sample_id	Med_withoutZeros
378	NA
```

Note that the sample ID is missing. 

Corrected output: 

```bash
> Rscript src/WGD/bin/medianCoverage.R test_input.bed -H test_output.bed
> cat test_output.bed

#sample_id	Med_withZeros	Med_withoutZeros
NA12878	378	NA
```
