### PR TITLE
Replace root with an env variable for the `output_*` and `wd_*` directories in sv-shell 

### DIFF
--- a/src/sv_shell/annotate_vcf.sh
+++ b/src/sv_shell/annotate_vcf.sh
@@ -24,7 +24,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_annotate_vcf_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_annotate_vcf_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -36,7 +36,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_annotate_vcf_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_annotate_vcf_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 echo "Annotate VCF Working directory: ${working_dir}"
@@ -84,7 +84,7 @@ echo "JVM memory: $JVM_MAX_MEM"
 # ---------------------------------------------------------------------------------------------------------------------
 # TODO: assuming you always provide external_af_ref_bed, this is an optional input and is currently configured
 
-split_ref_bed_working_dir=$(mktemp -d /wd_split_ref_bed_XXXXXXXX)
+split_ref_bed_working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_split_ref_bed_XXXXXXXX)
 split_ref_bed_working_dir="$(realpath ${split_ref_bed_working_dir})"
 cd "${split_ref_bed_working_dir}"
 

--- a/src/sv_shell/batch_evidence_merging.sh
+++ b/src/sv_shell/batch_evidence_merging.sh
@@ -93,7 +93,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_batch_evidence_merging_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_batch_evidence_merging_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -105,7 +105,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_batch_evidence_merging_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_batch_evidence_merging_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/cluster_batch.sh
+++ b/src/sv_shell/cluster_batch.sh
@@ -13,7 +13,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_cluster_batch_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_cluster_batch_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -25,7 +25,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_cluster_batch_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_cluster_batch_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 
@@ -118,7 +118,7 @@ if [ -n "${dragen_vcf_tar}" ]; then
   echo "Running PE/SR clustering on Dragen VCF."
 
   cd "${working_dir}"
-  dragen_pesr_output_dir=$(mktemp -d "/output_dragen_pesr_XXXXXXXX")
+  dragen_pesr_output_dir=$(mktemp -d "${SV_SHELL_BASE_DIR}/output_dragen_pesr_XXXXXXXX")
   dragen_pesr_output_dir="$(realpath ${dragen_pesr_output_dir})"
   dragen_pesr_inputs_json="$(realpath "${dragen_pesr_output_dir}/dragen_pesr_inputs.json")"
   dragen_pesr_output_json="$(realpath "${dragen_pesr_output_dir}/dragen_pesr_output.json")"
@@ -177,7 +177,7 @@ if [ -n "${manta_vcf_tar}" ]; then
   echo "Running PE/SR clustering on Manta VCF."
 
   cd "${working_dir}"
-  manta_pesr_output_dir=$(mktemp -d "/output_manta_pesr_XXXXXXXX")
+  manta_pesr_output_dir=$(mktemp -d "${SV_SHELL_BASE_DIR}/output_manta_pesr_XXXXXXXX")
   manta_pesr_output_dir="$(realpath ${manta_pesr_output_dir})"
   manta_pesr_inputs_json="$(realpath "${manta_pesr_output_dir}/manta_pesr_inputs.json")"
   manta_pesr_output_json="$(realpath "${manta_pesr_output_dir}/manta_pesr_output.json")"
@@ -236,7 +236,7 @@ if [ -n "${wham_vcf_tar}" ]; then
   echo "Running PE/SR clustering on Wham VCF."
 
   cd "${working_dir}"
-  wham_pesr_output_dir=$(mktemp -d "/output_wham_pesr_XXXXXXXX")
+  wham_pesr_output_dir=$(mktemp -d "${SV_SHELL_BASE_DIR}/output_wham_pesr_XXXXXXXX")
   wham_pesr_output_dir="$(realpath ${wham_pesr_output_dir})"
   wham_pesr_inputs_json="$(realpath "${wham_pesr_output_dir}/wham_pesr_inputs.json")"
   wham_pesr_output_json="$(realpath "${wham_pesr_output_dir}/wham_pesr_output.json")"
@@ -295,7 +295,7 @@ if [ -n "${scramble_vcf_tar}" ]; then
   echo "Running PE/SR clustering on Scramble VCF."
 
   cd "${working_dir}"
-  scramble_pesr_output_dir=$(mktemp -d "/output_scramble_pesr_XXXXXXXX")
+  scramble_pesr_output_dir=$(mktemp -d "${SV_SHELL_BASE_DIR}/output_scramble_pesr_XXXXXXXX")
   scramble_pesr_output_dir="$(realpath ${scramble_pesr_output_dir})"
   scramble_pesr_inputs_json="$(realpath "${scramble_pesr_output_dir}/scramble_pesr_inputs.json")"
   scramble_pesr_output_json="$(realpath "${scramble_pesr_output_dir}/scramble_pesr_output.json")"
@@ -351,7 +351,7 @@ fi
 echo "Running cluster depth"
 
 cd "${working_dir}"
-cluster_depth_output_dir=$(mktemp -d "/output_cluster_depth_XXXXXXXX")
+cluster_depth_output_dir=$(mktemp -d "${SV_SHELL_BASE_DIR}/output_cluster_depth_XXXXXXXX")
 cluster_depth_output_dir="$(realpath ${cluster_depth_output_dir})"
 cluster_depth_inputs_json="$(realpath "${cluster_depth_output_dir}/cluster_depth_inputs.json")"
 cluster_depth_output_json="$(realpath "${cluster_depth_output_dir}/cluster_depth_output.json")"

--- a/src/sv_shell/cluster_depth.sh
+++ b/src/sv_shell/cluster_depth.sh
@@ -12,7 +12,7 @@ function ShardBedThenConvertToVcf()
   cd "${working_dir}"
 
   # Task: ScatterCompressedBedOmitHeaders
-  shard_bed_convert_vcf_working_dir=$(mktemp -d /wd_shard_bed_convert_vcf_XXXXXXXX)
+  shard_bed_convert_vcf_working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_shard_bed_convert_vcf_XXXXXXXX)
   shard_bed_convert_vcf_working_dir="$(realpath ${shard_bed_convert_vcf_working_dir})"
   cd "${shard_bed_convert_vcf_working_dir}"
   n_digits=6
@@ -68,7 +68,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_cluster_depth_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_cluster_depth_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -80,7 +80,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_cluster_depth_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_cluster_depth_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 
@@ -135,12 +135,12 @@ for contig in "${contigs[@]}"; do
   echo "Starting to cluster ${contig}."
 
   cd "${working_dir}"
-  cluster_contig_output_dir=$(mktemp -d "/output_cluster_contig_${contig}_XXXXXXXX")
+  cluster_contig_output_dir=$(mktemp -d "${SV_SHELL_BASE_DIR}/output_cluster_contig_${contig}_XXXXXXXX")
   cluster_contig_output_dir="$(realpath ${cluster_contig_output_dir})"
   contig_cluster_inputs_json="$(realpath "${cluster_contig_output_dir}/contig_cluster_inputs.json")"
   contig_cluster_output_json="$(realpath "${cluster_contig_output_dir}/contig_cluster_output.json")"
 
-  cluster_contig_wd_dir=$(mktemp -d "/wd_cluster_contig_${contig}_XXXXXXXX")
+  cluster_contig_wd_dir=$(mktemp -d "${SV_SHELL_BASE_DIR}/wd_cluster_contig_${contig}_XXXXXXXX")
   cluster_contig_wd_dir="$(realpath ${cluster_contig_wd_dir})"
 
   jq -n \
@@ -225,7 +225,7 @@ done
 # as it only includes the execution path/args used for this Depth clustering task.
 
 cd "${working_dir}"
-concat_vcf_working_dir=$(mktemp -d /wd_ConcatVcfs_XXXXXXXX)
+concat_vcf_working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_ConcatVcfs_XXXXXXXX)
 concat_vcf_working_dir="$(realpath ${concat_vcf_working_dir})"
 cd "${concat_vcf_working_dir}"
 

--- a/src/sv_shell/cluster_pesr.sh
+++ b/src/sv_shell/cluster_pesr.sh
@@ -36,7 +36,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_cluster_pesr_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_cluster_pesr_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -48,7 +48,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_cluster_pesr_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_cluster_pesr_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 
@@ -121,7 +121,7 @@ for contig in "${contigs[@]}"; do
 
   # SVCluster
   # -------------------------------------------------------------------------------------------------------------------
-  sv_cluster_output_dir=$(mktemp -d /output_sv_cluster_XXXXXXXX)
+  sv_cluster_output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_sv_cluster_XXXXXXXX)
   sv_cluster_output_dir="$(realpath ${sv_cluster_output_dir})"
   sv_cluster_inputs_json="$(realpath "${sv_cluster_output_dir}/sv_cluster_inputs.json")"
   sv_cluster_outputs_json="$(realpath "${sv_cluster_output_dir}/sv_cluster_outputs.json")"
@@ -165,7 +165,7 @@ for contig in "${contigs[@]}"; do
   # ExcludeIntervalsByEndpoints
   # -------------------------------------------------------------------------------------------------------------------
   # Remove variants from VCF that overlap with regions in the exclude_intervals file.
-  working_dir=$(mktemp -d /wd_ExcludeIntervalsByEndpoints_XXXXXXXX)
+  working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_ExcludeIntervalsByEndpoints_XXXXXXXX)
   working_dir="$(realpath ${working_dir})"
   cd "${working_dir}"
   output_prefix="${batch}.cluster_batch.${caller}.${contig}.exclude_intervals"
@@ -179,7 +179,7 @@ for contig in "${contigs[@]}"; do
 
   # GatkToSvtkVcf
   # -------------------------------------------------------------------------------------------------------------------
-  working_dir=$(mktemp -d /wd_GatkToSvtkVcf_XXXXXXXX)
+  working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_GatkToSvtkVcf_XXXXXXXX)
   working_dir="$(realpath ${working_dir})"
   cd "${working_dir}"
   output_prefix="${batch}.cluster_batch.${caller}.${contig}.svtk_formatted"
@@ -200,7 +200,7 @@ done
 # Note the following is a simplified implementation than the WDL-based
 # as it only includes the execution path/args used for this PE/SR clustering task.
 
-working_dir=$(mktemp -d /wd_ConcatVcfs_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_ConcatVcfs_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/cnmops.sh
+++ b/src/sv_shell/cnmops.sh
@@ -132,7 +132,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_batch_evidence_merging_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_batch_evidence_merging_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -144,7 +144,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_batch_evidence_merging_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_batch_evidence_merging_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 echo "cnMOPS Working directory: ${working_dir}"
@@ -173,14 +173,14 @@ male_r2_gff=()
 allos=($(awk '{print $1}' "${allo_file}"))
 for allo in "${allos[@]}"; do
   # Male R2
-  working_dir=$(mktemp -d /wd_cn_sample_normal_${allo}_${r2}_XXXXXXXX)
+  working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_cn_sample_normal_${allo}_${r2}_XXXXXXXX)
   working_dir="$(realpath ${working_dir})"
   cd "${working_dir}"
   CNSampleNormal "${allo}" "1" "${r2}"
   male_r2_gff+=("${working_dir}/calls/cnMOPS.cnMOPS.gff")
 
   # Male R1
-  working_dir=$(mktemp -d /wd_cn_sample_normal_${allo}_${r1}_XXXXXXXX)
+  working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_cn_sample_normal_${allo}_${r1}_XXXXXXXX)
   working_dir="$(realpath ${working_dir})"
   cd "${working_dir}"
   CNSampleNormal "${allo}" "1" "${r1}"
@@ -192,14 +192,14 @@ normal_r2_gff=()
 chroms=($(awk '{print $1}' "${chrom_file}"))
 for chrom in "${chroms[@]}"; do
   # Normal R2
-  working_dir=$(mktemp -d /wd_cn_sample_normal_${chrom}_${r2}_XXXXXXXX)
+  working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_cn_sample_normal_${chrom}_${r2}_XXXXXXXX)
   working_dir="$(realpath ${working_dir})"
   cd "${working_dir}"
   CNSampleNormal "${chrom}" "normal" "${r2}"
   normal_r2_gff+=("${working_dir}/calls/cnMOPS.cnMOPS.gff")
 
   # Normal R1
-  working_dir=$(mktemp -d /wd_cn_sample_normal_${chrom}_${r1}_XXXXXXXX)
+  working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_cn_sample_normal_${chrom}_${r1}_XXXXXXXX)
   working_dir="$(realpath ${working_dir})"
   cd "${working_dir}"
   CNSampleNormal "${chrom}" "normal" "${r1}"
@@ -208,14 +208,14 @@ done
 
 
 # Female R2
-working_dir=$(mktemp -d /wd_cn_sample_normal_chrX_${r2}_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_cn_sample_normal_chrX_${r2}_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 CNSampleNormal "chrX" "2" "${r2}"
 female_r2_gff=("${working_dir}/calls/cnMOPS.cnMOPS.gff")
 
 # Female R1
-working_dir=$(mktemp -d /wd_cn_sample_normal_chrX_${r1}_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_cn_sample_normal_chrX_${r1}_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 CNSampleNormal "chrX" "2" "${r1}"
@@ -223,7 +223,7 @@ female_r1_gff=("${working_dir}/calls/cnMOPS.cnMOPS.gff")
 
 
 # CleanCNMops
-working_dir=$(mktemp -d /wd_clean_cnmops_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_clean_cnmops_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/cnv_germline_case.sh
+++ b/src/sv_shell/cnv_germline_case.sh
@@ -14,7 +14,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_cnv_germline_case_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_cnv_germline_case_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -26,7 +26,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_cnv_germline_case_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_cnv_germline_case_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 
@@ -69,7 +69,7 @@ set +u
 conda activate gatk
 set -u
 
-DetermineGermlineContigPloidyCaseMode_wd=$(mktemp -d /wd_DetermineGermlineContigPloidyCaseMode_XXXXXXXX)
+DetermineGermlineContigPloidyCaseMode_wd=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_DetermineGermlineContigPloidyCaseMode_XXXXXXXX)
 DetermineGermlineContigPloidyCaseMode_wd="$(realpath ${DetermineGermlineContigPloidyCaseMode_wd})"
 cd "${DetermineGermlineContigPloidyCaseMode_wd}"
 
@@ -116,7 +116,7 @@ gcnv_output_jsons=()
 
 for (( scatter_index=0; scatter_index<${#gcnv_model_tars[@]}; scatter_index++ )); do
 
-  gcnv_case_scatter_wd=$(mktemp -d "/wd_germline_cnv_caller_case_mode_scatter_${scatter_index}_XXXXXXXX")
+  gcnv_case_scatter_wd=$(mktemp -d "${SV_SHELL_BASE_DIR}/wd_germline_cnv_caller_case_mode_scatter_${scatter_index}_XXXXXXXX")
   gcnv_case_scatter_wd="$(realpath ${gcnv_case_scatter_wd})"
   gcnv_case_shard_inputs_json="${gcnv_case_scatter_wd}/inputs.json"
   gcnv_case_shard_outputs_json="${gcnv_case_scatter_wd}/outputs.json"
@@ -212,7 +212,7 @@ PostprocessGermlineCNVCalls_outputs_jsons=()
 num_samples=${#counts[@]}
 for (( sample_index=0; sample_index<num_samples; sample_index++ )); do
 
-  PostprocessGermlineCNVCalls_wd=$(mktemp -d "/wd_PostprocessGermlineCNVCalls_${sample_index}_XXXXXXXX")
+  PostprocessGermlineCNVCalls_wd=$(mktemp -d "${SV_SHELL_BASE_DIR}/wd_PostprocessGermlineCNVCalls_${sample_index}_XXXXXXXX")
   PostprocessGermlineCNVCalls_wd="$(realpath ${PostprocessGermlineCNVCalls_wd})"
   PostprocessGermlineCNVCalls_inputs_json="${PostprocessGermlineCNVCalls_wd}/inputs.json"
   PostprocessGermlineCNVCalls_outputs_json="${PostprocessGermlineCNVCalls_wd}/outputs.json"

--- a/src/sv_shell/collect_counts.sh
+++ b/src/sv_shell/collect_counts.sh
@@ -28,9 +28,9 @@ echo "ref_fasta_dict:        " "${ref_fasta_dict}"
 echo "gatk4_jar_override:    " "${gatk4_jar_override}"
 echo "disabled_read_filters: " "${disabled_read_filters}"
 
-working_dir=$(mktemp -d /wd_collect_counts_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_collect_counts_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
-output_dir=$(mktemp -d /output_collect_counts_XXXXXXXX)
+output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_collect_counts_XXXXXXXX)
 output_dir="$(realpath ${output_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/collect_sv_evidence.sh
+++ b/src/sv_shell/collect_sv_evidence.sh
@@ -21,9 +21,9 @@ primary_contigs_list="${12:-}"
 gatk_jar_override="${13:-/root/gatk.jar}"
 command_mem_mb=${14:-3250}
 
-working_dir=$(mktemp -d /wd_collect_sv_evidence_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_collect_sv_evidence_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
-output_dir=$(mktemp -d /output_collect_sv_evidence_XXXXXXXX)
+output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_collect_sv_evidence_XXXXXXXX)
 output_dir="$(realpath ${output_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/combine_batches.sh
+++ b/src/sv_shell/combine_batches.sh
@@ -13,7 +13,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_combine_batches_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_combine_batches_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -25,7 +25,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_combine_batches_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_combine_batches_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 
@@ -131,7 +131,7 @@ reformatted_vcfs_idx_array=()
 for vcf in "${all_vcfs[@]}"; do
   cd "${working_dir}"
 
-  format_vcf_working_dir=$(mktemp -d /wd_format_vcf_XXXXXXXX)
+  format_vcf_working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_format_vcf_XXXXXXXX)
   format_vcf_working_dir="$(realpath ${format_vcf_working_dir})"
   cd "${format_vcf_working_dir}"
 
@@ -158,7 +158,7 @@ done
 # ---------------------------------------------------------------------------------------------------------------------
 
 cd "${working_dir}"
-join_vcfs_output_dir=$(mktemp -d /output_join_vcfs_XXXXXXXX)
+join_vcfs_output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_join_vcfs_XXXXXXXX)
 join_vcfs_output_dir="$(realpath ${join_vcfs_output_dir})"
 join_vcfs_inputs_json="$(realpath "${join_vcfs_output_dir}/sv_cluster_inputs.json")"
 join_vcfs_outputs_json="$(realpath "${join_vcfs_output_dir}/sv_cluster_outputs.json")"
@@ -215,7 +215,7 @@ echo "Successfully finished Join VCFs clustering."
 # ---------------------------------------------------------------------------------------------------------------------
 
 cd "${working_dir}"
-cluster_sites_output_dir=$(mktemp -d /output_cluster_sites_XXXXXXXX)
+cluster_sites_output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_cluster_sites_XXXXXXXX)
 cluster_sites_output_dir="$(realpath ${cluster_sites_output_dir})"
 cluster_sites_inputs_json="$(realpath "${cluster_sites_output_dir}/sv_cluster_inputs.json")"
 cluster_sites_outputs_json="$(realpath "${cluster_sites_output_dir}/sv_cluster_outputs.json")"
@@ -288,7 +288,7 @@ done
 # ---------------------------------------------------------------------------------------------------------------------
 
 cd "${working_dir}"
-grouped_sv_cluster_p1_wd=$(mktemp -d /wd_grouped_sv_cluster_p1_XXXXXXXX)
+grouped_sv_cluster_p1_wd=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_grouped_sv_cluster_p1_XXXXXXXX)
 grouped_sv_cluster_p1_wd="$(realpath ${grouped_sv_cluster_p1_wd})"
 cd "${grouped_sv_cluster_p1_wd}"
 
@@ -319,7 +319,7 @@ echo "Successfully finished grouped SV cluster part 1."
 # ---------------------------------------------------------------------------------------------------------------------
 
 cd "${working_dir}"
-grouped_sv_cluster_p2_wd=$(mktemp -d /wd_grouped_sv_cluster_p2_XXXXXXXX)
+grouped_sv_cluster_p2_wd=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_grouped_sv_cluster_p2_XXXXXXXX)
 grouped_sv_cluster_p2_wd="$(realpath ${grouped_sv_cluster_p2_wd})"
 cd "${grouped_sv_cluster_p2_wd}"
 

--- a/src/sv_shell/condense_read_counts.sh
+++ b/src/sv_shell/condense_read_counts.sh
@@ -14,7 +14,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_condense_read_counts_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_condense_read_counts_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -26,7 +26,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_condense_read_counts_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_condense_read_counts_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 echo "Condense Read Counts Working directory: ${working_dir}"

--- a/src/sv_shell/evidence_qc.sh
+++ b/src/sv_shell/evidence_qc.sh
@@ -13,7 +13,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_evidence_qc_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_evidence_qc_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -25,7 +25,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_evidence_qc_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_evidence_qc_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/filter_genotypes.sh
+++ b/src/sv_shell/filter_genotypes.sh
@@ -15,7 +15,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_filter_genotypes_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_filter_genotypes_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -27,7 +27,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_filter_genotypes_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_filter_genotypes_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 echo "Filter Genotypes working directory: ${working_dir}"

--- a/src/sv_shell/gather_batch_evidence.sh
+++ b/src/sv_shell/gather_batch_evidence.sh
@@ -20,7 +20,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_gather_batch_evidence_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_gather_batch_evidence_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -32,7 +32,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_gather_batch_evidence_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_gather_batch_evidence_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/gather_sample_evidence.sh
+++ b/src/sv_shell/gather_sample_evidence.sh
@@ -27,7 +27,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_gather_sample_evidence_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_gather_sample_evidence_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -39,7 +39,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_gather_sample_evidence_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_gather_sample_evidence_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/genotype_complex_variants.sh
+++ b/src/sv_shell/genotype_complex_variants.sh
@@ -14,7 +14,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_genotype_complex_variants_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_genotype_complex_variants_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -26,7 +26,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_genotype_complex_variants_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_genotype_complex_variants_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 echo "Genotype complex variants working directory: ${working_dir}"

--- a/src/sv_shell/germline_cnv_caller_case_mode.sh
+++ b/src/sv_shell/germline_cnv_caller_case_mode.sh
@@ -58,7 +58,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_germline_cnv_caller_case_mode_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_germline_cnv_caller_case_mode_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -70,7 +70,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_germline_cnv_caller_case_mode_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_germline_cnv_caller_case_mode_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/join_raw_calls.sh
+++ b/src/sv_shell/join_raw_calls.sh
@@ -14,7 +14,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_join_raw_calls_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_join_raw_calls_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -26,7 +26,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_join_raw_calls_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_join_raw_calls_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 
@@ -115,12 +115,12 @@ tabix "${FormatVcfForGatk_gatk_formatted_vcf}"
 # SVCluster
 # ---------------------------------------------------------------------------------------------------------------------
 
-sv_cluster_output_dir=$(mktemp -d "/output_sv_cluster_XXXXXXXX")
+sv_cluster_output_dir=$(mktemp -d "${SV_SHELL_BASE_DIR}/output_sv_cluster_XXXXXXXX")
 sv_cluster_output_dir="$(realpath ${sv_cluster_output_dir})"
 sv_cluster_inputs_json="$(realpath "${sv_cluster_output_dir}/sv_cluster_inputs.json")"
 sv_cluster_output_json="$(realpath "${sv_cluster_output_dir}/sv_cluster_output.json")"
 
-sv_cluster_wd_dir=$(mktemp -d "/wd_sv_cluster_XXXXXXXX")
+sv_cluster_wd_dir=$(mktemp -d "${SV_SHELL_BASE_DIR}/wd_sv_cluster_XXXXXXXX")
 sv_cluster_wd_dir="$(realpath ${sv_cluster_wd_dir})"
 
 jq -n \

--- a/src/sv_shell/make_bincov_matrix.sh
+++ b/src/sv_shell/make_bincov_matrix.sh
@@ -28,7 +28,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_make_bincov_matrix_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_make_bincov_matrix_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -40,7 +40,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_make_bincov_matrix_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_make_bincov_matrix_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/median_cov.sh
+++ b/src/sv_shell/median_cov.sh
@@ -14,7 +14,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_median_cov_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_median_cov_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -26,7 +26,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_median_cov_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_median_cov_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 echo "Median coverage Working directory: ${working_dir}"

--- a/src/sv_shell/merge_depth.sh
+++ b/src/sv_shell/merge_depth.sh
@@ -66,7 +66,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_merge_depth_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_merge_depth_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -78,7 +78,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_merge_depth_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_merge_depth_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 echo "Merge Depth Working directory: ${working_dir}"
@@ -99,7 +99,7 @@ defragment_max_dist=$(jq -r '.defragment_max_dist // ""' "$input_json")
 # Merge Sample DEL
 merged_del_beds=()
 for sample in "${samples[@]}"; do
-  working_dir=$(mktemp -d /wd_merge_sample_del_XXXXXXXX)
+  working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_merge_sample_del_XXXXXXXX)
   working_dir="$(realpath ${working_dir})"
   cd "${working_dir}"
 
@@ -111,7 +111,7 @@ done
 # Merge Sample DUP
 merged_dup_bed=()
 for sample in "${samples[@]}"; do
-  working_dir=$(mktemp -d /wd_merge_sample_dup_XXXXXXXX)
+  working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_merge_sample_dup_XXXXXXXX)
   working_dir="$(realpath ${working_dir})"
   cd "${working_dir}"
 
@@ -121,7 +121,7 @@ done
 
 
 # Merge DEL
-working_dir=$(mktemp -d /wd_merge_del_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_merge_del_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 # note that "merged_del_beds" in the following is passing the array, not a string.
@@ -131,7 +131,7 @@ merge_set_del_idx="${working_dir}/${batch}.DEL.bed.gz.tbi"
 
 
 # Merge DUP
-working_dir=$(mktemp -d /wd_merge_dup_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_merge_dup_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 # note that "merged_del_beds" in the following is passing the array, not a string.

--- a/src/sv_shell/ploidy_estimation.sh
+++ b/src/sv_shell/ploidy_estimation.sh
@@ -13,7 +13,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_ploidy_estimation_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_ploidy_estimation_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -25,7 +25,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_ploidy_estimation_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_ploidy_estimation_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/post_processing_germline_cnv_calls.sh
+++ b/src/sv_shell/post_processing_germline_cnv_calls.sh
@@ -13,7 +13,7 @@ output_dir=${3:-""}
 input_json="$(realpath "${input_json}")"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_post_process_germline_cnv_calls_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_post_process_germline_cnv_calls_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -25,7 +25,7 @@ else
   output_json_filename="$(realpath "${output_json_filename}")"
 fi
 
-working_dir=$(mktemp -d /wd_post_process_germline_cnv_calls_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_post_process_germline_cnv_calls_XXXXXXXX)
 working_dir="$(realpath "${working_dir}")"
 cd "${working_dir}"
 

--- a/src/sv_shell/preprocess_pesr.sh
+++ b/src/sv_shell/preprocess_pesr.sh
@@ -58,7 +58,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_preprocess_pesr_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_preprocess_pesr_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -70,7 +70,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_preprocess_pesr_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_preprocess_pesr_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 echo "Preprocess PE-SR Working directory: ${working_dir}"
@@ -98,7 +98,7 @@ dragen_out_output=""
 if (( "${#dragen_vcfs[@]}" > 0 )); then
   algorithm="dragen"
   prefix="${batch}.${algorithm}_std"
-  working_dir=$(mktemp -d /wd_preprocess_pesr_dragen_XXXXXXXX)
+  working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_preprocess_pesr_dragen_XXXXXXXX)
   working_dir="$(realpath ${working_dir})"
   cd "${working_dir}"
 
@@ -114,7 +114,7 @@ manta_out_output=""
 if (( "${#manta_vcfs[@]}" > 0 )); then
   algorithm="manta"
   prefix="${batch}.${algorithm}_std"
-  working_dir=$(mktemp -d /wd_preprocess_pesr_manta_XXXXXXXX)
+  working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_preprocess_pesr_manta_XXXXXXXX)
   working_dir="$(realpath ${working_dir})"
   cd "${working_dir}"
 
@@ -130,7 +130,7 @@ scramble_out_output=""
 if (( "${#manta_vcfs[@]}" > 0 )); then
   algorithm="scramble"
   prefix="${batch}.${algorithm}_std"
-  working_dir=$(mktemp -d /wd_preprocess_pesr_scramble_XXXXXXXX)
+  working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_preprocess_pesr_scramble_XXXXXXXX)
   working_dir="$(realpath ${working_dir})"
   cd "${working_dir}"
 
@@ -146,7 +146,7 @@ wham_out_output=""
 if (( "${#wham_vcfs[@]}" > 0 )); then
   algorithm="wham"
   prefix="${batch}.${algorithm}_std"
-  working_dir=$(mktemp -d /wd_preprocess_pesr_wham_XXXXXXXX)
+  working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_preprocess_pesr_wham_XXXXXXXX)
   working_dir="$(realpath ${working_dir})"
   cd "${working_dir}"
 

--- a/src/sv_shell/realign_soft_clipped_reads.sh
+++ b/src/sv_shell/realign_soft_clipped_reads.sh
@@ -21,9 +21,9 @@ reference_bwa_pac=${12}
 reference_bwa_sa=${13}
 outputs_json_filename=${14}
 
-working_dir=$(mktemp -d /wd_realign_soft_clipped_reads_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_realign_soft_clipped_reads_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
-output_dir=$(mktemp -d /output_realign_soft_clipped_reads_XXXXXXXX)
+output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_realign_soft_clipped_reads_XXXXXXXX)
 output_dir="$(realpath ${output_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/refine_complex_variants.sh
+++ b/src/sv_shell/refine_complex_variants.sh
@@ -36,7 +36,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_refine_complex_variants_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_refine_complex_variants_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -48,7 +48,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_refine_complex_variants_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_refine_complex_variants_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 echo "Refine complex variants working directory: ${working_dir}"
@@ -147,7 +147,7 @@ ExtractCpxLgCnvByBatch_lg_cnv_dup="$(realpath "${batch_name}.lg_cnv.DUP.bed.gz")
 # SeekDepthSuppForCpx as seek_depth_supp_for_cpx_del
 # ---------------------------------------------------------------------------------------------------------------------
 cd "${working_dir}"
-wd_seek_depth_supp_for_cpx_del=$(mktemp -d /wd_seek_depth_supp_for_cpx_del_XXXXXXXX)
+wd_seek_depth_supp_for_cpx_del=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_seek_depth_supp_for_cpx_del_XXXXXXXX)
 wd_seek_depth_supp_for_cpx_del="$(realpath ${wd_seek_depth_supp_for_cpx_del})"
 cd "${wd_seek_depth_supp_for_cpx_del}"
 cpx_del_prefix="$(basename "${ExtractCpxLgCnvByBatch_lg_cnv_del}" .bed.gz)"
@@ -160,7 +160,7 @@ cd "${working_dir}"
 
 # SeekDepthSuppForCpx as seek_depth_supp_for_cpx_dup
 # ---------------------------------------------------------------------------------------------------------------------
-wd_seek_depth_supp_for_cpx_dup=$(mktemp -d /wd_seek_depth_supp_for_cpx_dup_XXXXXXXX)
+wd_seek_depth_supp_for_cpx_dup=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_seek_depth_supp_for_cpx_dup_XXXXXXXX)
 wd_seek_depth_supp_for_cpx_dup="$(realpath ${wd_seek_depth_supp_for_cpx_dup})"
 cd "${wd_seek_depth_supp_for_cpx_dup}"
 cpx_dup_prefix="$(basename "${ExtractCpxLgCnvByBatch_lg_cnv_dup}" .bed.gz)"
@@ -282,7 +282,7 @@ CollectPEMetricsForCPX_evi_stat="${CalcuPEStat_evi_stat}"
 # CalculateCpxEvidences
 # ---------------------------------------------------------------------------------------------------------------------
 cd "${working_dir}"
-wd_CalculateCpxEvidences=$(mktemp -d /wd_CalculateCpxEvidences_XXXXXXXX)
+wd_CalculateCpxEvidences=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_CalculateCpxEvidences_XXXXXXXX)
 wd_CalculateCpxEvidences="$(realpath ${wd_CalculateCpxEvidences})"
 cd "${wd_CalculateCpxEvidences}"
 
@@ -303,7 +303,7 @@ CalculateCpxEvidences_manual_revise_CPX_results="$(realpath "${prefix}.manual_re
 # CalculateCtxEvidences
 # ---------------------------------------------------------------------------------------------------------------------
 cd "${working_dir}"
-wd_CalculateCtxEvidences=$(mktemp -d /wd_CalculateCtxEvidences_XXXXXXXX)
+wd_CalculateCtxEvidences=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_CalculateCtxEvidences_XXXXXXXX)
 wd_CalculateCtxEvidences="$(realpath ${wd_CalculateCtxEvidences})"
 cd "${wd_CalculateCtxEvidences}"
 
@@ -324,7 +324,7 @@ CalculateCtxEvidences_manual_revise_CTX_results="$(realpath "${prefix}.manual_re
 # ReviseVcf
 # ---------------------------------------------------------------------------------------------------------------------
 cd "${working_dir}"
-wd_ReviseVcf=$(mktemp -d /wd_ReviseVcf_XXXXXXXX)
+wd_ReviseVcf=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_ReviseVcf_XXXXXXXX)
 wd_ReviseVcf="$(realpath ${wd_ReviseVcf})"
 cd "${wd_ReviseVcf}"
 

--- a/src/sv_shell/resolve_complex_sv.sh
+++ b/src/sv_shell/resolve_complex_sv.sh
@@ -13,7 +13,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_resolve_complex_sv_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_resolve_complex_sv_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -25,7 +25,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir="$(mktemp -d /wd_resolve_complex_sv_XXXXXXXX)"
+working_dir="$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_resolve_complex_sv_XXXXXXXX)"
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/resolve_complex_variants.sh
+++ b/src/sv_shell/resolve_complex_variants.sh
@@ -13,7 +13,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_resolve_complex_variants_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_resolve_complex_variants_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -25,7 +25,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir="$(mktemp -d /wd_resolve_complex_variants_XXXXXXXX)"
+working_dir="$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_resolve_complex_variants_XXXXXXXX)"
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 
@@ -53,7 +53,7 @@ SubsetInversions_filtered_vcf_idx="${SubsetInversions_filtered_vcf}.tbi"
 
 # ResolveCpxInv
 # ---------------------------------------------------------------------------------------------------------------------
-ResolveCpxInv_wd=$(mktemp -d "/wd_ResolveCpxInv_XXXXXXXX")
+ResolveCpxInv_wd=$(mktemp -d "${SV_SHELL_BASE_DIR}/wd_ResolveCpxInv_XXXXXXXX")
 ResolveCpxInv_wd="$(realpath ${ResolveCpxInv_wd})"
 ResolveCpxInv_inputs_json="${ResolveCpxInv_wd}/inputs.json"
 ResolveCpxInv_outputs_json="${ResolveCpxInv_wd}/outputs.json"
@@ -102,7 +102,7 @@ BreakpointOverlap_dropped_record_vcf_index="$(realpath "${BreakpointOverlap_pref
 
 # ResolveCpxAll
 # ---------------------------------------------------------------------------------------------------------------------
-ResolveCpxAll_wd=$(mktemp -d "/wd_ResolveCpxAll_XXXXXXXX")
+ResolveCpxAll_wd=$(mktemp -d "${SV_SHELL_BASE_DIR}/wd_ResolveCpxAll_XXXXXXXX")
 ResolveCpxAll_wd="$(realpath ${ResolveCpxAll_wd})"
 ResolveCpxAll_inputs_json="${ResolveCpxAll_wd}/inputs.json"
 ResolveCpxAll_outputs_json="${ResolveCpxAll_wd}/outputs.json"

--- a/src/sv_shell/run_manta.sh
+++ b/src/sv_shell/run_manta.sh
@@ -32,9 +32,9 @@ echo "=============== Running manta"
 # > Each analysis must be configured in a separate directory.
 TMPDIR=`mktemp -d -p .` || exit 1
 
-working_dir=$(mktemp -d /wd_manta_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_manta_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
-output_dir=$(mktemp -d /output_manta_XXXXXXXX)
+output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_manta_XXXXXXXX)
 output_dir="$(realpath ${output_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/run_whamg.sh
+++ b/src/sv_shell/run_whamg.sh
@@ -19,9 +19,9 @@ cpu_cores=${9:-4}
 include_bed_file_abs_path=$(realpath $include_bed_file)
 reference_fasta_abs_path=$(realpath $reference_fasta)
 
-working_dir=$(mktemp -d /wd_collect_counts_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_collect_counts_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
-output_dir=$(mktemp -d /output_collect_counts_XXXXXXXX)
+output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_collect_counts_XXXXXXXX)
 output_dir="$(realpath ${output_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/score_genotypes.sh
+++ b/src/sv_shell/score_genotypes.sh
@@ -15,7 +15,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_score_genotypes_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_score_genotypes_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -27,7 +27,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_score_genotypes_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_score_genotypes_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 echo "Filter Genotypes working directory: ${working_dir}"

--- a/src/sv_shell/scramble.sh
+++ b/src/sv_shell/scramble.sh
@@ -61,7 +61,7 @@ echo "make_scramble_vcf_args:     " "${make_scramble_vcf_args}"
 
 
 initial_wd=$PWD
-output_dir=$(mktemp -d /output_scramble_XXXXXXXX)
+output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_scramble_XXXXXXXX)
 output_dir="$(realpath ${output_dir})"
 
 scramble_dir="/app/scramble-gatk-sv"
@@ -86,7 +86,7 @@ scramble_dir="/app/scramble-gatk-sv"
 # ScramblePart1
 # -------------
 
-working_dir_p1=$(mktemp -d /wd_scramble_p1_XXXXXXXX)
+working_dir_p1=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_scramble_p1_XXXXXXXX)
 working_dir_p1="$(realpath ${working_dir_p1})"
 cd "${working_dir_p1}"
 
@@ -119,7 +119,7 @@ done < "${regions_list}"
 # -------------
 
 cd "${initial_wd}"
-working_dir_p2=$(mktemp -d /wd_scramble_p2_XXXXXXXX)
+working_dir_p2=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_scramble_p2_XXXXXXXX)
 working_dir_p2="$(realpath ${working_dir_p2})"
 cd "${working_dir_p2}"
 
@@ -154,7 +154,7 @@ scramble_table="$(realpath ${sample_name}.scramble.tsv.gz)"
 # ---------------
 
 cd "${initial_wd}"
-working_dir_make_vcf=$(mktemp -d /wd_scramble_make_vcf_XXXXXXXX)
+working_dir_make_vcf=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_scramble_make_vcf_XXXXXXXX)
 working_dir_make_vcf="$(realpath ${working_dir_make_vcf})"
 cd "${working_dir_make_vcf}"
 

--- a/src/sv_shell/single_sample_metrics.sh
+++ b/src/sv_shell/single_sample_metrics.sh
@@ -13,7 +13,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_single_sample_metrics_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_single_sample_metrics_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -25,7 +25,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir="$(mktemp -d /wd_single_sample_metrics_XXXXXXXX)"
+working_dir="$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_single_sample_metrics_XXXXXXXX)"
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/stripy.sh
+++ b/src/sv_shell/stripy.sh
@@ -14,7 +14,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_stripy_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_stripy_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -26,7 +26,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(realpath $(mktemp -d "/wd_stripy_XXXXXXXX"))
+working_dir=$(realpath $(mktemp -d "${SV_SHELL_BASE_DIR}/wd_stripy_XXXXXXXX"))
 cd "${working_dir}"
 echo "stripy Working directory: ${working_dir}"
 

--- a/src/sv_shell/sv_cluster.sh
+++ b/src/sv_shell/sv_cluster.sh
@@ -13,7 +13,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_sv_cluster_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_sv_cluster_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -25,7 +25,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir="$(mktemp -d /wd_sv_cluster_XXXXXXXX)"
+working_dir="$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_sv_cluster_XXXXXXXX)"
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/sv_concordance.sh
+++ b/src/sv_shell/sv_concordance.sh
@@ -13,7 +13,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_sv_concordance_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_sv_concordance_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -25,7 +25,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir="$(mktemp -d /wd_sv_concordance_XXXXXXXX)"
+working_dir="$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_sv_concordance_XXXXXXXX)"
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 

--- a/src/sv_shell/wgd.sh
+++ b/src/sv_shell/wgd.sh
@@ -13,7 +13,7 @@ output_dir=${3:-""}
 input_json="$(realpath ${input_json})"
 
 if [ -z "${output_dir}" ]; then
-  output_dir=$(mktemp -d /output_wgd_XXXXXXXX)
+  output_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/output_wgd_XXXXXXXX)
 else
   mkdir -p "${output_dir}"
 fi
@@ -25,7 +25,7 @@ else
   output_json_filename="$(realpath ${output_json_filename})"
 fi
 
-working_dir=$(mktemp -d /wd_wgd_XXXXXXXX)
+working_dir=$(mktemp -d ${SV_SHELL_BASE_DIR}/wd_wgd_XXXXXXXX)
 working_dir="$(realpath ${working_dir})"
 cd "${working_dir}"
 


### PR DESCRIPTION
SV-shell scripts create working (`wd_*`) and output (`output_*`) directories at the root level (i.e., `/`). 
To improve support for environments where a non-root directory is preferred, this PR updates all working and output directory definitions to rely on a path defined in an environment variable.

You can set the environment variable as follows:

```shell
mkdir -p /preferred_path
export SV_SHELL_BASE_DIR="/preferred_path"
```

### Context
This change is essential when running sv-shell on cloud VMs with mounted external disks. Cloud VM boot disks often have limited space, causing the sv-shell Docker image to quickly run out of space when writing to the root path.

Previously, we addressed this by changing Docker's default data root to a mounted disk (see the workaround below). While this ensures the Docker image has access to the full disk space, it is often counterintuitive and complex to configure. This PR simplifies this by mounting a volume to the Docker container and setting that path via the environment variable, so to avoid needing to reconfigure the Docker daemon entirely.

```shell
sudo systemctl stop docker docker.socket
sudo bash -c 'cat > /etc/docker/daemon.json <<EOF
{
  "data-root": "/mnt/disks/gatk-sv/sv-shell/docker-data"
}
EOF' 
sudo mv /var/lib/docker/* /mnt/disks/gatk-sv/sv-shell/docker-data/ 

sudo systemctl daemon-reload
sudo systemctl start docker  

docker info | grep "Docker Root Dir"
```