### PR TITLE
Fix Stripy VCF sample ID

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -240,6 +240,7 @@ workflows:
     filters:
       branches:
         - main
+        - mw_stripy_sample_id_fix
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -240,7 +240,6 @@ workflows:
     filters:
       branches:
         - main
-        - mw_stripy_sample_id_fix
       tags:
         - /.*/
 

--- a/src/stripy/stripy
+++ b/src/stripy/stripy
@@ -3,10 +3,8 @@
 import json
 import sys
 import os
-import argparse
 import tempfile
 import subprocess
-from pathlib import Path
 
 def load_locus_profiles(profiles_path=None):
     """Load locus profiles from JSON file"""
@@ -133,9 +131,48 @@ def find_vcf_script():
             return path
     return None
 
+def find_output_file(output_dir, extension, preferred_names=None):
+    if not output_dir or not os.path.isdir(output_dir):
+        return None
+
+    preferred_names = preferred_names or []
+    for name in preferred_names:
+        path = os.path.join(output_dir, name)
+        if os.path.isfile(path):
+            return path
+
+    candidates = [
+        os.path.join(output_dir, name)
+        for name in os.listdir(output_dir)
+        if name.lower().endswith(extension) and os.path.isfile(os.path.join(output_dir, name))
+    ]
+    if not candidates:
+        return None
+    return sorted(candidates, key=lambda path: os.path.getsize(path), reverse=True)[0]
+
+def normalize_sample_output(output_dir, sample_name, extension, input_bam=None):
+    preferred_names = []
+    if input_bam:
+        input_filename = os.path.basename(input_bam)
+        input_base = os.path.splitext(input_filename)[0]
+        preferred_names.extend([
+            f"{input_filename}{extension}",
+            f"{input_base}{extension}",
+        ])
+    preferred_names.append(f"{sample_name}{extension}")
+
+    source = find_output_file(output_dir, extension, preferred_names=preferred_names)
+    if source is None:
+        return None
+
+    target = os.path.join(output_dir, f"{sample_name}{extension}")
+    if os.path.abspath(source) != os.path.abspath(target):
+        os.replace(source, target)
+    return target
+
 def main():
     if len(sys.argv) < 2:
-        print("Usage: stripy [STRipy arguments...]", file=sys.stderr)
+        print("Usage: stripy --sample-name SAMPLE_ID [STRipy arguments...]", file=sys.stderr)
         sys.exit(1)
     
     args = sys.argv[1:]
@@ -146,6 +183,7 @@ def main():
     output_dir = None
     reference_fasta = None
     input_bam = None
+    sample_name = None
     
     # Config options we handle
     config_options = {
@@ -203,6 +241,9 @@ def main():
             input_bam = args[i + 1]
             new_args.extend([arg, input_bam])
             i += 2
+        elif arg == "--sample-name" and i + 1 < len(args):
+            sample_name = args[i + 1]
+            i += 2
         elif arg == "--locus" and i + 1 < len(args):
             # Found --locus, expand it
             profiles = load_locus_profiles()
@@ -214,6 +255,10 @@ def main():
         else:
             new_args.append(arg)
             i += 1
+
+    if not sample_name and "--help" not in args and "-h" not in args:
+        print("ERROR: --sample-name is required", file=sys.stderr)
+        sys.exit(1)
     
     # Always create config file (base config is required)
     config_file = create_config_file(
@@ -258,28 +303,30 @@ def main():
         if not vcf_tool:
             print("ERROR: Could not locate stripy_to_vcf.py script", file=sys.stderr)
             sys.exit(1)
-        json_candidates = []
-        if os.path.isdir(output_dir):
-            for name in os.listdir(output_dir):
-                if name.lower().endswith('.json'):
-                    json_candidates.append(os.path.join(output_dir, name))
-        if not json_candidates:
+
+        preferred_json_names = []
+        if input_bam:
+            input_filename = os.path.basename(input_bam)
+            input_base = os.path.splitext(input_filename)[0]
+            preferred_json_names.extend([f"{input_filename}.json", f"{input_base}.json"])
+        json_path = find_output_file(output_dir, ".json", preferred_names=preferred_json_names)
+        if not json_path:
             print("ERROR: No JSON output found to convert to VCF", file=sys.stderr)
             sys.exit(1)
-        json_path = sorted(json_candidates, key=lambda p: os.path.getsize(p), reverse=True)[0]
+
+        json_path = normalize_sample_output(output_dir, sample_name, ".json", input_bam=input_bam) or json_path
         
-        # Derive VCF filename from input BAM filename (like other outputs)
-        if input_bam:
-            base_name = os.path.splitext(os.path.basename(input_bam))[0]
-            vcf_filename = f"{base_name}.vcf"
-        else:
-            vcf_filename = "stripy.vcf"
+        vcf_filename = f"{sample_name}.vcf"
         
         vcf_out = os.path.join(output_dir, vcf_filename)
         vcf_cmd = ["python3", vcf_tool, "--json", json_path, "-o", vcf_out]
+        vcf_cmd.extend(["--sample-name", sample_name])
         if reference_fasta:
             vcf_cmd.extend(["--reference", reference_fasta])
         vcf_res = subprocess.run(vcf_cmd)
+        if vcf_res.returncode == 0:
+            normalize_sample_output(output_dir, sample_name, ".tsv", input_bam=input_bam)
+            normalize_sample_output(output_dir, sample_name, ".html", input_bam=input_bam)
         sys.exit(vcf_res.returncode)
     else:
         os.execvp("python3", ["python3", "/opt/stripy-pipeline/stri.py"] + new_args)

--- a/src/sv-pipeline/scripts/merge_stripy_single_sample.py
+++ b/src/sv-pipeline/scripts/merge_stripy_single_sample.py
@@ -28,16 +28,12 @@ def update_header(header: pysam.VariantHeader) -> None:
 
 
 def validate_sample_id(main_header: pysam.VariantHeader,
-                       stripy_header: pysam.VariantHeader):
+                       stripy_header: pysam.VariantHeader) -> Text:
     if len(stripy_header.samples) != 1:
         raise ValueError(f"Expected exactly 1 sample in STRipy header but got {len(stripy_header.samples)}")
-    sample_raw = stripy_header.samples[0]
-    # TODO temp fix; we should expect the correct ID here
-    if not sample_raw.endswith(".final"):
-        raise ValueError(f"Expected STRipy sample ID to end with .final but got {sample_raw}")
-    sample = sample_raw.rsplit(".", 1)[0]
+    sample = stripy_header.samples[0]
     if sample not in main_header.samples:
-        raise ValueError(f"Sample {sample} (raw ID {sample_raw}) not found in single-sample VCF header")
+        raise ValueError(f"Sample {sample} not found in single-sample VCF header")
     return sample
 
 
@@ -60,7 +56,7 @@ def _process(sample: Text,
                 record.info[key] = stripy_record.info[key]
         record.samples[sample]['GT'] = (None, None)
         for key in FORMAT_FIELDS:
-            s = stripy_record.samples[sample + ".final"]
+            s = stripy_record.samples[sample]
             if key in s:
                 record.samples[sample][key] = s[key]
         out_vcf.write(record)
@@ -75,7 +71,7 @@ def _parse_arguments(argv: List[Text]) -> argparse.Namespace:
     parser.add_argument("--main-vcf", type=str, required=True,
                         help="GATK-SV vcf, must contain the sample provided by --stripy-vcf")
     parser.add_argument("--stripy-vcf", type=str, required=True,
-                        help="Single-sample STRipy vcf, with sample ID ending with \".final\"")
+                        help="Single-sample STRipy vcf, with sample ID present in --main-vcf")
     parser.add_argument("--out", type=str, required=True,
                         help="Output vcf (unsorted)")
     if len(argv) <= 1:

--- a/src/sv_shell/stripy.sh
+++ b/src/sv_shell/stripy.sh
@@ -71,6 +71,7 @@ stripy_output_dir="STRipy_output"
 mkdir -p "${stripy_output_dir}"
 stripy \
   --input "${bam_or_cram_file}" \
+  --sample-name "${sample_name}" \
   --genome "${genome_build}" \
   --reference "${reference_fasta}" \
   --output "${stripy_output_dir}" \
@@ -85,26 +86,6 @@ stripy \
   --sex "${GetSampleSex_out_string}"
 
 deactivate
-
-ACTUAL_FILENAME=$(basename "${bam_or_cram_file}")
-ACTUAL_BASE=$(echo "${ACTUAL_FILENAME}" | sed 's/\.[^.]*$//')
-TARGET_BASE="${sample_name}"
-echo "ACTUAL_FILENAME: ${ACTUAL_FILENAME}"
-echo "ACTUAL_BASE: ${ACTUAL_BASE}"
-echo "TARGET_BASE: ${TARGET_BASE}"
-ls "${stripy_output_dir}"
-if [ -f "${stripy_output_dir}/${ACTUAL_FILENAME}.json" ]; then
-  mv "${stripy_output_dir}/${ACTUAL_FILENAME}.json" "${stripy_output_dir}/${TARGET_BASE}.json"
-fi
-if [ -f "${stripy_output_dir}/${ACTUAL_FILENAME}.tsv" ]; then
-  mv "${stripy_output_dir}/${ACTUAL_FILENAME}.tsv" "${stripy_output_dir}/${TARGET_BASE}.tsv"
-fi
-if [ -f "${stripy_output_dir}/${ACTUAL_FILENAME}.html" ]; then
-  mv "${stripy_output_dir}/${ACTUAL_FILENAME}.html" "${stripy_output_dir}/${TARGET_BASE}.html"
-fi
-if [ -f "${stripy_output_dir}/${ACTUAL_BASE}.vcf" ]; then
-  mv "${stripy_output_dir}/${ACTUAL_BASE}.vcf" "${stripy_output_dir}/${TARGET_BASE}.vcf"
-fi
 
 
 # -------------------------------------------------------

--- a/wdl/GATKSVPipelineSingleSample.wdl
+++ b/wdl/GATKSVPipelineSingleSample.wdl
@@ -796,6 +796,7 @@ workflow GATKSVPipelineSingleSample {
     call stripy.StripyWorkflow {
       input:
         bam_or_cram_file = select_first([bam_or_cram_file]),
+        bam_or_cram_index = bam_or_cram_index,
         sample_name = sample_id,
         ped_file = combined_ped_file,
         reference_fasta = reference_fasta,

--- a/wdl/GenotypeBatch.wdl
+++ b/wdl/GenotypeBatch.wdl
@@ -255,7 +255,7 @@ task GenotypeSVs {
 
   RuntimeAttr default_attr = object {
                                cpu_cores: 1,
-                               mem_gb: 3.75,
+                               mem_gb: 7.5,
                                disk_gb: ceil(50 + size([vcf, rd_file, pe_file, sr_file], "GB")),
                                boot_disk_gb: 10,
                                preemptible_tries: 3,

--- a/wdl/StripyWorkflow.wdl
+++ b/wdl/StripyWorkflow.wdl
@@ -95,13 +95,21 @@ task RunStripy {
     String tsv_path = output_dir + "/" + sample_name + ".tsv"
     String html_path = output_dir + "/" + sample_name + ".html"
     String vcf_path = output_dir + "/" + sample_name + ".vcf"
+    String input_filename = basename(bam_or_cram_file)
+    Boolean input_is_bam = basename(bam_or_cram_file, ".bam") + ".bam" == basename(bam_or_cram_file)
+    String staged_index_filename = input_filename + if input_is_bam then ".bai" else ".crai"
 
     command <<<
         # Run STRipy pipeline using our wrapper
         set -euxo pipefail
         mkdir -p ~{output_dir}
+
+        # STRipy expects the BAM/CRAM index to live beside the input file.
+        ln -s ~{bam_or_cram_file} ~{input_filename}
+        ln -s ~{bam_or_cram_index} ~{staged_index_filename}
+
         stripy \
-            --input ~{bam_or_cram_file} \
+            --input ~{input_filename} \
             --sample-name ~{sample_name} \
             --genome ~{genome_build} \
             --reference ~{reference_fasta} \

--- a/wdl/StripyWorkflow.wdl
+++ b/wdl/StripyWorkflow.wdl
@@ -91,9 +91,6 @@ task RunStripy {
                                }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
 
-    String bam_filename = basename(bam_or_cram_file)
-    String bam_base_default = sub(bam_filename, "\\\.[^.]+$", "")
-
     String json_path = output_dir + "/" + sample_name + ".json"
     String tsv_path = output_dir + "/" + sample_name + ".tsv"
     String html_path = output_dir + "/" + sample_name + ".html"
@@ -105,6 +102,7 @@ task RunStripy {
         mkdir -p ~{output_dir}
         stripy \
             --input ~{bam_or_cram_file} \
+            --sample-name ~{sample_name} \
             --genome ~{genome_build} \
             --reference ~{reference_fasta} \
             --output ~{output_dir} \
@@ -119,26 +117,6 @@ task RunStripy {
             ~{if defined(locus) then "--locus " + locus else ""} \
             ~{if defined(sex) then "--sex " + sex else ""} \
             ~{if defined(custom_catalog) then "--custom " + custom_catalog else ""}
-
-        ACTUAL_FILENAME=$(basename "~{bam_or_cram_file}")
-        ACTUAL_BASE=$(echo "${ACTUAL_FILENAME}" | sed 's/\.[^.]*$//')
-        TARGET_BASE='~{sample_name}'
-        echo "ACTUAL_FILENAME: ${ACTUAL_FILENAME}"
-        echo "ACTUAL_BASE: ${ACTUAL_BASE}"
-        echo "TARGET_BASE: ${TARGET_BASE}"
-        ls ~{output_dir}
-        if [ -f "~{output_dir}/${ACTUAL_FILENAME}.json" ]; then
-            mv "~{output_dir}/${ACTUAL_FILENAME}.json" "~{output_dir}/${TARGET_BASE}.json"
-        fi
-        if [ -f "~{output_dir}/${ACTUAL_FILENAME}.tsv" ]; then
-            mv "~{output_dir}/${ACTUAL_FILENAME}.tsv" "~{output_dir}/${TARGET_BASE}.tsv"
-        fi
-        if [ -f "~{output_dir}/${ACTUAL_FILENAME}.html" ]; then
-            mv "~{output_dir}/${ACTUAL_FILENAME}.html" "~{output_dir}/${TARGET_BASE}.html"
-        fi
-        if [ -f "~{output_dir}/${ACTUAL_BASE}.vcf" ]; then
-            mv "~{output_dir}/${ACTUAL_BASE}.vcf" "~{output_dir}/${TARGET_BASE}.vcf"
-        fi
     >>>
 
     runtime {


### PR DESCRIPTION
Addresses an assumption about sample ID naming in the Stripy workflow. Stripy now requires `--sample-id` to be provided at the CLI and uses that for setting the sample ID in the output vcf rather than slicing it from the BAM/CRAM name directly.

Tested successfully on a cram with a different filename format.

TODO: revert dockstore.yml and dockers.