### PR TITLE
Ensure logging to both stdout & stderr in sv-shell

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.13
       uses: actions/setup-python@v3
       with:
-        python-version: 3.8
+        python-version: 3.13
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.13
+    - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:
-        python-version: 3.13
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/src/sv_shell/gather_sample_evidence.sh
+++ b/src/sv_shell/gather_sample_evidence.sh
@@ -209,7 +209,7 @@ if [[ "${collect_pesr}" == true ]]; then
   bash /opt/sv_shell/collect_sv_evidence.sh \
     "${collect_pesr_inputs_json_filename}" \
     "${collect_pesr_outputs_json_filename}" \
-    "${collect_pesr_output_dir}" > (tee "${collect_pesr_stdout}") 2> >(tee "${collect_pesr_stderr}" >&2)
+    "${collect_pesr_output_dir}" > >(tee "${collect_pesr_stdout}") 2> >(tee "${collect_pesr_stderr}" >&2)
 
   collect_pesr_end_time=`date +%s`
   collect_pesr_et=$((collect_pesr_end_time-collect_pesr_start_time))
@@ -281,7 +281,7 @@ if [[ "${run_scramble}" == true && "${run_manta}" == true ]]; then
       "${scramble_alignment_score_cutoff}" \
       "${mei_bed}" \
       "${scramble_p2_outputs_json_filename}"
-  } > (tee "${scramble_stdout}") 2> >(tee "${scramble_stderr}" >&2)
+  } > >(tee "${scramble_stdout}") 2> >(tee "${scramble_stderr}" >&2)
 
   scramble_end_time=`date +%s`
   scramble_et=$((scramble_end_time-scramble_start_time))
@@ -305,7 +305,7 @@ if [[ "${run_wham}" == true ]]; then
     "${reference_index}" \
     "${include_bed_file}" \
     "${primary_contigs_list}" \
-    "${wham_outputs_json_filename}" > (tee "${wham_stdout}") 2> >("${wham_stderr}" >&2)
+    "${wham_outputs_json_filename}" > >(tee "${wham_stdout}") 2> >(tee "${wham_stderr}" >&2)
 
   wham_end_time=`date +%s`
   wham_et=$((wham_end_time-wham_start_time))

--- a/src/sv_shell/gather_sample_evidence.sh
+++ b/src/sv_shell/gather_sample_evidence.sh
@@ -148,7 +148,7 @@ if [[ "${collect_coverage}" == true || "${run_scramble}" == true ]]; then
     "${reference_dict}" \
     "${collect_counts_outputs_json_filename}" \
     "/root/gatk.jar" \
-    "${disabled_read_filters}" > "${collect_counts_stdout}" 2> "${collect_counts_stderr}"
+    "${disabled_read_filters}" > >(tee "${collect_counts_stdout}") 2> >(tee "${collect_counts_stderr}" >&2)
 
   collect_counts_end_time=`date +%s`
   collect_counts_et=$((collect_counts_end_time-collect_counts_start_time))
@@ -171,7 +171,7 @@ if [[ "${run_manta}" == true ]]; then
     "${reference_fasta}" \
     "${manta_regions_bed}" \
     "${manta_regions_bed_index}" \
-    "${manta_outputs_json_filename}" > "${manta_stdout}" 2> "${manta_stderr}"
+    "${manta_outputs_json_filename}" > >(tee "${manta_stdout}") 2> >(tee "${manta_stderr}" >&2)
 
   manta_end_time=`date +%s`
   manta_et=$((manta_end_time-manta_start_time))
@@ -209,7 +209,7 @@ if [[ "${collect_pesr}" == true ]]; then
   bash /opt/sv_shell/collect_sv_evidence.sh \
     "${collect_pesr_inputs_json_filename}" \
     "${collect_pesr_outputs_json_filename}" \
-    "${collect_pesr_output_dir}" > "${collect_pesr_stdout}" 2> "${collect_pesr_stderr}"
+    "${collect_pesr_output_dir}" > (tee "${collect_pesr_stdout}") 2> >(tee "${collect_pesr_stderr}" >&2)
 
   collect_pesr_end_time=`date +%s`
   collect_pesr_et=$((collect_pesr_end_time-collect_pesr_start_time))
@@ -281,7 +281,7 @@ if [[ "${run_scramble}" == true && "${run_manta}" == true ]]; then
       "${scramble_alignment_score_cutoff}" \
       "${mei_bed}" \
       "${scramble_p2_outputs_json_filename}"
-  } > "${scramble_stdout}" 2> "${scramble_stderr}"
+  } > (tee "${scramble_stdout}") 2> >(tee "${scramble_stderr}" >&2)
 
   scramble_end_time=`date +%s`
   scramble_et=$((scramble_end_time-scramble_start_time))
@@ -305,7 +305,7 @@ if [[ "${run_wham}" == true ]]; then
     "${reference_index}" \
     "${include_bed_file}" \
     "${primary_contigs_list}" \
-    "${wham_outputs_json_filename}" > "${wham_stdout}" 2> "${wham_stderr}"
+    "${wham_outputs_json_filename}" > (tee "${wham_stdout}") 2> >("${wham_stderr}" >&2)
 
   wham_end_time=`date +%s`
   wham_et=$((wham_end_time-wham_start_time))


### PR DESCRIPTION
Some tasks in sv-shell direct `stdout` and `stderr` to files; this is needed when running the tasks in a VM using tmux because it makes older logs easily accessible. However, when running sv-shell through Terra, these log files are not delocalized; hence, information needed for debugging failed tasks is not accessible. This PR updates those tasks to log to both stderr and stdout files in addition to standard stdout and stderr. 

This update has been successfully tested on both the sv-shell's single-VM and Terra setups. 