### PR TITLE
Fix file path for binned CN plots in sample QC notebook

### DIFF
--- a/scripts/notebooks/SampleQC.ipynb
+++ b/scripts/notebooks/SampleQC.ipynb
@@ -1230,7 +1230,7 @@
     "    # Log batch-specific information\n",
     "    image_paths = {}\n",
     "    for batch_id, sample_ids in failed_batches.items():\n",
-    "        image_file_path = str(batch_id) + \"_ploidy/ploidy_est/estimated_CN_per_bin.all_samples.\" + str(chromosome).split(\"_\")[0] + \".png\"\n",
+    "        image_file_path = os.path.join(TLD_PATH, \"ploidy\", str(batch_id) + \"_ploidy/ploidy_est/estimated_CN_per_bin.all_samples.\" + str(chromosome).split(\"_\")[0] + \".png\")\n",
     "        image_paths[batch_id] = image_file_path\n",
     "    \n",
     "    if (display):\n",


### PR DESCRIPTION
### Updates

In #858 I moved the location of the ploidy data in the sample QC notebook, but missed a spot that needed to be changed to match. This PR fixes this oversight.

### Testing

Tested viewing binned autosomal CN plots with updated code with reference panel data.