### PR TITLE
Security: Shell Command Injection via os.popen in generate_cnv_segment_from_cpx.py

### DIFF
--- a/src/sv-pipeline/scripts/generate_cnv_segment_from_cpx.py
+++ b/src/sv-pipeline/scripts/generate_cnv_segment_from_cpx.py
@@ -1,5 +1,6 @@
 import os
 import argparse
+import subprocess
 
 # Implementation note:
 # This code implements the same python code in the GenerateCnvSegmentFromCpx task without alterations.
@@ -23,7 +24,7 @@ def get_sample_batch_map(sample_batch_pe_map):
 
 def readin_cpx_cnv(bed_input, sample_to_batch, min_depth_size):
     CPX_CNV = []
-    f_bed = os.popen(r'''zcat %s''' % (bed_input))
+    f_bed = subprocess.Popen(['zcat', bed_input], stdout=subprocess.PIPE, text=True).stdout
     for line in f_bed:
         pin = line.strip().split('\t')
         if pin[0][0] == '#':


### PR DESCRIPTION
## Summary

Security: Shell Command Injection via os.popen in generate_cnv_segment_from_cpx.py

## Problem

**Severity**: `Critical` | **File**: `src/sv-pipeline/scripts/generate_cnv_segment_from_cpx.py:L37`

The script uses os.popen with string formatting to execute a shell command containing user-provided input (bed_input). An attacker could inject shell metacharacters through the --bed argument to execute arbitrary commands.

## Solution

Use subprocess module with a list of arguments instead of os.popen with string formatting. Prefer subprocess.run(['zcat', bed_input], ...).

## Changes

- `src/sv-pipeline/scripts/generate_cnv_segment_from_cpx.py` (modified)