### PR TITLE
CleanVcf - PostHoc updates

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -241,6 +241,7 @@ workflows:
     filters:
       branches:
         - main
+        - kj_cleanvcf_posthoc_fix
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -141,7 +141,6 @@ workflows:
     filters:
       branches:
         - main
-        - kj_cleanvcf_posthoc_fix
       tags:
         - /.*/
 
@@ -241,7 +240,6 @@ workflows:
     filters:
       branches:
         - main
-        - kj_cleanvcf_posthoc_fix
       tags:
         - /.*/
 

--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -141,6 +141,7 @@ workflows:
     filters:
       branches:
         - main
+        - kj_cleanvcf_posthoc_fix
       tags:
         - /.*/
 

--- a/inputs/values/dockers.json
+++ b/inputs/values/dockers.json
@@ -1,7 +1,7 @@
 {
   "name": "dockers",
   "cnmops_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/cnmops:2026-05-30-v1.1-0639be96",
-  "gatk_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/gatk:mw-gatk-sv-672d85",
+  "gatk_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/gatk:mw-gatk-sv-53d5c2d",
   "genomes_in_the_cloud_docker": "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.3.2-1510681135",
   "linux_docker": "marketplace.gcr.io/google/ubuntu1804",
   "manta_docker": "us.gcr.io/broad-dsde-methods/gatk-sv/manta:2023-09-14-v0.28.3-beta-3f22f94d",

--- a/src/sv-pipeline/04_variant_resolution/scripts/add_retro_del_filters.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/add_retro_del_filters.py
@@ -7,7 +7,7 @@ import gzip
 import pysam
 
 
-def load_introns_for_contig(intron_file):
+def load_introns_for_contig(intron_file, contig):
     introns = []
     is_gzipped = intron_file.endswith('.gz')
     opener = gzip.open if is_gzipped else open
@@ -17,7 +17,9 @@ def load_introns_for_contig(intron_file):
             fields = line.strip().split('\t')
             if len(fields) < 4:
                 continue
-            _, start, end = fields[0], int(float(fields[2])), int(float(fields[3]))
+            chrom, start, end = fields[0], int(float(fields[2])), int(float(fields[3]))
+            if chrom != contig:
+                continue
 
             if start > end:
                 start, end = end, start
@@ -46,6 +48,7 @@ def main():
     parser.add_argument('vcf', help='Input VCF file')
     parser.add_argument('intron_reference', help='Intron reference file (can be gzipped)')
     parser.add_argument('output', help='Output VCF file (will be bgzipped)')
+    parser.add_argument('--contig', required=True, help='Contig to restrict intron matching to')
     parser.add_argument(
         '--max-distance',
         type=int,
@@ -55,7 +58,7 @@ def main():
 
     args = parser.parse_args()
 
-    introns = load_introns_for_contig(args.intron_reference)
+    introns = load_introns_for_contig(args.intron_reference, args.contig)
 
     with pysam.VariantFile(args.vcf, 'r') as fin:
         header = fin.header

--- a/src/sv-pipeline/04_variant_resolution/scripts/cleanvcf_preprocess.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/cleanvcf_preprocess.py
@@ -1,6 +1,7 @@
 #!/bin/python
 
 import argparse
+import re
 import pysam
 import gzip
 
@@ -13,7 +14,8 @@ UNRESOLVED = 'UNRESOLVED'
 HIGH_SR_BACKGROUND = 'HIGH_SR_BACKGROUND'
 BOTHSIDES_SUPPORT = 'BOTHSIDES_SUPPORT'
 REVISED_EVENT = 'REVISED_EVENT'
-EV_VALUES = ['SR', 'PE', 'SR,PE', 'RD', 'BAF', 'RD,BAF']
+EV = 'EV'
+EV_VALUES = [None, 'RD', 'PE', 'RD,PE', 'SR', 'RD,SR', 'PE,SR', 'RD,PE,SR']
 MIN_ALLOSOME_EVENT_SIZE = 5000
 
 
@@ -188,6 +190,20 @@ def process_record(record, chrX, chrY, fail_set, pass_set, unknown_sex_samples):
     return record
 
 
+def recode_ev_header(header):
+    new_header = pysam.VariantHeader()
+    for line in str(header).split('\n'):
+        if line.startswith('#CHROM'):
+            continue
+        if line.startswith('##FORMAT=<ID=EV,'):
+            line = re.sub('Type=Integer', 'Type=String', line)
+        if line:
+            new_header.add_line(line)
+    for sample in header.samples:
+        new_header.add_sample(sample)
+    return new_header
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='CleanVcf preprocessing.')
     parser.add_argument('-V', '--input', dest='input_vcf', required=True, help='Input VCF file')
@@ -210,14 +226,26 @@ if __name__ == '__main__':
     else:
         vcf_in = pysam.VariantFile(args.input_vcf)
 
+    output_header = recode_ev_header(vcf_in.header)
     if args.output_vcf.endswith('.gz'):
-        vcf_out = pysam.VariantFile(args.output_vcf, 'wz', header=vcf_in.header)
+        vcf_out = pysam.VariantFile(args.output_vcf, 'wz', header=output_header)
     else:
-        vcf_out = pysam.VariantFile(args.output_vcf, 'w', header=vcf_in.header.copy())
+        vcf_out = pysam.VariantFile(args.output_vcf, 'w', header=output_header)
 
     for record in vcf_in:
-        record = process_record(record, chrX, chrY, fail_set, pass_set, unknown_sex_samples)
-        vcf_out.write(record)
+        new_record = output_header.new_record(contig=record.contig, start=record.start, stop=record.stop,
+                                               alleles=record.alleles, id=record.id, qual=record.qual,
+                                               filter=list(record.filter))
+        for key in record.info.keys():
+            new_record.info[key] = record.info[key]
+        for sample in record.samples:
+            for key in record.samples[sample].keys():
+                value = record.samples[sample][key]
+                if key == EV and isinstance(value, int):
+                    value = EV_VALUES[value]
+                new_record.samples[sample][key] = value
+        new_record = process_record(new_record, chrX, chrY, fail_set, pass_set, unknown_sex_samples)
+        vcf_out.write(new_record)
 
     vcf_in.close()
     vcf_out.close()

--- a/src/sv-pipeline/04_variant_resolution/scripts/cleanvcf_preprocess.py
+++ b/src/sv-pipeline/04_variant_resolution/scripts/cleanvcf_preprocess.py
@@ -190,6 +190,10 @@ def process_record(record, chrX, chrY, fail_set, pass_set, unknown_sex_samples):
     return record
 
 
+def needs_ev_recode(header):
+    return header.formats[EV].type == 'Integer'
+
+
 def recode_ev_header(header):
     new_header = pysam.VariantHeader()
     for line in str(header).split('\n'):
@@ -202,6 +206,21 @@ def recode_ev_header(header):
     for sample in header.samples:
         new_header.add_sample(sample)
     return new_header
+
+
+def rebuild_record(record, output_header):
+    new_record = output_header.new_record(contig=record.contig, start=record.start, stop=record.stop,
+                                          alleles=record.alleles, id=record.id, qual=record.qual,
+                                          filter=list(record.filter))
+    for key in record.info.keys():
+        new_record.info[key] = record.info[key]
+    for sample in record.samples:
+        for key in record.samples[sample].keys():
+            value = record.samples[sample][key]
+            if key == EV and isinstance(value, int):
+                value = EV_VALUES[value]
+            new_record.samples[sample][key] = value
+    return new_record
 
 
 if __name__ == '__main__':
@@ -226,26 +245,18 @@ if __name__ == '__main__':
     else:
         vcf_in = pysam.VariantFile(args.input_vcf)
 
-    output_header = recode_ev_header(vcf_in.header)
+    recode_ev = needs_ev_recode(vcf_in.header)
+    output_header = recode_ev_header(vcf_in.header) if recode_ev else vcf_in.header
     if args.output_vcf.endswith('.gz'):
         vcf_out = pysam.VariantFile(args.output_vcf, 'wz', header=output_header)
     else:
         vcf_out = pysam.VariantFile(args.output_vcf, 'w', header=output_header)
 
     for record in vcf_in:
-        new_record = output_header.new_record(contig=record.contig, start=record.start, stop=record.stop,
-                                               alleles=record.alleles, id=record.id, qual=record.qual,
-                                               filter=list(record.filter))
-        for key in record.info.keys():
-            new_record.info[key] = record.info[key]
-        for sample in record.samples:
-            for key in record.samples[sample].keys():
-                value = record.samples[sample][key]
-                if key == EV and isinstance(value, int):
-                    value = EV_VALUES[value]
-                new_record.samples[sample][key] = value
-        new_record = process_record(new_record, chrX, chrY, fail_set, pass_set, unknown_sex_samples)
-        vcf_out.write(new_record)
+        if recode_ev:
+            record = rebuild_record(record, output_header)
+        record = process_record(record, chrX, chrY, fail_set, pass_set, unknown_sex_samples)
+        vcf_out.write(record)
 
     vcf_in.close()
     vcf_out.close()

--- a/src/sv-pipeline/scripts/vcf_qc/plot_sv_vcf_distribs.R
+++ b/src/sv-pipeline/scripts/vcf_qc/plot_sv_vcf_distribs.R
@@ -1023,10 +1023,10 @@ plotHWSingle <- function(dat,svtypes,title=NULL,full.legend=T,lab.cex=1){
   if(nrow(HW.dat)>0){
     #Prep HW matrix
     nsamps <- HW.dat$reference_gts+HW.dat$het_gts+HW.dat$hom_gts
-    HW.mat <- data.frame("AA"=HW.dat$reference_gts/nsamps,
+    HW.mat <- as.matrix(data.frame("AA"=HW.dat$reference_gts/nsamps,
                          "AB"=HW.dat$het_gts/nsamps,
-                         "BB"=HW.dat$hom_gts/nsamps)
-    
+                         "BB"=HW.dat$hom_gts/nsamps))
+
     #Gather HW p-values & colors
     HW.p <- HWChisqStats(X=HW.mat*nsamp,x.linked=F,pvalues=T)
     HW.cols <- rep("#4DAC26",times=length(HW.p))

--- a/wdl/CleanVcfChromosome.wdl
+++ b/wdl/CleanVcfChromosome.wdl
@@ -802,7 +802,8 @@ task AddRetroDelFilters {
     python /opt/sv-pipeline/04_variant_resolution/scripts/add_retro_del_filters.py \
       ~{vcf} \
       ~{intron_reference} \
-      ~{prefix}.vcf.gz
+      ~{prefix}.vcf.gz \
+      --contig ~{contig}
   >>>
 
   output {


### PR DESCRIPTION
### Description
This PR is a follow-up from #912 - it resolves some disparities involved when migrating _CleanVcf_ into a GATK-based implementation. It is intended to accompany [this PR](https://github.com/broadinstitute/gatk/pull/9408) for GATK.

Additionally, it resolves an issue in the retrotransposon annotation code, in which the retrotransposon chromosome was not being accounted for when calculating overlap.

### Testing
- [This Terra job](https://app.terra.bio/#workspaces/broad-firecloud-dsde-methods/kj-cleanvcf-cohort-mode/submission_history/9a7e4e7e-e46f-44ca-8e33-92a07b3ff656) shows a run of the pipeline in cohort mode mode prior to this change.
- [This Terra job](https://app.terra.bio/#workspaces/broad-firecloud-dsde-methods/kj-cleanvcf-cohort-mode/submission_history/fa7351a9-2eee-4259-a2ea-babf0538e7ec) shows a run of the pipeline in cohort mode mode with this change. While the output VCFs are identical for the most part, there are minor differences with the above run, accounted for by:
  -  86 records that were originally given the `RETRO_DUP` filter now `PASS`. This is becaue the original script did not take chromosome into account when accounting for overlaps, so was purely based on the raw variant breakpoints.
  - 2 extra DUPs in the evaluation run are due to the legacy's pysam genotype handlin, which truncates/nulls the ALT allele when a sample's GT allele index is ≥2 and causes it to silently drop these records.
- Skipped single-sample pipeline testing, as discussed with Emma.
- Validated all WDLs with womtool.