### PR TITLE
Input template updates to accommodate ScoreGenotypes

### DIFF
--- a/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/FilterGenotypes.json.tmpl
+++ b/inputs/templates/terra_workspaces/cohort_mode/workflow_configurations/FilterGenotypes.json.tmpl
@@ -1,5 +1,5 @@
 {
-  "FilterGenotypes.vcf": "${this.concordance_vcf}",
+  "FilterGenotypes.vcf": "${this.unfiltered_recalibrated_vcf}",
   "FilterGenotypes.output_prefix": "${this.sample_set_set_id}",
   "FilterGenotypes.ploidy_table": "${this.ploidy_table}",
   

--- a/scripts/test/terra_validation.py
+++ b/scripts/test/terra_validation.py
@@ -113,7 +113,7 @@ def main():
     parser.add_argument("-j", "--womtool-jar", help="Path to womtool jar", required=True)
     parser.add_argument("-n", "--num-input-jsons",
                         help="Number of Terra input JSONs expected",
-                        required=False, default=25, type=int)
+                        required=False, default=26, type=int)
     parser.add_argument("--log-level",
                         help="Specify level of logging information, ie. info, warning, error (not case-sensitive)",
                         required=False, default="INFO")


### PR DESCRIPTION
### Updates
* The VCF input for FilterGenotypes was still set to the output of SVConcordance. This PR updates the input to point to the output of the new ScoreGenotypes workflow.
* Also updated the number of expected input JSONs for the Terra validation script 

### Testing
* Filtering ran successfully with the updated input (fails if given the concordance VCF)
* Validated all WDLs and JSONs with womtool and Terra validation script (no more warning about too many JSONs)

Note that I made a separate PR from #928 since that PR should wait for v1.2 but this one does not need to. But this PR does need to be merged before the next update to the featured workspace.