### PR TITLE
Add gnomAD v4 benchmarking set to resources json and input configs

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/FilterGenotypes.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/FilterGenotypes.json.tmpl
@@ -24,6 +24,7 @@
   "FilterGenotypes.primary_contigs_fai": "${workspace.primary_contigs_fai}",
   "FilterGenotypes.site_level_comparison_datasets": [
     {{ reference_resources.ccdg_abel_site_level_benchmarking_dataset | tojson }},
+    {{ reference_resources.gnomad_v4_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.gnomad_v2_collins_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.hgsv_byrska_bishop_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.thousand_genomes_site_level_benchmarking_dataset | tojson }}

--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MainVcfQc.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/MainVcfQc.json.tmpl
@@ -3,6 +3,7 @@
 
   "MainVcfQc.site_level_comparison_datasets": [
     {{ reference_resources.ccdg_abel_site_level_benchmarking_dataset | tojson }},
+    {{ reference_resources.gnomad_v4_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.gnomad_v2_collins_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.hgsv_byrska_bishop_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.thousand_genomes_site_level_benchmarking_dataset | tojson }}

--- a/inputs/templates/test/FilterGenotypes/FilterGenotypes.fixed_cutoffs.json.tmpl
+++ b/inputs/templates/test/FilterGenotypes/FilterGenotypes.fixed_cutoffs.json.tmpl
@@ -24,6 +24,7 @@
   "FilterGenotypes.primary_contigs_fai": {{ reference_resources.primary_contigs_fai | tojson }},
   "FilterGenotypes.site_level_comparison_datasets": [
     {{ reference_resources.ccdg_abel_site_level_benchmarking_dataset | tojson }},
+    {{ reference_resources.gnomad_v4_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.gnomad_v2_collins_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.hgsv_byrska_bishop_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.thousand_genomes_site_level_benchmarking_dataset | tojson }}

--- a/inputs/templates/test/FilterGenotypes/FilterGenotypes.optimize_cutoffs.json.tmpl
+++ b/inputs/templates/test/FilterGenotypes/FilterGenotypes.optimize_cutoffs.json.tmpl
@@ -24,6 +24,7 @@
   "FilterGenotypes.ped_file": {{ test_batch.ped_file | tojson }},
   "FilterGenotypes.site_level_comparison_datasets": [
     {{ reference_resources.ccdg_abel_site_level_benchmarking_dataset | tojson }},
+    {{ reference_resources.gnomad_v4_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.gnomad_v2_collins_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.hgsv_byrska_bishop_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.thousand_genomes_site_level_benchmarking_dataset | tojson }}

--- a/inputs/templates/test/MainVcfQc/MainVcfQc.json.tmpl
+++ b/inputs/templates/test/MainVcfQc/MainVcfQc.json.tmpl
@@ -3,6 +3,7 @@
 
   "MainVcfQc.site_level_comparison_datasets": [
     {{ reference_resources.ccdg_abel_site_level_benchmarking_dataset | tojson }},
+    {{ reference_resources.gnomad_v4_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.gnomad_v2_collins_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.hgsv_byrska_bishop_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.thousand_genomes_site_level_benchmarking_dataset | tojson }}

--- a/inputs/templates/test/MainVcfQc/MainVcfQc.per_sample_benchmark.json.tmpl
+++ b/inputs/templates/test/MainVcfQc/MainVcfQc.per_sample_benchmark.json.tmpl
@@ -3,6 +3,7 @@
 
   "MainVcfQc.site_level_comparison_datasets": [
     {{ reference_resources.ccdg_abel_site_level_benchmarking_dataset | tojson }},
+    {{ reference_resources.gnomad_v4_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.gnomad_v2_collins_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.hgsv_byrska_bishop_site_level_benchmarking_dataset | tojson }},
     {{ reference_resources.thousand_genomes_site_level_benchmarking_dataset | tojson }}

--- a/inputs/values/resources_hg38.json
+++ b/inputs/values/resources_hg38.json
@@ -82,6 +82,7 @@
   "recalibrate_gq_genome_track_umap24_index": "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38_umap_s24.bed.gz.tbi",
 
   "ccdg_abel_site_level_benchmarking_dataset" : ["CCDG_abel", "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/CCDG_Abel"],
+  "gnomad_v4_site_level_benchmarking_dataset": ["gnomAD_v4", "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/gnomAD_v4"],
   "gnomad_v2_collins_sample_level_benchmarking_dataset": ["gnomAD_v2_Collins", "gs://gatk-sv-resources-secure/resources/hg38_benchmarking/gnomAD_v2_Collins_perSample.tar.gz"],
   "gnomad_v2_collins_site_level_benchmarking_dataset" : ["gnomAD_v2_Collins", "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/gnomAD_v2_Collins"],
   "hgsv_byrska_bishop_sample_level_benchmarking_dataset": ["HGSV_ByrskaBishop", "gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/HGSV_ByrskaBishop_GATKSV_perSample.tar.gz"],


### PR DESCRIPTION
### Updates
This PR adds the gnomAD v4 site-level benchmarking dataset to the resources JSON and to the input configurations for MainVcfQc and FilterGenotypes.
* The benchmarking set, originally created by Xuefang, was moved to `gs://gatk-sv-resources-public/hg38/v0/sv-resources/resources/v1/gnomAD_v4` to match the location of other benchmarking datasets
* The names of the benchmarking files were updated to include `.SV.` like previous datasets, as the `.ALL` substring is required by the `MainVcfQc.SanitizeOutputs` task

### Testing
* Tested MainVcfQc on reference panel with new inputs and checked the QC tarball for gnomAD-v4 benchmarking plots in the main plots directory

### Notes
* This PR does not include a sample-level benchmarking dataset for gnomAD-v4 as I am not aware of one
* We should standardize the process to generate new benchmarking sets, or at the very least document unexpected requirements like the file naming scheme