### PR TITLE
Undo dockstore sync of GenotypeComplexVariants

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -132,7 +132,6 @@ workflows:
     filters:
       branches:
         - main
-        - kj_cpx_cutoff_modification
       tags:
         - /.*/
 


### PR DESCRIPTION
https://github.com/broadinstitute/gatk-sv/pull/850 was merged without removing the syncing of the branch to dockstore - this PR intends to undo this.