### PR TITLE
Skip running readonly checks if committed by gatk-sv-bot

### DIFF
--- a/.github/workflows/readonly_check.yaml
+++ b/.github/workflows/readonly_check.yaml
@@ -12,6 +12,7 @@ jobs:
   readonly:
     name: Verify
     runs-on: ubuntu-latest
+    if: github.actor != 'gatk-sv-bot'
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
To prevent accidental commits to some files, the `Readonly Check` action tests if the "readonly" files are included in the changes of a commit/PR. However, gatk-sv-bot can make changes to some files, e.g., `dockers.json`, and that will result in `Readonly Check` failing. We can safely ignore that failure, but to avoid confusion, this PR extends the `Readonly Check` action to skip running if the commit is made by gatk-sv-bot. 