### PR TITLE
Fix a bug in RdTest.R

### DIFF
--- a/src/RdTest/RdTest.R
+++ b/src/RdTest/RdTest.R
@@ -1354,13 +1354,22 @@ runRdTest<-function(bed)
       p.2ndmax[count]<-p[2]
     }
     ##Combine individual P-values with fisher.method##
-    if (length(p.list) > 1) {
-    ##Need to change 0 to 1e-300 for sumlog function##  
-      p.list<-rapply(p.list,function(x) ifelse(x==0,1e-300,x), how = "replace")
-      p.2ndmax<-rapply(p.2ndmax,function(x) ifelse(x==0,1e-300,x), how = "replace")
-      p <- list(sumlog(unlist(p.list))$p, sumlog(unlist(p.2ndmax))$p)
+    clean_p.list <- unlist(p.list)[!is.na(unlist(p.list))]
+    clean_p.2ndmax <- unlist(p.2ndmax)[!is.na(unlist(p.2ndmax))]
+
+    if (length(clean_p.list) > 1) {
+      ##Need to change 0 to 1e-300 for sumlog function##
+      clean_p.list <- ifelse(clean_p.list == 0, 1e-300, clean_p.list)
+      clean_p.2ndmax <- ifelse(clean_p.2ndmax == 0, 1e-300, clean_p.2ndmax)
+
+      p1_val <- sumlog(clean_p.list)$p
+      p2_val <- if(length(clean_p.2ndmax) > 0) sumlog(clean_p.2ndmax)$p else NA
+
+      p <- list(p1_val, p2_val)
+    } else if (length(clean_p.list) == 1) {
+      p <- c(clean_p.list[1], if(length(clean_p.2ndmax) > 0) clean_p.2ndmax[1] else NA)
     } else {
-      p <- c(p.list[1], p.2ndmax[1])
+      p <- c(NA, NA)
     }
     p[3]<-"singlesampZ"
     names(p)<-c("Pvalue","Pmax_2nd","Test")

--- a/src/RdTest/RdTest.R
+++ b/src/RdTest/RdTest.R
@@ -1369,7 +1369,7 @@ runRdTest<-function(bed)
     } else if (length(clean_p.list) == 1) {
       p <- c(clean_p.list[1], if(length(clean_p.2ndmax) > 0) clean_p.2ndmax[1] else NA)
     } else {
-      p <- c(NA, NA)
+      p <- c(0, 0)
     }
     p[3]<-"singlesampZ"
     names(p)<-c("Pvalue","Pmax_2nd","Test")

--- a/src/RdTest/RdTest.R
+++ b/src/RdTest/RdTest.R
@@ -1369,7 +1369,7 @@ runRdTest<-function(bed)
     } else if (length(clean_p.list) == 1) {
       p <- c(clean_p.list[1], if(length(clean_p.2ndmax) > 0) clean_p.2ndmax[1] else NA)
     } else {
-      p <- c(0, 0)
+      p <- c(NA, NA)
     }
     p[3]<-"singlesampZ"
     names(p)<-c("Pvalue","Pmax_2nd","Test")


### PR DESCRIPTION
The [RdTest.R](https://github.com/broadinstitute/gatk-sv/blob/main/src/RdTest/RdTest.R) script separates the male samples, then, based on the provided bed file, it splits the male samples into the treatment and control. The bed file has the following columns:

```
Column 1-3: chr, start, end
Column 4: locus ID
Column 5: A comma-separated list of sample ids
Column 6: cnv type
```

The script performs bin compression and normalization, which can lead to zero variance when processing some regions of the coverage matrix file. Because the entire control group can end up with identical normalized depth values (e.g., `0`) (specifically when isolating the control group here (e.g., [here](https://github.com/broadinstitute/gatk-sv/blob/7eb2af1feea9f81a390caff211f6832c6e7f7ac5/src/RdTest/RdTest.R#L701)), the standard deviation evaluates to `0`. This results in a divide by zero when calculating the Z-score inside the `onesamplezscore.median` function: 

https://github.com/broadinstitute/gatk-sv/blob/7eb2af1feea9f81a390caff211f6832c6e7f7ac5/src/RdTest/RdTest.R#L663-L667

which produces an `NA` instead of a valid p-value, which cascades down to the `runRdTest` function, which leads to the `sumlog` function in the following to crash.

https://github.com/broadinstitute/gatk-sv/blob/7eb2af1feea9f81a390caff211f6832c6e7f7ac5/src/RdTest/RdTest.R#L1361

and generates the following error:

```
The following objects are masked from 'package:plyr':

    rename, round_any

hash-2.2.6.3 provided by Decision Patterns

Error in if (invalid) { : missing value where TRUE/FALSE needed
Calls: alply ... llply -> loop_apply -> <Anonymous> -> .fun -> sumlog
6: sumlog(unlist(p.2ndmax))
5: .fun(piece, ...)
4: (function (i) 
    ...
3: loop_apply(n, do.ply)
2: llply(.data = pieces, .fun = .fun, ..., .progress = .progress, 
    ...
1: alply(intervals, 1, runRdTest)
```


This PR fixes this bug by removing `NA` values from the `p.list` and `p.2ndmax` arrays right before they are passed to the `sumlog()` function; if all values evaluate to `NA`, then the script catches this and passes `NA` forward.


