### PR TITLE
Use HTTPS CRAN mirrors in sv-base-virtual-env (fixes image-build CI)

### DIFF
--- a/dockerfiles/sv-base-virtual-env/Dockerfile
+++ b/dockerfiles/sv-base-virtual-env/Dockerfile
@@ -56,7 +56,7 @@ COPY dockerfiles/sv-base-virtual-env/union_lists.sh $R_INSTALL_BIN/
 ENV PATH=$R_INSTALL_BIN:/opt/bin:$PATH
 
 # update the installed R packages
-RUN Rscript -e "update.packages(contriburl=contrib.url(repos=c('http://lib.stat.cmu.edu/R/CRAN/', 'https://cran.rstudio.com')), clean=TRUE, quiet=TRUE, ask=FALSE)"
+RUN Rscript -e "update.packages(contriburl=contrib.url(repos=c('https://cloud.r-project.org', 'https://cran.rstudio.com')), clean=TRUE, quiet=TRUE, ask=FALSE)"
 # install the required R packages for this stage
 ARG SV_BASE_R_PKGS="optparse BiocManager"
 RUN install_R_packages.R $SV_BASE_R_PKGS

--- a/dockerfiles/sv-base-virtual-env/install_R_packages.R
+++ b/dockerfiles/sv-base-virtual-env/install_R_packages.R
@@ -14,7 +14,10 @@ if ( 0 == length(to.be.installed) ) {
 }
 
 # multiple repos, multiple retries when a package is not found
-repos <- c("http://lib.stat.cmu.edu/R/CRAN/", "https://cran.rstudio.com")
+# NOTE: the old primary mirror (http://lib.stat.cmu.edu/R/CRAN/) now redirects
+# plain HTTP to HTTPS / 403s, and with options(warn=2) an unreachable first repo
+# aborts the install even when a fallback mirror is listed. Use HTTPS CRAN CDN.
+repos <- c("https://cloud.r-project.org", "https://cran.rstudio.com")
 
 # install to default place, quietly, then leave
 install.packages(pkgs = to.be.installed, 

--- a/dockerfiles/sv-base-virtual-env/install_bioconductor_packages.R
+++ b/dockerfiles/sv-base-virtual-env/install_bioconductor_packages.R
@@ -14,9 +14,10 @@ if ( 0 == length(to.be.installed) ) {
 }
 
 # multiple repos, multiple retries when one of them is un-reachable
-repos <- c("http://lib.stat.cmu.edu/R/CRAN/",
-           "https://cran.rstudio.com",
-           "http://cran.mtu.edu")
+# See note in install_R_packages.R: plain-HTTP mirrors (lib.stat.cmu.edu,
+# cran.mtu.edu) break under options(warn=2); use HTTPS repos only.
+repos <- c("https://cloud.r-project.org",
+           "https://cran.rstudio.com")
 
 # install to default place, quietly, then leave
 if (!requireNamespace("BiocManager")){


### PR DESCRIPTION
## Problem
Image-build CI currently fails whenever the `sv-base-virtual-env` / `sv-pipeline-virtual-env` R layers are rebuilt, e.g. [run 34387428118](https://github.com/broadinstitute/gatk-sv/actions/runs/34387428118?pr=945) on #945:

```
Error: (converted from warning) unable to access index for repository http://lib.stat.cmu.edu/R/CRAN/src/contrib:
  cannot open URL 'http://lib.stat.cmu.edu/R/CRAN/src/contrib/PACKAGES'
```

The plain-HTTP mirror `http://lib.stat.cmu.edu/R/CRAN/` now 301-redirects to HTTPS (and 403s from some networks). `install_R_packages.R` / `install_bioconductor_packages.R` run with `options(warn = 2)`, so R's normally-tolerable "unreachable first repo, trying fallback" warning becomes fatal — the listed `cran.rstudio.com` fallback never gets used. This is infrastructure bit-rot: main is green only because no image rebuild has run since the mirror changed behavior.

## Fix
Point all three CRAN repo references in `dockerfiles/sv-base-virtual-env/` at `https://cloud.r-project.org` (CDN) with `https://cran.rstudio.com` as fallback — the same remedy already documented and used in `dockerfiles/sv-shell/Dockerfile` (see its comment about cran.us.r-project.org redirecting to CMU/403).

Note: the failing CI layer executes the install scripts baked into the **pinned** `sv-base-virtual-env:2026-05-30-v1.1-0639be96` image. Because this PR changes `dockerfiles/sv-base-virtual-env/`, `build_docker.py` will rebuild `sv-base-virtual-env` from source in CI and downstream layers will use the fixed scripts; a regular release build will republish the pin.

## Tests
- `curl -I https://cloud.r-project.org/src/contrib/PACKAGES` → HTTP/2 200
- Verified the three edited locations are the only live `lib.stat.cmu.edu` repo references in `dockerfiles/` on `main`
- Full validation is the image-build CI workflow on this PR (it will rebuild `sv-base-virtual-env` + dependents)

Related: unblocks the docker rebuild currently failing on #945 (that PR's own change is unrelated: it adds `pyro-ppl` to the conda env.
