### PR TITLE
Clean up runner disk space

### DIFF
--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -29,24 +29,6 @@ jobs:
       head_sha: ${{ steps.commit_sha.outputs.HEAD_SHA }}
       image_tag: ${{ steps.image_tag.outputs.IMAGE_TAG }}
     steps:
-      - name: Cleanup Disk Space
-        run: |
-          echo "=== Disk space before cleanup ==="
-          df -h
-          
-          # Remove heavy frameworks and SDKs
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          
-          # Prune internal Docker layers and images
-          sudo docker image prune --all --force
-          sudo docker builder prune --all --force
-          
-          echo "=== Disk space after cleanup ==="
-          df -h
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -135,6 +117,24 @@ jobs:
       matrix:
         python-version: ['3.8']
     steps:
+      - name: Cleanup Disk Space
+        run: |
+          echo "=== Disk space before cleanup ==="
+          df -h
+          
+          # Remove heavy frameworks and SDKs
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          
+          # Prune internal Docker layers and images
+          sudo docker image prune --all --force
+          sudo docker builder prune --all --force
+          
+          echo "=== Disk space after cleanup ==="
+          df -h
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -171,6 +171,24 @@ jobs:
     env:
       DOCKERS_GCP: "./inputs/values/dockers.json"
     steps:
+      - name: Cleanup Disk Space
+        run: |
+          echo "=== Disk space before cleanup ==="
+          df -h
+          
+          # Remove heavy frameworks and SDKs
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          
+          # Prune internal Docker layers and images
+          sudo docker image prune --all --force
+          sudo docker builder prune --all --force
+          
+          echo "=== Disk space after cleanup ==="
+          df -h
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -29,6 +29,24 @@ jobs:
       head_sha: ${{ steps.commit_sha.outputs.HEAD_SHA }}
       image_tag: ${{ steps.image_tag.outputs.IMAGE_TAG }}
     steps:
+      - name: Cleanup Disk Space
+        run: |
+          echo "=== Disk space before cleanup ==="
+          df -h
+          
+          # Remove heavy frameworks and SDKs
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          
+          # Prune internal Docker layers and images
+          sudo docker image prune --all --force
+          sudo docker builder prune --all --force
+          
+          echo "=== Disk space after cleanup ==="
+          df -h
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -150,6 +150,9 @@ jobs:
       - name: Run build_docker.py
         timeout-minutes: 360
         run: |
+          echo "=== TEST ==="
+          df -h
+          
           cd ./scripts/docker/
           python build_docker.py \
             --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -113,6 +113,7 @@ jobs:
     name: Test Images Build
     if: github.event_name == 'pull_request'
     needs: build_args_job
+    timeout-minutes: 360
     strategy:
       matrix:
         python-version: ['3.8']
@@ -147,6 +148,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run build_docker.py
+        timeout-minutes: 360
         run: |
           cd ./scripts/docker/
           python build_docker.py \
@@ -165,6 +167,7 @@ jobs:
     environment: Deploy
     if: github.event_name == 'push'
     needs: build_args_job
+    timeout-minutes: 360
     strategy:
       matrix:
         python-version: ['3.8']
@@ -243,6 +246,7 @@ jobs:
 
       - name: Build and Publish Docker Images to Google Artifact Registry
         id: build_and_publish
+        timeout-minutes: 360
         run: |
           python ./scripts/docker/build_docker.py \
             --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \

--- a/.github/workflows/sv_pipeline_docker.yml
+++ b/.github/workflows/sv_pipeline_docker.yml
@@ -113,7 +113,7 @@ jobs:
     name: Test Images Build
     if: github.event_name == 'pull_request'
     needs: build_args_job
-    timeout-minutes: 360
+    timeout-minutes: 120
     strategy:
       matrix:
         python-version: ['3.8']
@@ -148,11 +148,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run build_docker.py
-        timeout-minutes: 360
+        timeout-minutes: 120
         run: |
-          echo "=== TEST ==="
-          df -h
-          
           cd ./scripts/docker/
           python build_docker.py \
             --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \
@@ -170,7 +167,7 @@ jobs:
     environment: Deploy
     if: github.event_name == 'push'
     needs: build_args_job
-    timeout-minutes: 360
+    timeout-minutes: 120
     strategy:
       matrix:
         python-version: ['3.8']
@@ -249,7 +246,7 @@ jobs:
 
       - name: Build and Publish Docker Images to Google Artifact Registry
         id: build_and_publish
-        timeout-minutes: 360
+        timeout-minutes: 120
         run: |
           python ./scripts/docker/build_docker.py \
             --base-git-commit ${{ needs.build_args_job.outputs.base_sha }} \

--- a/dockerfiles/sv-shell/Dockerfile
+++ b/dockerfiles/sv-shell/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get clean && \
 RUN Rscript -e "install.packages('htmlwidgets', repos='http://cran.us.r-project.org')"
 RUN Rscript -e "install.packages('shiny', repos='http://cran.us.r-project.org')"
 RUN echo "r <- getOption('repos'); r['CRAN'] <- 'http://cran.us.r-project.org'; options(repos = r);" > ~/.Rprofile
-RUN Rscript -e "library(devtools); install_github('mhahsler/rBLAST')"
+RUN Rscript -e "install.packages('remotes', repos='http://cran.us.r-project.org'); remotes::install_github('mhahsler/rBLAST')"
 
 # install bcftools and htslib
 ARG HTSLIB_VERSION="1.18"

--- a/dockerfiles/sv-shell/Dockerfile
+++ b/dockerfiles/sv-shell/Dockerfile
@@ -2,6 +2,43 @@ ARG SV_PIPELINE_IMAGE=sv-pipeline:latest
 ARG WHAM_IMAGE=wham:latest
 
 FROM $WHAM_IMAGE as wham_layer
+
+# ---- GATK build stage --------------------------------------------------
+# Builds gatk.jar and the "gatk" conda env here, isolated from the final
+# image, so the full JDK, git, git-lfs, and gradle never ship at runtime.
+# note that gatk is installed in sv-base docker, which this docker image inherits.
+# however, the base images are currently being updated: https://github.com/broadinstitute/gatk-sv/pull/816
+# so as a temporary work-around we're re-installing gatk in this image using code in a specific branch.
+# setting SHELL to bash in the following is needed for the `source` command in the following RUN,
+# since the default sh does not support `source`.
+FROM $SV_PIPELINE_IMAGE AS gatk_builder
+ENV DEBIAN_FRONTEND noninteractive
+SHELL ["/bin/bash", "-c"]
+RUN apt-get update && apt-get -qqy install --no-upgrade --no-install-recommends --fix-missing \
+        git \
+        git-lfs \
+        openjdk-17-jdk \
+        libgomp1 \
+        wget && \
+    GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/broadinstitute/gatk.git && \
+    cd gatk && \
+    git checkout mw_gatk_sv && \
+    git checkout 672d8557d82d17cefe972df5796ba719f0d7adbc && \
+    mkdir -p /opt/gatk_miniconda3 && \
+    wget https://repo.anaconda.com/miniconda/Miniconda3-py310_23.10.0-1-Linux-x86_64.sh -O /opt/gatk_miniconda3/miniconda.sh && \
+    bash /opt/gatk_miniconda3/miniconda.sh -p /opt/gatk_miniconda3 -b -u && \
+    rm /opt/gatk_miniconda3/miniconda.sh && \
+    /opt/gatk_miniconda3/bin/conda config --append envs_dirs /opt/conda/envs && \
+    source /opt/gatk_miniconda3/bin/activate && \
+    conda config --set auto_update_conda false && \
+    conda config --set solver libmamba && \
+    ./gradlew localDevCondaEnv && \
+    ./gradlew localJar && \
+    cp ./build/libs/gatk.jar /opt/gatk.jar && \
+    cd / && rm -rf gatk ~/.gradle && \
+    conda clean -afy
+
+
 FROM $SV_PIPELINE_IMAGE
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -10,7 +47,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get clean all && \
     apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y  \
+    apt-get install -y --no-install-recommends \
         autoconf \
         autogen \
         build-essential \
@@ -90,7 +127,6 @@ CMD ["Rscript"]
 
 
 # Whamg Docker
-ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -qqy update --fix-missing && \
     apt-get -qqy dist-upgrade && \
     apt-get -qqy install --no-install-recommends \
@@ -112,31 +148,13 @@ RUN mkdir -p /opt/R/4.5.0/lib/R/doc/html && \
 
 
 # Install GATK
-# note that gatk is installed in sv-base docker, which this docker image inherits.
-# however, the base images are currently being updated: https://github.com/broadinstitute/gatk-sv/pull/816
-# so as a temporary work-around we're re-installing gatk in this image using code in a specific branch.
-# setting SHELL to bash in the following is needed for the `source` command in the following RUN,
-# since the default sh does not support `source`.
-SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get -qqy install --no-upgrade --no-install-recommends --fix-missing git git-lfs openjdk-17-jdk openjdk-17-jre-headless libgomp1 && \
-    GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/broadinstitute/gatk.git && \
-    cd gatk && \
-    git checkout mw_gatk_sv && \
-    git checkout 672d8557d82d17cefe972df5796ba719f0d7adbc && \
-    mkdir -p /opt/gatk_miniconda3 && \
-    wget https://repo.anaconda.com/miniconda/Miniconda3-py310_23.10.0-1-Linux-x86_64.sh -O /opt/gatk_miniconda3/miniconda.sh && \
-    bash /opt/gatk_miniconda3/miniconda.sh -p /opt/gatk_miniconda3 -b -u && \
-    rm /opt/gatk_miniconda3/miniconda.sh && \
-    /opt/gatk_miniconda3/bin/conda config --append envs_dirs /opt/conda/envs && \
-    source /opt/gatk_miniconda3/bin/activate && \
-    conda config --set auto_update_conda false && \
-    conda config --set solver libmamba && \
-    ./gradlew localDevCondaEnv && \
-    ./gradlew localJar && \
-    cp ./build/libs/gatk.jar /opt/gatk.jar && \
-    cd .. && \
-    rm -rf gatk/ && \
-    ln -s /opt/gatk_miniconda3/bin/conda /usr/local/bin/conda
+# gatk.jar and its conda env are built in the gatk_builder stage above; only the
+# JRE needed to run the jar, the jar itself, and the conda env are brought in here.
+RUN apt-get update && apt-get -qqy install --no-upgrade --no-install-recommends --fix-missing openjdk-17-jre-headless && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY --from=gatk_builder /opt/gatk.jar /opt/gatk.jar
+COPY --from=gatk_builder /opt/gatk_miniconda3 /opt/gatk_miniconda3
+RUN ln -s /opt/gatk_miniconda3/bin/conda /usr/local/bin/conda
 
 
 # stripy docker
@@ -164,8 +182,8 @@ RUN git clone https://gitlab.com/andreassh/stripy-pipeline.git /opt/stripy-pipel
 WORKDIR /opt/stripy-pipeline
 
 RUN python3 -m venv /opt/stripy-env
-RUN /opt/stripy-env/bin/pip install --upgrade pip && \
-    if [ -f requirements.txt ]; then /opt/stripy-env/bin/pip install -r requirements.txt; fi
+RUN /opt/stripy-env/bin/pip install --no-cache-dir --upgrade pip && \
+    if [ -f requirements.txt ]; then /opt/stripy-env/bin/pip install --no-cache-dir -r requirements.txt; fi
 
 # Copy wrapper script, default config, and loci profiles
 COPY src/stripy/stripy /usr/local/bin/stripy
@@ -181,7 +199,7 @@ RUN chmod +x /usr/local/bin/stripy
 COPY src/sv_shell /opt/sv_shell
 
 # SYSSTAT (SAR) configuration. Collect stats every 30 seconds (two measurements in 1min)
-RUN apt-get update && apt-get install -y cron sysstat && \
+RUN apt-get update && apt-get install -y --no-install-recommends cron sysstat && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     sed -i 's/ENABLED="false"/ENABLED="true"/' /etc/default/sysstat && \
     sed -i 's|^5-55/10.*|* * * * * root command -v debian-sa1 > /dev/null \&\& debian-sa1 30 2|' /etc/cron.d/sysstat

--- a/scripts/docker/build_docker.py
+++ b/scripts/docker/build_docker.py
@@ -248,17 +248,17 @@ class ProjectBuilder:
                 "samtools-cloud": "SAMTOOLS_CLOUD_IMAGE",
                 "sv-utils-env": "VIRTUAL_ENV_IMAGE"}
         ),
-        "denovo": ImageDependencies(
-            git_dependencies=("dockerfiles/denovo/*", "src/denovo/*"),
-            docker_dependencies={
-                "sv-pipeline": "SV_PIPELINE_IMAGE"}
-        )  # ,
-        # "sv-shell": ImageDependencies(
-        #     git_dependencies=("dockerfiles/sv-shell/*", "src/sv_shell/*"),
+        # "denovo": ImageDependencies(
+        #     git_dependencies=("dockerfiles/denovo/*", "src/denovo/*"),
         #     docker_dependencies={
-        #         "sv-pipeline": "SV_PIPELINE_IMAGE",
-        #         "wham": "WHAM_IMAGE"}
-        # )
+        #         "sv-pipeline": "SV_PIPELINE_IMAGE"}
+        # ),
+        "sv-shell": ImageDependencies(
+            git_dependencies=("dockerfiles/sv-shell/*", "src/sv_shell/*"),
+            docker_dependencies={
+                "sv-pipeline": "SV_PIPELINE_IMAGE",
+                "wham": "WHAM_IMAGE"}
+        )
     }
     non_public_images = frozenset({"melt"})
     images_built_by_all = frozenset(dependencies.keys()).difference({"melt"})

--- a/src/sv_shell/single_sample_pipeline.sh
+++ b/src/sv_shell/single_sample_pipeline.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# TEST
 # For details: https://serverfault.com/a/103569
 # saves original stdout to &3 and original stderr to &4
 # without this, the logs of subprocess can get mixed with the parent's logs.

--- a/src/sv_shell/single_sample_pipeline.sh
+++ b/src/sv_shell/single_sample_pipeline.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# TEST
 # For details: https://serverfault.com/a/103569
 # saves original stdout to &3 and original stderr to &4
 # without this, the logs of subprocess can get mixed with the parent's logs.


### PR DESCRIPTION
The SV-Shell Docker image has a large disk space requirement, so much so that the`build_docker.py` script runs out of disk space on GitHub runners.

Our initial plan was to split the Docker image build across separate GitHub jobs so that each image is built separately. This would reduce disk requirements and improve performance by running jobs in parallel. However, this approach is highly challenging from a GitHub Actions setup perspective: it requires replicating the Docker dependency tree (duplicating logic already in the `build_docker.py` script) and managing complex artifact orchestration between multiple jobs.

This PR takes a simpler approach: it keeps the build logic unchanged and instead frees up as much disk space as possible on the GitHub runners. This results in ~100 GB of free disk space on the runner. 

However, even this disk space cleanup was not enough. The main culprit is the GATK installation and a few missing `-no-install-recommends` in the SV-Shell Docker, fixed in this PR. 

SV-Shell Docker now successfully builds in GitHub Actions within the available disk space. 