### PR TITLE
Fix stale docker builds

### DIFF
--- a/dockerfiles/sv-base-virtual-env/Dockerfile
+++ b/dockerfiles/sv-base-virtual-env/Dockerfile
@@ -1,6 +1,6 @@
 ARG UBUNTU_RELEASE="22.04"
 # available R releases listed here:  https://cdn.rstudio.com/r/versions.json
-ARG R_RELEASE_VERSION="4.1.3"
+ARG R_RELEASE_VERSION="4.5.0"
 ARG R_INSTALL_PATH=/opt/R
 ARG APT_REQUIRED_PACKAGES="/opt/apt-required-packages.list"
 
@@ -23,7 +23,8 @@ ARG BUILD_DEPS="make cmake g++ gcc gfortran \
 ARG RUN_DEPS="wget curl apt-transport-https ca-certificates unzip zip ucf \
               libbz2-1.0 libopenblas0 libicu70 liblapack3 liblzma5 libpcre2-8-0 libpcre2-16-0 libpcre2-32-0 \
               libpcre2-posix3 zlib1g libc6 libcairo2 libcurl4 libglib2.0-0 libgomp1 libjpeg8 libpango-1.0-0 \
-              libpangocairo-1.0-0 libpaper-utils libpng16-16 libreadline8 libtcl8.6 libtiff5 libtk8.6 libx11-6 libxt6"
+              libpangocairo-1.0-0 libpaper-utils libpng16-16 libreadline8 libtcl8.6 libtiff5 libtk8.6 libx11-6 libxt6 \
+              libdeflate-dev libssl-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev libwebp-dev"
 ARG APT_REQUIRED_PACKAGES
 RUN printf "$RUN_DEPS" | fix_spaces.sh > $APT_REQUIRED_PACKAGES
 

--- a/dockerfiles/sv-pipeline-virtual-env/Dockerfile
+++ b/dockerfiles/sv-pipeline-virtual-env/Dockerfile
@@ -72,7 +72,7 @@ ARG BUILD_DEPS="make cmake g++ gcc gfortran \
                 libbz2-dev libblas-dev libicu-dev liblapack-dev liblzma-dev libpcre2-dev zlib1g-dev \
                 pkg-config libcurl4-openssl-dev libssl-dev libatlas-base-dev libssh2-1-dev libssh2-1 \
                 libgit2-dev libfftw3-dev libjpeg8-dev libxml2-dev libfontconfig1-dev libharfbuzz-dev \
-                libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev"
+                libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev libuv1-dev"
 ARG RUN_DEPS="file bzip2 libssl3 libatlas3-base libssh2-1 libgit2-1.1 libfftw3-3 libjpeg8 libxml2"
 RUN export NEW_PACKAGES=$(diff_of_lists.sh "$RUN_DEPS" $APT_REQUIRED_PACKAGES) && \
     printf " $NEW_PACKAGES" | fix_spaces.sh >> $APT_REQUIRED_PACKAGES
@@ -80,7 +80,7 @@ RUN export NEW_PACKAGES=$(diff_of_lists.sh "$RUN_DEPS" $APT_REQUIRED_PACKAGES) &
 # install R packages
 ARG R_PACKAGES="assertthat beeswarm BH BSDA caret cli crayon DAAG data.table devtools digest dplyr e1071 fansi fpc \
                 generics gert glue HardyWeinberg hash latticeExtra magrittr metap mnormt nlme nloptr nnet \
-                numDeriv perm pillar pkgconfig plogr plyr purrr pwr R6 RColorBrewer Rcpp reshape reshape2 rlang ROCR \
+                numDeriv perm pillar pkgconfig plyr purrr pwr R6 RColorBrewer Rcpp reshape reshape2 rlang ROCR \
                 rpart stringi stringr survival tibble tidyr tidyselect utf8 vioplot withr zoo"
 ARG BIOCONDUCTOR_PKGS="SNPRelate multtest"
 ARG DEBIAN_FRONTEND=noninteractive

--- a/dockerfiles/sv-shell/Dockerfile
+++ b/dockerfiles/sv-shell/Dockerfile
@@ -107,7 +107,7 @@ COPY --from=wham_layer /bin/whamg /bin/
 # cnmops
 # Note that the following installation is different from the installation in cnmops docker
 # since that method does not compile on this docker.
-RUN mkdir -p /opt/R/4.1.3/lib/R/doc/html && \
+RUN mkdir -p /opt/R/4.5.0/lib/R/doc/html && \
     R -e 'options(repos = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/focal/latest")); BiocManager::install(c("cn.mops", "rtracklayer", "XML"), update=FALSE, ask=FALSE)'
 
 


### PR DESCRIPTION
Updated Docker configuration to migrate the SV pipeline environment from **R 4.1.3** to **R 4.5.0**.

### What changed
- Bumped `R_RELEASE_VERSION` in `dockerfiles/sv-base-virtual-env/Dockerfile` from `4.1.3` to `4.5.0`
- Added additional runtime/build dependencies needed for newer R package compilation and graphics/SSL support:
  - `libdeflate-dev`
  - `libssl-dev`
  - `libfreetype6-dev`
  - `libpng-dev`
  - `libtiff5-dev`
  - `libjpeg-dev`
  - `libwebp-dev`
  - `libuv1-dev`
- Removed `plogr` from the pipeline image R package install list (deprecated package, not needed)
- Updated the hardcoded R doc/library path in `dockerfiles/sv-shell/Dockerfile` from `/opt/R/4.1.3/...` to `/opt/R/4.5.0/...`

This keeps the Dockerized analysis environment aligned with a newer R release and ensures required system libraries are present for package installation and runtime compatibility.

