### PR TITLE
Modify genotype filtering to read cutoffs from generalizable table 

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -177,6 +177,7 @@ workflows:
     filters:
       branches:
         - main
+        - kj_modify_sl_filter_input_format
       tags:
         - /.*/
 


### PR DESCRIPTION
### Description
This PR is intended to enable the use of a generalizable TSV file that contains cutoffs stratified by SV type, minimum size and maximum size when filtering genotypes.

### Testing
- The [following job](X) represents a run of the original WDL.
- The [following job](X) represents a run of the modified WDL with the original cutoffs from the job above passed, albeit in the form of a table rather than named arguments.
- Validated all WDLs with `womtool`.

### Pre-Merge Changes Required
Remove automated sync of the `FilterGenotypes` WDL to Dockstore.