### PR TITLE
Trivial change to trigger docker build

### DIFF
--- a/dockerfiles/sv-pipeline/Dockerfile
+++ b/dockerfiles/sv-pipeline/Dockerfile
@@ -65,7 +65,6 @@ RUN plink2 || true
 # the command should be installed, but has no help mode, and outputs an error if not used on data
 #RUN king
 
-
 # Compile and test classes from sv-pipeline
 # -Compile StitchFragmentedCNVs Java program
 # -Compile StitchFragmentedCNVs unit tests


### PR DESCRIPTION
Deployment of #894 was rejected due to an issue with the docker json. This PR follows #901 up with a small change to trigger a fresh Docker build.