### PR TITLE
Add GD workflows back to dockstore yml

### DIFF
--- a/.github/.dockstore.yml
+++ b/.github/.dockstore.yml
@@ -235,6 +235,24 @@ workflows:
         - /.*/
 
   - subclass: WDL
+      name: CallGenomicDisorderCNVs
+      primaryDescriptorPath: /wdl/CallGenomicDisorderCNVs.wdl
+      filters:
+        branches:
+          - main
+        tags:
+          - /.*/
+
+  - subclass: WDL
+    name: IntegrateGDVcf
+    primaryDescriptorPath: /wdl/IntegrateGDVcf.wdl
+    filters:
+      branches:
+        - main
+      tags:
+        - /.*/
+
+  - subclass: WDL
     name: SingleSamplePipeline
     primaryDescriptorPath: /wdl/GATKSVPipelineSingleSample.wdl
     filters:


### PR DESCRIPTION
The GD workflows were mistakenly removed entirely from the .dockstore.yml in #945 rather than just removing the development branch. This PR adds them back so that they will be synced to Dockstore and can be run in Terra.