### PR TITLE
Handle zero-length arrays in JoinRawCalls

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -159,6 +159,7 @@ workflows:
     filters:
       branches:
         - main
+        - eph_empty_lists_joinrawcalls
       tags:
         - /.*/
 

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/JoinRawCalls.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/JoinRawCalls.json.tmpl
@@ -12,6 +12,9 @@
   "JoinRawCalls.clustered_manta_vcfs" : "${this.sample_sets.clustered_manta_vcf}",
   "JoinRawCalls.clustered_manta_vcf_indexes" : "${this.sample_sets.clustered_manta_vcf_index}",
 
+  "JoinRawCalls.clustered_melt_vcfs" : "${this.sample_sets.clustered_melt_vcf}",
+  "JoinRawCalls.clustered_melt_vcf_indexes" : "${this.sample_sets.clustered_melt_vcf_index}",
+
   "JoinRawCalls.clustered_wham_vcfs" : "${this.sample_sets.clustered_wham_vcf}",
   "JoinRawCalls.clustered_wham_vcf_indexes" : "${this.sample_sets.clustered_wham_vcf_index}",
 

--- a/wdl/JoinRawCalls.wdl
+++ b/wdl/JoinRawCalls.wdl
@@ -47,6 +47,8 @@ workflow JoinRawCalls {
     RuntimeAttr? runtime_attr_prepare_truth
     RuntimeAttr? runtime_attr_svcluster
     RuntimeAttr? runtime_override_concat_vcfs_pesr
+
+    Array[File]? NONE_ARRAY_  # Do not assign
   }
 
   call tasks_cluster.CreatePloidyTableFromPed {
@@ -61,8 +63,27 @@ workflow JoinRawCalls {
       runtime_attr_override=runtime_attr_create_ploidy
   }
 
-  Array[Array[File]] vcf_matrix = transpose(select_all([clustered_depth_vcfs, clustered_dragen_vcfs, clustered_manta_vcfs, clustered_melt_vcfs, clustered_scramble_vcfs, clustered_wham_vcfs]))
-  Array[Array[File]] vcf_index_matrix = transpose(select_all([clustered_depth_vcf_indexes, clustered_dragen_vcf_indexes, clustered_manta_vcf_indexes, clustered_melt_vcf_indexes, clustered_scramble_vcf_indexes, clustered_wham_vcf_indexes]))
+  # Handle zero-length arrays
+  Array[File]? clustered_depth_vcfs_ = if (defined(clustered_depth_vcfs) && length(select_first([clustered_depth_vcfs])) > 0) then clustered_depth_vcfs else NONE_ARRAY_
+  Array[File]? clustered_depth_vcf_indexes_ = if (defined(clustered_depth_vcf_indexes) && length(select_first([clustered_depth_vcf_indexes])) > 0) then clustered_depth_vcf_indexes else NONE_ARRAY_
+
+  Array[File]? clustered_dragen_vcfs_ = if (defined(clustered_dragen_vcfs) && length(select_first([clustered_dragen_vcfs])) > 0) then clustered_dragen_vcfs else NONE_ARRAY_
+  Array[File]? clustered_dragen_vcf_indexes_ = if (defined(clustered_dragen_vcf_indexes) && length(select_first([clustered_dragen_vcf_indexes])) > 0) then clustered_dragen_vcf_indexes else NONE_ARRAY_
+
+  Array[File]? clustered_manta_vcfs_ = if (defined(clustered_manta_vcfs) && length(select_first([clustered_manta_vcfs])) > 0) then clustered_manta_vcfs else NONE_ARRAY_
+  Array[File]? clustered_manta_vcf_indexes_ = if (defined(clustered_manta_vcf_indexes) && length(select_first([clustered_manta_vcf_indexes])) > 0) then clustered_manta_vcf_indexes else NONE_ARRAY_
+
+  Array[File]? clustered_melt_vcfs_ = if (defined(clustered_melt_vcfs) && length(select_first([clustered_melt_vcfs])) > 0) then clustered_melt_vcfs else NONE_ARRAY_
+  Array[File]? clustered_melt_vcf_indexes_ = if (defined(clustered_melt_vcf_indexes) && length(select_first([clustered_melt_vcf_indexes])) > 0) then clustered_melt_vcf_indexes else NONE_ARRAY_
+
+  Array[File]? clustered_scramble_vcfs_ = if (defined(clustered_scramble_vcfs) && length(select_first([clustered_scramble_vcfs])) > 0) then clustered_scramble_vcfs else NONE_ARRAY_
+  Array[File]? clustered_scramble_vcf_indexes_ = if (defined(clustered_scramble_vcf_indexes) && length(select_first([clustered_scramble_vcf_indexes])) > 0) then clustered_scramble_vcf_indexes else NONE_ARRAY_
+
+  Array[File]? clustered_wham_vcfs_ = if (defined(clustered_wham_vcfs) && length(select_first([clustered_wham_vcfs])) > 0) then clustered_wham_vcfs else NONE_ARRAY_
+  Array[File]? clustered_wham_vcf_indexes_ = if (defined(clustered_wham_vcf_indexes) && length(select_first([clustered_wham_vcf_indexes])) > 0) then clustered_wham_vcf_indexes else NONE_ARRAY_
+
+  Array[Array[File]] vcf_matrix = transpose(select_all([clustered_depth_vcfs_, clustered_dragen_vcfs_, clustered_manta_vcfs_, clustered_melt_vcfs_, clustered_scramble_vcfs_, clustered_wham_vcfs_]))
+  Array[Array[File]] vcf_index_matrix = transpose(select_all([clustered_depth_vcf_indexes_, clustered_dragen_vcf_indexes_, clustered_manta_vcf_indexes_, clustered_melt_vcf_indexes_, clustered_scramble_vcf_indexes_, clustered_wham_vcf_indexes_]))
   scatter (i in range(length(vcf_matrix))) {
     call tasks_cohort.ConcatVcfs as ConcatInputVcfs {
       input:


### PR DESCRIPTION
### Updates
* Handle arrays of length zero as clustered VCF inputs to JoinRawCalls. There are 6 different clustered VCF inputs for the different algorithms, and our input configurations provide all of them so that users don't have to edit them depending on which callers were used. But Terra translates an empty column to an empty array `[]` rather than a null value, so merely using `select_all` doesn't produce the expected results. This causes JoinRawCalls to fail with the default input configuration
* Add clustered MELT VCFs to the default input configuration - although MELT is now deprecated, users processing legacy data with MELT calls should include them when running JoinRawCalls

### Testing
* Validated WDLs and JSONs with womtool and Terra validation script
* Ran JoinRawCalls on one cohort, pointing to empty columns for DRAGEN and MELT VCFs. The run succeeded - but note that the cohort was only one batch, so I am relying on previous testing for the success of the multi-batch logic

### Notes
* Need to revert dockstore.yml before merging
* Need to merge before next release