### PR TITLE
Add Google Analytics 4

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -39,6 +39,10 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        gtag: {
+          trackingID: 'G-9DQEYKHD1M',
+          anonymizeIP: true,
+        },
       }),
     ],
   ],

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.5.2",
+    "@docusaurus/plugin-google-gtag": "^3.9.2",
     "@docusaurus/preset-classic": "^3.5.2",
     "@docusaurus/theme-mermaid": "^3.5.2",
     "@mdx-js/react": "^3.0.0",


### PR DESCRIPTION
Configure website integration with Google Analytics 4 for traffic stats. 